### PR TITLE
Translate theme panel hotkeys to Windows and Linux

### DIFF
--- a/apps/playground/app/explore-components/kbd-specimen.tsx
+++ b/apps/playground/app/explore-components/kbd-specimen.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import * as React from 'react';
+
+import { Flex, Kbd, Text } from '@radix-ui/themes';
+
+export const KbdSpecimen = () => {
+  type Platform = 'apple' | 'nonApple';
+
+  const [platform, setPlatform] = React.useState<Platform | null>(null);
+
+  // set user's platform
+  React.useEffect(() => {
+    if (typeof navigator !== 'undefined') {
+      if (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+        setPlatform('apple');
+      } else setPlatform('nonApple');
+    }
+  }, []);
+
+  // display correct action key based on the user's platform
+  const ActionKey = () => {
+    if (platform === 'apple') return <>⌘ </>;
+    return <>Ctrl+</>;
+  };
+
+  if (platform)
+    return (
+      <Flex direction="column" gap="4" my="6">
+        <Text as="p" size="2">
+          Press{' '}
+          <Kbd>
+            <ActionKey />C
+          </Kbd>{' '}
+          to show/hide the Theme Panel, or press{' '}
+          <Kbd>
+            <ActionKey />D
+          </Kbd>{' '}
+          to toggle dark mode.
+        </Text>
+        <Text as="p" size="3">
+          Press{' '}
+          <Kbd>
+            <ActionKey />C
+          </Kbd>{' '}
+          to show/hide the Theme Panel, or press{' '}
+          <Kbd>
+            <ActionKey />D
+          </Kbd>{' '}
+          to toggle dark mode.
+        </Text>
+        <Text as="p" size="4">
+          Press{' '}
+          <Kbd>
+            <ActionKey />C
+          </Kbd>{' '}
+          to show/hide the Theme Panel, or press{' '}
+          <Kbd>
+            <ActionKey />D
+          </Kbd>{' '}
+          to toggle dark mode.
+        </Text>
+        <Text as="p" size="5">
+          Press{' '}
+          <Kbd>
+            <ActionKey />C
+          </Kbd>{' '}
+          to show/hide the Theme Panel, or press{' '}
+          <Kbd>
+            <ActionKey />D
+          </Kbd>{' '}
+          to toggle dark mode.
+        </Text>
+      </Flex>
+    );
+};

--- a/apps/playground/app/explore-components/page.tsx
+++ b/apps/playground/app/explore-components/page.tsx
@@ -181,6 +181,7 @@ import {
   MagnifyingGlassIcon,
   StarIcon,
 } from '@radix-ui/react-icons';
+import { KbdSpecimen } from './kbd-specimen';
 import { getPeopleForColor } from './people';
 import styles from './page.module.css';
 
@@ -2344,24 +2345,7 @@ export default function ExploreComponents() {
                   </TabsList>
 
                   <TabsContent value="specimen">
-                    <Flex direction="column" gap="4" my="6">
-                      <Text as="p" size="2">
-                        Press <Kbd>⌘ C</Kbd> to show/hide the Theme Panel, or press <Kbd>⌘ D</Kbd>{' '}
-                        to toggle dark mode.
-                      </Text>
-                      <Text as="p" size="3">
-                        Press <Kbd>⌘ C</Kbd> to show/hide the Theme Panel, or press <Kbd>⌘ D</Kbd>{' '}
-                        to toggle dark mode.
-                      </Text>
-                      <Text as="p" size="4">
-                        Press <Kbd>⌘ C</Kbd> to show/hide the Theme Panel, or press <Kbd>⌘ D</Kbd>{' '}
-                        to toggle dark mode.
-                      </Text>
-                      <Text as="p" size="5">
-                        Press <Kbd>⌘ C</Kbd> to show/hide the Theme Panel, or press <Kbd>⌘ D</Kbd>{' '}
-                        to toggle dark mode.
-                      </Text>
-                    </Flex>
+                    <KbdSpecimen />
                   </TabsContent>
 
                   <TabsContent value="all-sizes">

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -129,7 +129,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
 
     // display correct action key based on the user's platform
     const ActionKey = () => {
-      if (platform === 'apple') return <>⌘ </>;
+      if (platform === 'apple') return <>⌘&thinsp;</>;
       return <>Ctrl+</>;
     };
 

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -114,12 +114,31 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
       setTimeout(() => setCopyState('idle'), 2000);
     }
 
