### PR TITLE
Fix nested Grid values inheritance

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -3833,6 +3833,34 @@ export default function Sink() {
                       </Flex>
                     </Flex>
                   </DocsSection>
+
+                  <DocsSection title="Grid">
+                    <Grid columns={{ initial: '1', md: '2', lg: '3' }} gap="3">
+                      <Box style={{ height: 256 }}>
+                        <Grid gap="3">
+                          {Array.from(Array(4).keys()).map((i) => (
+                            <Box key={i} style={{ height: 55, background: 'var(--accent-9)' }} />
+                          ))}
+                        </Grid>
+                      </Box>
+
+                      <Box style={{ height: 256 }}>
+                        <Grid columns="5" gap="3" height="100%">
+                          {Array.from(Array(5).keys()).map((i) => (
+                            <Box key={i} style={{ background: 'var(--accent-9)' }} />
+                          ))}
+                        </Grid>
+                      </Box>
+
+                      <Box style={{ height: 256 }}>
+                        <Grid columns={{ initial: '5' }} gap="3" height="100%">
+                          {Array.from(Array(20).keys()).map((i) => (
+                            <Box key={i} style={{ background: 'var(--accent-9)' }} />
+                          ))}
+                        </Grid>
+                      </Box>
+                    </Grid>
+                  </DocsSection>
                 </main>
               </Box>
             </div>

--- a/packages/radix-ui-themes/src/components/grid.css
+++ b/packages/radix-ui-themes/src/components/grid.css
@@ -5,103 +5,107 @@
   display: grid;
   align-items: stretch;
   justify-content: flex-start;
-  grid-template-columns: var(--grid-template-columns);
-  grid-template-rows: var(--grid-template-rows);
-  --grid-template-columns: var(--grid-template-columns-initial, 1fr);
-  --grid-template-rows: var(--grid-template-rows-initial, none);
+
+  grid-template-columns: var(--grid-template-columns-initial);
+  grid-template-rows: var(--grid-template-rows-initial);
+
+  --grid-template-columns-initial: 1fr;
+  --grid-template-rows-initial: none;
+
+  /* Unset responsive values so that they are not inherited from an ancestor Grid */
+  --grid-template-columns-xs: initial;
+  --grid-template-columns-sm: initial;
+  --grid-template-columns-md: initial;
+  --grid-template-columns-lg: initial;
+  --grid-template-columns-xl: initial;
+  --grid-template-rows-xs: initial;
+  --grid-template-rows-sm: initial;
+  --grid-template-rows-md: initial;
+  --grid-template-rows-lg: initial;
+  --grid-template-rows-xl: initial;
 }
 
 /* prettier-ignore */
 @media (--xs) {
   .rt-Grid {
-    --grid-template-columns: var(
-      --grid-template-columns-xs, var(
-      --grid-template-columns-initial, 1fr
-    ));
+    grid-template-columns:
+      var(--grid-template-columns-xs,
+      var(--grid-template-columns-initial));
 
-    --grid-template-rows: var(
-      --grid-template-rows-xs, var(
-      --grid-template-rows-initial, none
-    ));
+    grid-template-rows:
+      var(--grid-template-rows-xs,
+      var(--grid-template-rows-initial));
   }
 }
 
 /* prettier-ignore */
 @media (--sm) {
   .rt-Grid {
-    --grid-template-columns: var(
-      --grid-template-columns-sm, var(
-      --grid-template-columns-xs, var(
-      --grid-template-columns-initial, 1fr
-    )));
+    grid-template-columns:
+      var(--grid-template-columns-sm,
+      var(--grid-template-columns-xs,
+      var(--grid-template-columns-initial)));
 
-    --grid-template-rows: var(
-      --grid-template-rows-sm, var(
-      --grid-template-rows-xs, var(
-      --grid-template-rows-initial, none
-    )));
+    grid-template-rows:
+      var(--grid-template-rows-sm,
+      var(--grid-template-rows-xs,
+      var(--grid-template-rows-initial)));
   }
 }
 
 /* prettier-ignore */
 @media (--md) {
   .rt-Grid {
-    --grid-template-columns: var(
-      --grid-template-columns-md, var(
-      --grid-template-columns-sm, var(
-      --grid-template-columns-xs, var(
-      --grid-template-columns-initial, 1fr
-    ))));
+    grid-template-columns:
+      var(--grid-template-columns-md,
+      var(--grid-template-columns-sm,
+      var(--grid-template-columns-xs,
+      var(--grid-template-columns-initial))));
 
-    --grid-template-rows: var(
-      --grid-template-rows-md, var(
-      --grid-template-rows-sm, var(
-      --grid-template-rows-xs, var(
-      --grid-template-rows-initial, none
-    ))));
+    grid-template-rows:
+      var(--grid-template-rows-md,
+      var(--grid-template-rows-sm,
+      var(--grid-template-rows-xs,
+      var(--grid-template-rows-initial))));
   }
 }
 
 /* prettier-ignore */
 @media (--lg) {
   .rt-Grid {
-    --grid-template-columns: var(
-      --grid-template-columns-lg, var(
-      --grid-template-columns-md, var(
-      --grid-template-columns-sm, var(
-      --grid-template-columns-xs, var(
-      --grid-template-columns-initial, 1fr
-    )))));
+    grid-template-columns:
+      var(--grid-template-columns-lg,
+      var(--grid-template-columns-md,
+      var(--grid-template-columns-sm,
+      var(--grid-template-columns-xs,
+      var(--grid-template-columns-initial)))));
 
-    --grid-template-rows: var(
-      --grid-template-rows-lg, var(
-      --grid-template-rows-md, var(
-      --grid-template-rows-sm, var(
-      --grid-template-rows-xs, var(
-      --grid-template-rows-initial, none
-    )))));
+    grid-template-rows:
+      var(--grid-template-rows-lg,
+      var(--grid-template-rows-md,
+      var(--grid-template-rows-sm,
+      var(--grid-template-rows-xs,
+      var(--grid-template-rows-initial)))));
   }
 }
 
 /* prettier-ignore */
 @media (--xl) {
   .rt-Grid {
-    --grid-template-columns: var(
-      --grid-template-columns-xl, var(
-      --grid-template-columns-lg, var(
-      --grid-template-columns-md, var(
-      --grid-template-columns-sm, var(
-      --grid-template-columns-xs, var(
-      --grid-template-columns-initial, 1fr
-    ))))));
+    grid-template-columns:
+      var(--grid-template-columns-xl,
+      var(--grid-template-columns-lg,
+      var(--grid-template-columns-md,
+      var(--grid-template-columns-sm,
+      var(--grid-template-columns-xs,
+      var(--grid-template-columns-initial))))));
 
-    --grid-template-rows: var(
-      --grid-template-rows-xl, var(
-      --grid-template-rows-lg, var(
-      --grid-template-rows-md, var(
-      --grid-template-rows-sm, var(
-      --grid-template-rows-xs, var(
-      --grid-template-rows-initial, none
-    ))))));
+    grid-template-rows:
+      var(--grid-template-rows-xl,
+      var(--grid-template-rows-lg,
+      var(--grid-template-rows-md,
+      var(--grid-template-rows-sm,
+      var(--grid-template-rows-xs,
+      var(--grid-template-rows-initial))))));
   }
 }

