### PR TITLE
Better focus outlines

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -6,6 +6,7 @@
   - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser.
   - Remove comments from the CSS build.
   - Make sure that forced light/dark appearance on the `Theme` component also sets the corresponding browser colors, like the correct input autofill background color.
+  - Use `outline` rather than `box-shadow` for most focus styles, which avoids a slight anti-aliasing issue in Chrome on focused elements
 
 ## 1.1.2
 

--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -184,8 +184,8 @@
   }
 
   &:where(:focus-visible) {
-    box-shadow: 0 0 0 2px var(--accent-3), 0 0 0 4px var(--accent-a8),
-      var(--button__classic__box-shadow);
+    outline: 2px solid var(--accent-a8);
+    outline-offset: 2px;
   }
 
   &:where(.rt-high-contrast) {
@@ -243,7 +243,8 @@
     filter: var(--button-filter__solid-active);
   }
   &:where(:focus-visible) {
-    box-shadow: 0 0 0 2px var(--accent-3), 0 0 0 4px var(--accent-a8);
+    outline: 2px solid var(--accent-a8);
+    outline-offset: 2px;
   }
 
   &:where(.rt-high-contrast) {
@@ -274,7 +275,8 @@
   color: var(--accent-a11);
 
   &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
   }
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -327,7 +329,8 @@
     background-color: var(--accent-a3);
   }
   &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-a8), 0 0 0 1px var(--accent-a8);
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
   }
 
   &:where(.rt-high-contrast) {
@@ -335,8 +338,8 @@
     color: var(--accent-12);
 
     &:where(:focus-visible) {
-      box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a12),
-        0 0 0 1px var(--accent-a7), 0 0 0 1px var(--gray-a12);
+      outline: 2px solid var(--accent-12);
+      outline-offset: -1px;
     }
   }
 }
@@ -361,7 +364,8 @@
     box-shadow: inset 0 0 0 1px var(--accent-a8);
   }
   &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
   }
 
   &:where(.rt-high-contrast) {

--- a/packages/radix-ui-themes/src/components/card.css
+++ b/packages/radix-ui-themes/src/components/card.css
@@ -12,6 +12,11 @@
     border-radius: inherit;
     content: '';
   }
+
+  &:where(:focus-visible)::after {
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
+  }
 }
 
 .rt-CardInner {
@@ -107,9 +112,6 @@
     &:active::after {
       box-shadow: inset 0 0 0 1px var(--gray-a8), inset 0 0 0 1px var(--gray-a6);
     }
-    &:focus-visible::after {
-      box-shadow: 0 0 0 2px var(--accent-a8);
-    }
   }
 }
 
@@ -139,9 +141,6 @@
       transition-duration: 40ms;
       box-shadow: var(--shadow-2), var(--shadow-2);
     }
-    &:focus-visible::after {
-      box-shadow: 0 0 0 2px var(--accent-a8);
-    }
   }
 }
 
@@ -153,9 +152,6 @@
       &:hover {
         background-color: var(--gray-a3);
       }
-    }
-    &:focus-visible::after {
-      box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
     }
   }
 }

--- a/packages/radix-ui-themes/src/components/checkbox.css
+++ b/packages/radix-ui-themes/src/components/checkbox.css
@@ -15,6 +15,10 @@
   box-sizing: border-box;
   height: var(--checkbox-size);
   width: var(--checkbox-size);
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-a8);
+    outline-offset: 2px;
+  }
 }
 
 .rt-CheckboxIndicator {
@@ -66,17 +70,10 @@
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
-  &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--gray-a7), 0 0 0 2px var(--accent-3),
-      0 0 0 4px var(--accent-a8);
-  }
   &:where([data-state='checked']) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
 
-    &:where(:focus-visible) {
-      box-shadow: 0 0 0 2px var(--accent-3), 0 0 0 4px var(--accent-a8);
-    }
     &:where(.rt-high-contrast) {
       background-color: var(--accent-12);
       color: var(--accent-1);
@@ -91,17 +88,10 @@
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1);
   }
-  &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1), 0 0 0 2px var(--accent-3),
-      0 0 0 4px var(--accent-a8);
-  }
   &:where([data-state='checked']) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
 
