### PR TITLE
[ScrollArea] Reduce thumb tap target size

### DIFF
--- a/packages/radix-ui-themes/src/components/scroll-area.css
+++ b/packages/radix-ui-themes/src/components/scroll-area.css
@@ -54,8 +54,8 @@
     transform: translate(-50%, -50%);
     width: 100%;
     height: 100%;
-    min-width: 44px;
-    min-height: 44px;
+    min-width: 16px;
+    min-height: 16px;
   }
 }
 


### PR DESCRIPTION
This is currently a little overzealous, creating issues with overlapping elements or text selections within blocks:

https://github.com/radix-ui/themes/assets/11708259/ab9372c6-d0d5-4f2e-9f3e-c8e4036a5b98
