### PR TITLE
Set color scheme with forced light/dark appearance

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -3,8 +3,9 @@
 ## Up next
 
 - General
-  - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser
-  - Remove comments from the CSS build
+  - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser.
+  - Remove comments from the CSS build.
+  - Make sure that forced light/dark appearance on the `Theme` component also sets the corresponding browser colors, like the correct input autofill background color.
 
 ## 1.1.2
 

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -171,6 +171,14 @@
   --color-surface: rgba(255, 255, 255, 0.9);
 }
 
+/* Make sure that forced light/dark appearance also sets corresponding browser colors, like input autofill color */
+.radix-themes:where(.light, .light-theme) {
+  color-scheme: light;
+}
+.radix-themes:where(.dark, .dark-theme) {
+  color-scheme: dark;
+}
+
 :is(.dark, .dark-theme),
 :is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
   --color-overlay: rgba(0, 0, 0, 0.75);


### PR DESCRIPTION
Fixes an issue when an input within a forced dark/light appearance section would not used the appropriate autofill background color, as the browser wouldn't know that the color scheme was changed in the section