--- a/packages/radix-ui-themes/src/components/grid.tsx
+++ b/packages/radix-ui-themes/src/components/grid.tsx
@@ -49,14 +49,14 @@ const Grid = React.forwardRef<GridElement, GridProps>((props, forwardedRef) => {
 
   if (typeof columns === 'string') {
     style = {
-      '--grid-template-columns': parseGridValue(columns),
+      '--grid-template-columns-initial': parseGridValue(columns),
       ...style,
     };
   }
 
   if (typeof rows === 'string') {
     style = {
-      '--grid-template-rows': parseGridValue(rows),
+      '--grid-template-rows-initial': parseGridValue(rows),
       ...style,
     };
   }


### PR DESCRIPTION
Example layout, before:

<img width="1220" alt="Screenshot 2023-09-08 at 11 34 22" src="https://github.com/radix-ui/themes/assets/8441036/b589b92e-30c9-4504-aedb-d93c008d9463">

This is incorrect—first and last child grid inherit parent grid columns, instead of using own values.

Example layout, after:

<img width="1220" alt="Screenshot 2023-09-08 at 11 34 33" src="https://github.com/radix-ui/themes/assets/8441036/7db90fb6-8e2f-4b3e-aec4-dd5f058da36a">

***

Inspecting a child element, before:

<img width="1512" alt="Screenshot 2023-09-08 at 11 41 32" src="https://github.com/radix-ui/themes/assets/8441036/46e3590a-d1a9-4615-bddb-4dca8a1e3d85">

Inspecting a child element, after:

<img width="1512" alt="Screenshot 2023-09-08 at 11 41 26" src="https://github.com/radix-ui/themes/assets/8441036/abae7496-18fd-4ca3-bfb1-a03e383ec93b">

