### PR TITLE
Combine duplicate CSS selectors

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Up next
+
+- General
+  - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser
+  - Remove comments from the CSS build
+
 ## 1.1.2
 
 - General

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -90,6 +90,7 @@
     "eslint-config-custom": "*",
     "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
+    "postcss-combine-duplicated-selectors": "^10.0.3",
     "postcss-custom-media": "^9.1.4",
     "postcss-import": "^15.1.0",
     "postcss-nesting": "^11.3.0",

--- a/packages/radix-ui-themes/postcss-radix-themes.js
+++ b/packages/radix-ui-themes/postcss-radix-themes.js
@@ -21,6 +21,10 @@ const cache = new WeakMap();
 
 module.exports = () => ({
   postcssPlugin: 'postcss-radix-themes',
+  Comment(comment) {
+    // Remove all comments from CSS source
+    comment.remove();
+  },
   Rule(rule) {
     if (rule.parent.name === 'breakpoints') {
       const breakpointsRule = rule.parent;

--- a/packages/radix-ui-themes/postcss.config.js
+++ b/packages/radix-ui-themes/postcss.config.js
@@ -8,6 +8,7 @@ module.exports = {
     require('postcss-nesting'),
     require('./postcss-radix-themes'),
     require('postcss-custom-media'),
+    require('postcss-combine-duplicated-selectors'),
     require('autoprefixer'),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2636,6 +2636,13 @@ postcss-cli@^10.1.0:
     slash "^5.0.0"
     yargs "^17.0.0"
 
+postcss-combine-duplicated-selectors@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-combine-duplicated-selectors/-/postcss-combine-duplicated-selectors-10.0.3.tgz#71e8b6783e99cd560cf08ba7b896ad0db318c11c"
+  integrity sha512-IP0BmwFloCskv7DV7xqvzDXqMHpwdczJa6ZvIW8abgHdcIHs9mCJX2ltFhu3EwA51ozp13DByng30+Ke+eIExA==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
 postcss-custom-media@^9.1.4:
   version "9.1.4"
   resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-9.1.4.tgz#90ea49986b91512f95430775b191d83893142c16"
@@ -2679,7 +2686,7 @@ postcss-reporter@^7.0.0:
     picocolors "^1.0.0"
     thenby "^1.3.4"
 
-postcss-selector-parser@^6.0.10:
+postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.4:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==


### PR DESCRIPTION
- Combine duplicate CSS selectors to improve the developer experience when inspecting Radix Themes elements
- Remove comments from the CSS build

Before:
https://github.com/radix-ui/themes/assets/8441036/d124f12f-1fce-4e44-a38d-249573563a33

After:
https://github.com/radix-ui/themes/assets/8441036/25997e8c-6101-4c8d-a609-e6ce61734302

Build diff:
https://www.diffchecker.com/hY0sDxP9/