-    &:where(:focus-visible) {
-      box-shadow: 0 0 0 2px var(--accent-3), 0 0 0 4px var(--accent-a8);
-    }
     &:where(.rt-high-contrast) {
       background-color: var(--accent-12);
       color: var(--accent-1);
@@ -113,9 +103,6 @@
 
 .rt-CheckboxButton.rt-variant-soft {
   background-color: var(--accent-a5);
-  &:where(:focus-visible) {
-    box-shadow: 0 0 0 2px var(--accent-1), 0 0 0 4px var(--accent-a8);
-  }
   &:where([data-state='checked']) {
     color: var(--accent-11);
 

--- a/packages/radix-ui-themes/src/components/radio-group.css
+++ b/packages/radix-ui-themes/src/components/radio-group.css
@@ -19,6 +19,11 @@
   height: var(--radio-group-item-size);
   width: var(--radio-group-item-size);
   border-radius: 100%;
+
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-a8);
+    outline-offset: 2px;
+  }
 }
 
 .rt-RadioGroupIndicator {
@@ -60,10 +65,6 @@
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
-  .rt-RadioGroupButton:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--gray-a7), 0 0 0 2px var(--accent-3),
-      0 0 0 4px var(--accent-a8);
-  }
   .rt-RadioGroupButton:where([data-state='checked']) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
@@ -81,10 +82,6 @@
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1);
   }
-  .rt-RadioGroupButton:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1), 0 0 0 2px var(--accent-3),
-      0 0 0 4px var(--accent-a8);
-  }
   .rt-RadioGroupButton:where([data-state='checked']) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
@@ -100,10 +97,6 @@
 .rt-RadioGroupRoot.rt-variant-soft {
   .rt-RadioGroupButton {
     background-color: var(--accent-a5);
-  }
-
-  .rt-RadioGroupButton:where(:focus-visible) {
-    box-shadow: 0 0 0 2px var(--accent-1), 0 0 0 4px var(--accent-a8);
   }
   .rt-RadioGroupButton:where([data-state='checked']) {
     color: var(--accent-11);

--- a/packages/radix-ui-themes/src/components/scroll-area.css
+++ b/packages/radix-ui-themes/src/components/scroll-area.css
@@ -23,7 +23,8 @@
   position: absolute;
   inset: 0;
   pointer-events: none;
-  box-shadow: inset 0 0 0 2px var(--accent-a8);
+  outline: 2px solid var(--accent-8);
+  outline-offset: -2px;
 }
 
 .rt-ScrollAreaScrollbar {

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -7,6 +7,11 @@
   user-select: none;
   vertical-align: top;
   line-height: var(--height);
+
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
+  }
 }
 
 .rt-SelectIcon {
@@ -283,9 +288,6 @@
   &:where([data-state='open']) {
     box-shadow: inset 0 0 0 1px var(--gray-a8);
   }
-  &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
-  }
 }
 
 /* classic */
@@ -343,9 +345,6 @@
   &:where([data-state='open']) {
     background-image: linear-gradient(var(--black-a3), var(--black-a2) 50%);
   }
-  &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
-  }
 }
 
 /* soft / ghost */
@@ -360,9 +359,6 @@
       color: var(--accent-12);
       opacity: 0.5;
     }
-  }
-  &:where(:focus-visible) {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
   }
 }
 .rt-SelectTrigger:where(.rt-variant-soft) {

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -54,14 +54,9 @@
     transition-duration: 30ms;
   }
 
-  /* A pseudo element for the focus outline */
-  &:where(:focus-visible)::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    border-radius: inherit;
-    box-shadow: 0 0 0 2px var(--accent-3), 0 0 0 4px var(--accent-a8);
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-a8);
+    outline-offset: 2px;
   }
 }
 

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -115,7 +115,8 @@
     color: var(--gray-12);
   }
   &:focus-visible .rt-TabsTriggerInner {
-    box-shadow: 0 0 0 2px var(--accent-a8);
+    outline: 2px solid var(--accent-8);
+    outline-offset: -2px;
   }
   &[data-state='active']::before {
     box-sizing: border-box;
@@ -130,5 +131,5 @@
 }
 
 .rt-TabsContent:focus-visible {
-  box-shadow: 0 0 0 2px var(--accent-a8);
+  outline: 2px solid var(--accent-8);
 }

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -13,6 +13,11 @@
 
   resize: none;
 
