### PR TITLE
Use explicit React.FC type

### DIFF
--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -229,7 +229,9 @@ ContextMenuCheckboxItem.displayName = 'ContextMenuCheckboxItem';
 
 interface ContextMenuSubProps
   extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Sub> {}
-const ContextMenuSub = (props: ContextMenuSubProps) => <ContextMenuPrimitive.Sub {...props} />;
+const ContextMenuSub: React.FC<ContextMenuSubProps> = (props) => (
+  <ContextMenuPrimitive.Sub {...props} />
+);
 ContextMenuSub.displayName = 'ContextMenuSub';
 
 type ContextMenuSubTriggerElement = React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>;

--- a/packages/radix-ui-themes/src/components/dialog.tsx
+++ b/packages/radix-ui-themes/src/components/dialog.tsx
@@ -13,7 +13,7 @@ import type { GetPropDefTypes } from '../helpers';
 
 interface DialogRootProps
   extends Omit<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>, 'modal'> {}
-const DialogRoot = (props: DialogRootProps) => <DialogPrimitive.Root {...props} modal />;
+const DialogRoot: React.FC<DialogRootProps> = (props) => <DialogPrimitive.Root {...props} modal />;
 DialogRoot.displayName = 'DialogRoot';
 
 type DialogTriggerElement = React.ElementRef<typeof DialogPrimitive.Trigger>;

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -230,7 +230,9 @@ DropdownMenuCheckboxItem.displayName = 'DropdownMenuCheckboxItem';
 
 interface DropdownMenuSubProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Sub> {}
-const DropdownMenuSub = (props: DropdownMenuSubProps) => <DropdownMenuPrimitive.Sub {...props} />;
+const DropdownMenuSub: React.FC<DropdownMenuSubProps> = (props) => (
+  <DropdownMenuPrimitive.Sub {...props} />
+);
 DropdownMenuSub.displayName = 'DropdownMenuSub';
 
 type DropdownMenuSubTriggerElement = React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>;

--- a/packages/radix-ui-themes/src/components/hover-card.tsx
+++ b/packages/radix-ui-themes/src/components/hover-card.tsx
@@ -11,7 +11,7 @@ import type { GetPropDefTypes } from '../helpers';
 
 interface HoverCardRootProps
   extends React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root> {}
-const HoverCardRoot = (props: HoverCardRootProps) => (
+const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => (
   <HoverCardPrimitive.Root closeDelay={150} openDelay={200} {...props} />
 );
 HoverCardRoot.displayName = 'HoverCardRoot';

--- a/packages/radix-ui-themes/src/components/popover.tsx
+++ b/packages/radix-ui-themes/src/components/popover.tsx
@@ -10,7 +10,9 @@ import { Theme } from '../theme';
 import type { GetPropDefTypes } from '../helpers';
 
 interface PopoverRootProps extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root> {}
-const PopoverRoot = (props: PopoverRootProps) => <PopoverPrimitive.Root {...props} />;
+const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => (
+  <PopoverPrimitive.Root {...props} />
+);
 PopoverRoot.displayName = 'PopoverRoot';
 
 type PopoverTriggerElement = React.ElementRef<typeof PopoverPrimitive.Trigger>;


### PR DESCRIPTION
Use explicit React.FC type for components that don’t forward refs