-    // quickly show/hide using ⌘C
+    type Platform = 'apple' | 'nonApple';
+
+    const [platform, setPlatform] = React.useState<Platform | null>(null);
+
+    // set user's platform
+    React.useEffect(() => {
+      if (typeof navigator !== 'undefined') {
+        if (/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+          setPlatform('apple');
+        } else setPlatform('nonApple');
+      }
+    }, []);
+
+    // display correct action key based on the user's platform
+    const ActionKey = () => {
+      if (platform === 'apple') return <>⌘ </>;
+      return <>Ctrl+</>;
+    };
+
+    // quickly show/hide using ⌘C / Ctrl+C
     React.useEffect(() => {
       function handleKeydown(event: KeyboardEvent) {
-        const isCmdC =
-          event.metaKey && event.key === 'c' && !event.shiftKey && !event.altKey && !event.ctrlKey;
-        if (isCmdC && window.getSelection()?.toString() === '') {
+        const isCmdCOrCtrlC =
+          (event.metaKey || event.ctrlKey) && event.key === 'c' && !event.shiftKey && !event.altKey;
+        if (isCmdCOrCtrlC && window.getSelection()?.toString() === '') {
           onOpenChange(!open);
         }
       }
@@ -127,10 +146,10 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
       return () => document.removeEventListener('keydown', handleKeydown);
     }, [onOpenChange, open]);
 
-    // quickly toggle appearance using cmd+d
+    // quickly toggle appearance using cmd+d / Ctrl+D
     React.useEffect(() => {
       function handleKeydown(event: KeyboardEvent) {
-        if (event.metaKey && event.key === 'd') {
+        if ((event.metaKey || event.ctrlKey) && event.key === 'd') {
           event.preventDefault();
           handleAppearanceChange(appearance === 'dark' ? 'light' : 'dark');
         }
@@ -205,15 +224,21 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
           <ScrollArea>
             <Box grow="1" p="5" position="relative">
               <Box position="absolute" top="0" right="0" m="2">
-                <Tooltip
-                  content="Press ⌘&thinsp;C to show/hide the Theme Panel"
-                  side="bottom"
-                  sideOffset={6}
-                >
-                  <Kbd size="3" tabIndex={0} className="rt-ThemePanelShortcut">
-                    ⌘&thinsp;C
-                  </Kbd>
-                </Tooltip>
+                {platform && (
+                  <Tooltip
+                    content={
+                      <>
+                        Press <ActionKey />C to show/hide the Theme Panel
+                      </>
+                    }
+                    side="bottom"
+                    sideOffset={6}
+                  >
+                    <Kbd size="3" tabIndex={0} className="rt-ThemePanelShortcut">
+                      <ActionKey />C
+                    </Kbd>
+                  </Tooltip>
+                )}
               </Box>
 
               <Heading size="5" trim="both" as="h3" mb="5">


### PR DESCRIPTION
Fixes #75 - both the theme panel and the `explore-components` page in playground.

Automatically detects the user's platform and displays the correct shortcut action key (⌘ on macOS, Ctrl on Windows, Linux etc.)

Now the shortcuts work properly on Windows:
https://github.com/radix-ui/themes/assets/28688352/45e42277-9e2b-4d52-9280-339323be2d5f

while macOS still has ⌘:
https://github.com/radix-ui/themes/assets/28688352/db05c804-084b-4415-b4de-a3397d0927f9