+  &:focus {
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
+  }
+
   /* scrollbar */
   & {
     /* Arrow mouse cursor over the scrollbar */
@@ -92,10 +97,6 @@
   &:autofill {
     -webkit-text-fill-color: var(--gray-12);
     box-shadow: var(--shadow-1), inset 0 0 0 100px var(--accent-3);
-    &:focus {
-      box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8),
-        inset 0 0 0 100px var(--accent-3);
-    }
   }
   &:read-only {
     &::placeholder {
@@ -108,34 +109,23 @@
 }
 
 /* surface */
-
 .rt-TextArea.rt-variant-surface {
   color: var(--gray-12);
   background-color: var(--color-surface);
   box-shadow: inset 0 0 0 1px var(--gray-a7);
-  &:focus {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
-  }
 }
 
 /* classic */
-
 .rt-TextArea.rt-variant-classic {
   color: var(--gray-12);
   background-color: var(--color-surface);
   box-shadow: var(--shadow-1);
-  &:focus {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8), var(--shadow-1);
-  }
 }
 
 /* soft */
 .rt-TextArea.rt-variant-soft {
   color: var(--accent-12);
   background-color: var(--accent-a3);
-  &:focus {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
-  }
   &:read-only {
     color: var(--gray-12);
   }
@@ -149,7 +139,6 @@
 }
 
 /* all disabled textareas */
-
 .rt-TextArea:disabled {
   color: var(--gray-a9);
   box-shadow: inset 0 0 0 1px var(--gray-a6);
@@ -158,13 +147,10 @@
 }
 
 /* all readonly textareas */
-
 .rt-TextArea:read-only {
   background-color: var(--gray-a3);
-  &:not(:focus) {
-    box-shadow: inset 0 0 0 1px var(--gray-a6);
-  }
+  box-shadow: inset 0 0 0 1px var(--gray-a6);
   &:focus {
-    box-shadow: inset 0 0 0 1px var(--gray-8), 0 0 0 1px var(--gray-a8);
+    outline: 2px solid var(--gray-8);
   }
 }

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -14,6 +14,11 @@
 
   position: relative;
   z-index: 1;
+
+  &:focus + .rt-TextFieldChrome {
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
+  }
 }
 .rt-TextFieldChrome {
   position: absolute;
@@ -137,10 +142,6 @@
       -webkit-text-fill-color: var(--gray-12);
       box-shadow: var(--shadow-1), inset 0 0 0 100px var(--accent-3);
     }
-    &:focus + .rt-TextFieldChrome {
-      box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8),
-        inset 0 0 0 100px var(--accent-3);
-    }
   }
   &:read-only {
     &::placeholder {
@@ -161,9 +162,6 @@
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
-  &:focus + .rt-TextFieldChrome {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
-  }
 }
 
 /* classic */
@@ -175,9 +173,6 @@
     background-color: var(--color-surface);
     box-shadow: var(--shadow-1);
   }
-  &:focus + .rt-TextFieldChrome {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8), var(--shadow-1);
-  }
 }
 
 /* soft */
@@ -186,9 +181,6 @@
 
   & + .rt-TextFieldChrome {
     background-color: var(--accent-a3);
-  }
-  &:focus + .rt-TextFieldChrome {
-    box-shadow: inset 0 0 0 1px var(--accent-8), 0 0 0 1px var(--accent-a8);
   }
   &:read-only {
     color: var(--gray-12);
@@ -225,11 +217,9 @@
 .rt-TextFieldInput:read-only {
   & + .rt-TextFieldChrome {
     background-color: var(--gray-a3);
-  }
-  &:not(:focus) + .rt-TextFieldChrome {
     box-shadow: inset 0 0 0 1px var(--gray-a6);
   }
   &:focus + .rt-TextFieldChrome {
-    box-shadow: inset 0 0 0 1px var(--gray-8), 0 0 0 1px var(--gray-a8);
+    outline: 2px solid var(--gray-8);
   }
 }


### PR DESCRIPTION
Fixes janky focus outline anti-aliasing in Chrome

***

Before/after, light mode

<img width="661" alt="Screenshot 2023-09-01 at 13 51 51" src="https://github.com/radix-ui/themes/assets/8441036/221e9555-be78-47ea-bf61-9183aed6c882">

<img width="707" alt="Screenshot 2023-09-01 at 13 52 29" src="https://github.com/radix-ui/themes/assets/8441036/57f4ff27-0765-43cc-a4b9-607b89b9edb9">

***

Before/after, dark mode

<img width="667" alt="Screenshot 2023-09-01 at 13 51 37" src="https://github.com/radix-ui/themes/assets/8441036/81371d3f-0710-47cc-8600-a46e4d2b5040">

<img width="694" alt="Screenshot 2023-09-01 at 13 50 56" src="https://github.com/radix-ui/themes/assets/8441036/092347be-b303-4739-ae8b-f8b325e4ed2c">
