### PR TITLE
Reduce CSS selector specificity

### DIFF
--- a/apps/playground/.eslintrc.js
+++ b/apps/playground/.eslintrc.js
@@ -1,8 +1,4 @@
 module.exports = {
   root: true,
   extends: ['custom'],
-  rules: {
-    'jsx-a11y/alt-text': 'off',
-    '@next/next/no-img-element': 'off',
-  },
 };

--- a/apps/playground/.eslintrc.js
+++ b/apps/playground/.eslintrc.js
@@ -1,4 +1,8 @@
 module.exports = {
   root: true,
-  extends: ["custom"],
+  extends: ['custom'],
+  rules: {
+    'jsx-a11y/alt-text': 'off',
+    '@next/next/no-img-element': 'off',
+  },
 };

--- a/apps/playground/app/explore-components/page.tsx
+++ b/apps/playground/app/explore-components/page.tsx
@@ -4190,7 +4190,7 @@ function AvatarIconFallback() {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="currentColor"
-      className="w-6 h-6"
+      style={{ width: '60%', height: '60%' }}
     >
       <path
         fillRule="evenodd"

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4111,7 +4111,7 @@ function CustomUserIcon() {
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       fill="currentColor"
-      className="w-6 h-6"
+      style={{ width: '60%', height: '60%' }}
     >
       <path
         fillRule="evenodd"

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -1,6 +1,9 @@
 module.exports = {
   extends: ['next', 'turbo', 'prettier'],
   rules: {
+    // Not useful for our playground apps:
+    'jsx-a11y/alt-text': 'off',
+    '@next/next/no-img-element': 'off',
     '@next/next/no-html-link-for-pages': 'off',
   },
   parserOptions: {

--- a/packages/radix-ui-themes/.stylelintrc.js
+++ b/packages/radix-ui-themes/.stylelintrc.js
@@ -1,8 +1,11 @@
 module.exports = {
   rules: {
-    // Allow 0,1,1 specificity for pseudo elements and effectively cap at 0,1,0 in all other cases
+    // Disallow element type selector.
     'selector-max-type': 0,
+    // Allow 0,1,1 specificity for pseudo elements and effectively cap at 0,1,0 in all other cases.
+    // This is so that Tailwind classes work as expected.
     'selector-max-specificity': ['0,1,1'],
+    // Enforce prefixes on classnames and keyframes
     'selector-class-pattern': /^-?rt-|^radix-themes$|^(light|dark)(-theme)?$/,
     'keyframes-name-pattern': /^rt-([a-z]|-)+$/,
   },

--- a/packages/radix-ui-themes/.stylelintrc.js
+++ b/packages/radix-ui-themes/.stylelintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rules: {
+    // Allow 0,1,1 specificity for pseudo elements and effectively cap at 0,1,0 in all other cases
+    'selector-max-type': 0,
+    'selector-max-specificity': ['0,1,1'],
+    'selector-class-pattern': /^-?rt-|^radix-themes$|^(light|dark)(-theme)?$/,
+    'keyframes-name-pattern': /^rt-([a-z]|-)+$/,
+  },
+};

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -3,6 +3,10 @@
 ## Up next
 
 - General
+  - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser.
+  - Remove comments from the CSS build.
+  - Cap CSS selector specificity at 0,1,0 for styling HTML elements and at 0,1,1 for styling pseudo-elements, improving compatibility with Tailwind.
+    - **[Upgrade guide]** If you were relying on any specificity quirks of Radix Themes, make sure that your style overrides still work as expected.
   - Rework dark mode colors, refine light mode colors (via Radix Colors 3.0.0).
     - Fix oversaturated transparent grays.
     - **[Upgrade guide]** If you were using the color tokens for your custom styles, make sure that your designs look as expected.
@@ -34,10 +38,12 @@
       - Change `--white-a11` to `--white-a9`
       - Change `--white-a12` to `--white-a11` or `--white-a12`
   - Refine the shadow scale.
-  - Combine selectors in the CSS build, improving the developer experience when inspecting elements in the browser.
-  - Remove comments from the CSS build.
   - Make sure that forced light/dark appearance on the `Theme` component also sets the corresponding browser colors, like the correct input autofill background color.
+  - Rename all `@keyframes` animations with `rt-` prefix and into kebab case.
   - Use `outline` rather than `box-shadow` for most focus styles, which avoids a slight anti-aliasing issue in Chrome on focused elements.
+- `Avatar`
+  - Don’t enforce fallback icon size
+    - **[Upgarde guide]** If you were using `svg` assets as a fallback, make sure to set an appropriate size manually.
 - `Button`, `IconButton`
   - Refine and normalise the look and feel of the disabled states.
   - Improve `variant="classic"` look and feel across different accent colors in light and dark mode.
@@ -60,12 +66,24 @@
   - Automatically adjust table cell padding for when `Table` is inside `Inset`
 - `Link`
   - Desaturate the underline color.
+  - Make links automatically high-contrast within colored `Heading` elements (similarly to the automatic high-contrast within `Text`).
 - `RadioGroup`
   - Refine and normalise the look and feel of the disabled states.
 - `Select`
   - Fix invisible scrollbar in long item lists
   - Improve `variant="classic"` look and feel across light and dark mode.
   - Align `SelectContent` to the left of the trigger when using `position="popper"`
+- `ScrollArea`
+  - Rename scrollbar margin variables to include the scrollbar orientation and declare them on `.radix-themes` to facilitate easier scrollbar position adjustments
+    - **[Upgarde guide]** If you were using the variables `--scrollarea-scrollbar-margin-top`, `--scrollarea-scrollbar-margin-left`, etc. make sure that they follow the new names and are set at the appropriate level. There's no need to target `.rt-ScrollAreaScrollbar` element to set the variables anymore, as they can be set just on the component that needs the override. New variables:
+      - `--scrollarea-scrollbar-horizontal-margin-top`
+      - `--scrollarea-scrollbar-horizontal-margin-bottom`
+      - `--scrollarea-scrollbar-horizontal-margin-left`
+      - `--scrollarea-scrollbar-horizontal-margin-right`
+      - `--scrollarea-scrollbar-vertical-margin-top`
+      - `--scrollarea-scrollbar-vertical-margin-bottom`
+      - `--scrollarea-scrollbar-vertical-margin-left`
+      - `--scrollarea-scrollbar-vertical-margin-right`
 - `Slider`, `Switch`
   - Refine the shadows and colors used in the components.
   - Refine and normalise the look and feel of the disabled states.

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -40,7 +40,8 @@
     "lint": "yarn lint:js && yarn lint:css",
     "lint:js": "eslint \"src/**/*.ts*\"",
     "lint:css": "stylelint \"src/**/*.css\"",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf styles.css"
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf styles.css",
+    "prepublishOnly": "yarn lint"
   },
   "dependencies": {
     "@radix-ui/colors": "^3.0.0-rc.4",

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -37,7 +37,9 @@
     "dev:js:cjs": "tsc --project tsconfig-cjs.json --watch",
     "dev:js:esm": "tsc --project tsconfig-esm.json --watch",
     "dev:css": "postcss src/styles/index.css -o styles.css --watch",
-    "lint": "eslint \"src/**/*.ts*\"",
+    "lint": "yarn lint:js && yarn lint:css",
+    "lint:js": "eslint \"src/**/*.ts*\"",
+    "lint:css": "stylelint \"src/**/*.css\"",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf styles.css"
   },
   "dependencies": {
@@ -96,6 +98,7 @@
     "postcss-nesting": "^11.3.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "stylelint": "^15.10.3",
     "typescript": "^4.5.3"
   },
   "publishConfig": {

--- a/packages/radix-ui-themes/src/components/avatar.css
+++ b/packages/radix-ui-themes/src/components/avatar.css
@@ -25,11 +25,6 @@
   justify-content: center;
   line-height: 1;
   border-radius: inherit;
-
-  & svg {
-    width: var(--avatar-font-size-one-letter);
-    height: var(--avatar-font-size-one-letter);
-  }
 }
 
 /***************************************************************************************************
@@ -42,69 +37,69 @@
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
 
-  &.rt-one-letter {
+  &:where(.rt-one-letter) {
     font-size: var(--avatar-font-size-one-letter);
   }
-  &.rt-two-letters {
+  &:where(.rt-two-letters) {
     font-size: var(--avatar-font-size-two-letters, var(--avatar-font-size-one-letter));
   }
 }
 
 @breakpoints {
   .rt-AvatarRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --avatar-size: var(--space-5);
       border-radius: max(var(--radius-2), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-2);
       --avatar-font-size-two-letters: var(--font-size-1);
       letter-spacing: var(--letter-spacing-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --avatar-size: var(--space-6);
       border-radius: max(var(--radius-2), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-3);
       --avatar-font-size-two-letters: var(--font-size-2);
       letter-spacing: var(--letter-spacing-2);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --avatar-size: var(--space-7);
       border-radius: max(var(--radius-3), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-4);
       --avatar-font-size-two-letters: var(--font-size-3);
       letter-spacing: var(--letter-spacing-3);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --avatar-size: var(--space-8);
       border-radius: max(var(--radius-3), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-5);
       --avatar-font-size-two-letters: var(--font-size-4);
       letter-spacing: var(--letter-spacing-4);
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       --avatar-size: var(--space-9);
       border-radius: max(var(--radius-4), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-6);
       letter-spacing: var(--letter-spacing-6);
     }
-    &.rt-r-size-6 {
+    &:where(.rt-r-size-6) {
       --avatar-size: 80px;
       border-radius: max(var(--radius-5), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-7);
       letter-spacing: var(--letter-spacing-7);
     }
-    &.rt-r-size-7 {
+    &:where(.rt-r-size-7) {
       --avatar-size: 96px;
       border-radius: max(var(--radius-5), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-7);
       letter-spacing: var(--letter-spacing-7);
     }
-    &.rt-r-size-8 {
+    &:where(.rt-r-size-8) {
       --avatar-size: 128px;
       border-radius: max(var(--radius-6), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-8);
       letter-spacing: var(--letter-spacing-8);
     }
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-9) {
       --avatar-size: 160px;
       border-radius: max(var(--radius-6), var(--radius-full));
       --avatar-font-size-one-letter: var(--font-size-9);
@@ -121,12 +116,12 @@
 
 /* solid */
 
-.rt-AvatarRoot.rt-variant-solid {
-  & .rt-AvatarFallback {
+.rt-AvatarRoot:where(.rt-variant-solid) {
+  & :where(.rt-AvatarFallback) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
   }
-  &:where(.rt-high-contrast) .rt-AvatarFallback {
+  &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     background-color: var(--accent-12);
     color: var(--accent-1);
   }
@@ -134,12 +129,12 @@
 
 /* soft */
 
-.rt-AvatarRoot.rt-variant-soft {
-  & .rt-AvatarFallback {
+.rt-AvatarRoot:where(.rt-variant-soft) {
+  & :where(.rt-AvatarFallback) {
     background-color: var(--accent-a3);
     color: var(--accent-a11);
   }
-  &:where(.rt-high-contrast) .rt-AvatarFallback {
+  &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     color: var(--accent-12);
   }
 }

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -18,7 +18,7 @@
 
 @breakpoints {
   .rt-Badge {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       font-size: var(--font-size-1);
       line-height: var(--line-height-1);
       letter-spacing: var(--letter-spacing-1);
@@ -26,7 +26,7 @@
       gap: var(--space-1);
       border-radius: max(var(--radius-1), var(--radius-full));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       font-size: var(--font-size-2);
       line-height: var(--line-height-2);
       letter-spacing: var(--letter-spacing-2);
@@ -45,7 +45,7 @@
 
 /* solid */
 
-.rt-Badge.rt-variant-solid {
+.rt-Badge:where(.rt-variant-solid) {
   background-color: var(--accent-9);
   color: var(--accent-9-contrast);
 
@@ -57,7 +57,7 @@
 
 /* surface */
 
-.rt-Badge.rt-variant-surface {
+.rt-Badge:where(.rt-variant-surface) {
   background-color: var(--color-surface-accent);
   box-shadow: inset 0 0 0 1px var(--accent-a7);
   color: var(--accent-a11);
@@ -69,7 +69,7 @@
 
 /* soft */
 
-.rt-Badge.rt-variant-soft {
+.rt-Badge:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
   color: var(--accent-a11);
   &:where(.rt-high-contrast) {
@@ -79,7 +79,7 @@
 
 /* outline */
 
-.rt-Badge.rt-variant-outline {
+.rt-Badge:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
   &:where(.rt-high-contrast) {

--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -26,20 +26,20 @@
 
 @breakpoints {
   .rt-BaseButton {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --base-button__classic-active__offset-override: 1px;
       --base-button-height: var(--space-5);
       border-radius: max(var(--radius-1), var(--radius-full));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --base-button-height: var(--space-6);
       border-radius: max(var(--radius-2), var(--radius-full));
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --base-button-height: var(--space-7);
       border-radius: max(var(--radius-3), var(--radius-full));
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --base-button-height: var(--space-8);
       border-radius: max(var(--radius-4), var(--radius-full));
     }
@@ -72,7 +72,7 @@
 }
 /* prettier-ignore */
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --button__classic__pseudo-inset: 1px;
   --button__classic__shadow-front-layer:
     inset 0 0 0 1px var(--white-a2),
@@ -91,7 +91,7 @@
   --button-filter__classic-high-contrast-active: brightness(0.95) saturate(1.2);
 }
 
-.rt-BaseButton.rt-variant-classic {
+.rt-BaseButton:where(.rt-variant-classic) {
   background-color: var(--accent-9);
   color: var(--accent-9-contrast);
   position: relative;
@@ -232,13 +232,13 @@
   --button-filter__solid-high-contrast-active: contrast(0.82) saturate(1.2) brightness(1.16);
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --button-filter__solid-active: brightness(1.08);
   --button-filter__solid-high-contrast-hover: contrast(0.88) saturate(1.3) brightness(1.18);
   --button-filter__solid-high-contrast-active: brightness(0.95) saturate(1.2);
 }
 
-.rt-BaseButton.rt-variant-solid {
+.rt-BaseButton:where(.rt-variant-solid) {
   background-color: var(--accent-9);
   color: var(--accent-9-contrast);
 
@@ -287,8 +287,7 @@
 
 /* soft / ghost */
 
-.rt-BaseButton.rt-variant-soft,
-.rt-BaseButton.rt-variant-ghost {
+.rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost) {
   color: var(--accent-a11);
 
   &:where(:focus-visible) {
@@ -305,7 +304,7 @@
   }
 }
 
-.rt-BaseButton.rt-variant-soft {
+.rt-BaseButton:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
 
   @media (hover: hover) {
@@ -326,7 +325,7 @@
   }
 }
 
-.rt-BaseButton.rt-variant-ghost {
+.rt-BaseButton:where(.rt-variant-ghost) {
   @media (hover: hover) {
     &:where(:hover) {
       background-color: var(--accent-a3);
@@ -347,7 +346,7 @@
 
 /* outline */
 
-.rt-BaseButton.rt-variant-outline {
+.rt-BaseButton:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
 
@@ -385,7 +384,7 @@
 
 /* surface */
 
-.rt-BaseButton.rt-variant-surface {
+.rt-BaseButton:where(.rt-variant-surface) {
   background-color: var(--color-surface-accent);
   box-shadow: inset 0 0 0 1px var(--accent-a7);
   color: var(--accent-a11);

--- a/packages/radix-ui-themes/src/components/base-menu.css
+++ b/packages/radix-ui-themes/src/components/base-menu.css
@@ -2,7 +2,7 @@
   --base-menu-radius: min(var(--base-menu-corner-height), max(var(--radius-3), var(--radius-full)));
   --base-menu-corner-height: calc(var(--base-menu-item-height) / 2 + var(--base-menu-padding));
   --base-menu-scrollbar-margin: max(calc(var(--base-menu-radius) / 1.5), var(--base-menu-padding));
-  --scrollarea-scrollbar-vertical-margin-top: var(--base-menu-scroll-barmargin);
+  --scrollarea-scrollbar-vertical-margin-top: var(--base-menu-scrollbar-margin);
   --scrollarea-scrollbar-vertical-margin-bottom: var(--base-menu-scrollbar-margin);
   --scrollarea-scrollbar-horizontal-margin-left: var(--base-menu-scrollbar-margin);
   --scrollarea-scrollbar-horizontal-margin-right: var(--base-menu-scrollbar-margin);

--- a/packages/radix-ui-themes/src/components/base-menu.css
+++ b/packages/radix-ui-themes/src/components/base-menu.css
@@ -92,6 +92,7 @@
   font-size: var(--font-size-1);
   line-height: var(--line-height-1);
   letter-spacing: var(--letter-spacing-1);
+  color: var(--gray-a11);
   user-select: none;
   cursor: default;
 
@@ -168,9 +169,6 @@
   & :where(.rt-BaseMenuShortcut) {
     color: inherit;
   }
-}
-.rt-BaseMenuLabel {
-  color: var(--gray-a11);
 }
 .rt-BaseMenuSeparator {
   background-color: var(--gray-a6);

--- a/packages/radix-ui-themes/src/components/base-menu.css
+++ b/packages/radix-ui-themes/src/components/base-menu.css
@@ -1,24 +1,18 @@
 .rt-BaseMenuContent {
+  --base-menu-radius: min(var(--base-menu-corner-height), max(var(--radius-3), var(--radius-full)));
+  --base-menu-corner-height: calc(var(--base-menu-item-height) / 2 + var(--base-menu-padding));
+  --base-menu-scrollbar-margin: max(calc(var(--base-menu-radius) / 1.5), var(--base-menu-padding));
+  --scrollarea-scrollbar-vertical-margin-top: var(--base-menu-scroll-barmargin);
+  --scrollarea-scrollbar-vertical-margin-bottom: var(--base-menu-scrollbar-margin);
+  --scrollarea-scrollbar-horizontal-margin-left: var(--base-menu-scrollbar-margin);
+  --scrollarea-scrollbar-horizontal-margin-right: var(--base-menu-scrollbar-margin);
+
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
   overflow: hidden;
-
   background-color: var(--base-menu-bg);
-  --base-menu-radius: min(
-    (var(--base-menu-item-height) / 2 + var(--base-menu-padding)),
-    max(var(--radius-3), var(--radius-full))
-  );
   border-radius: var(--base-menu-radius);
-
-  & .rt-ScrollAreaScrollbar {
-    --base-menu-scrollbar-margin: max(
-      calc(var(--base-menu-radius) / 1.5),
-      var(--base-menu-padding)
-    );
-    margin-top: var(--base-menu-scrollbar-margin);
-    margin-bottom: var(--base-menu-scrollbar-margin);
-  }
 }
 
 .rt-BaseMenuViewport {
@@ -28,8 +22,8 @@
   overflow: auto;
   padding: var(--base-menu-padding);
 
-  .rt-BaseMenuContent:has(.rt-ScrollAreaScrollbar[data-orientation='vertical']) & {
-    padding-right: 12px;
+  :where(.rt-BaseMenuContent:has(.rt-ScrollAreaScrollbar[data-orientation='vertical'])) & {
+    padding-right: var(--space-3);
   }
 }
 
@@ -51,15 +45,15 @@
   /* Fix sticky text highlighting after selection in Firefox */
   user-select: none;
 
-  &[data-disabled] {
+  &:where([data-disabled]) {
     pointer-events: none;
   }
 
   /* reset with :not:has so we still support browsers without :has */
-  .rt-BaseMenuContent:not(:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem)) & {
+  :where(.rt-BaseMenuContent:not(:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem))) & {
     padding-left: var(--space-3);
   }
-  .rt-BaseMenuContent:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem) & {
+  :where(.rt-BaseMenuContent:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem)) & {
     padding-left: var(--space-5);
   }
 }
@@ -68,10 +62,11 @@
   display: flex;
   align-items: center;
   margin-left: var(--space-5);
+}
 
-  & svg {
-    margin-right: calc(-2px * var(--scaling));
-  }
+.rt-BaseMenuSubTriggerIcon {
+  color: var(--gray-12);
+  margin-right: calc(-2px * var(--scaling));
 }
 
 .rt-BaseMenuItemIndicator {
@@ -100,15 +95,15 @@
   user-select: none;
   cursor: default;
 
-  &:not(:first-child) {
+  &:where(:not(:first-child)) {
     margin-top: var(--space-2);
   }
 
   /* reset with :not:has so we still support browsers without :has */
-  .rt-BaseMenuContent:not(:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem)) & {
+  :where(.rt-BaseMenuContent:not(:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem))) & {
     padding-left: var(--space-3);
   }
-  .rt-BaseMenuContent:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem) & {
+  :where(.rt-BaseMenuContent:has(.rt-BaseMenuCheckboxItem, .rt-BaseMenuRadioItem)) & {
     padding-left: var(--space-5);
   }
 }
@@ -125,22 +120,22 @@
 
 @breakpoints {
   .rt-BaseMenuContent {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --base-menu-padding: var(--space-1);
       --base-menu-item-height: var(--space-5);
 
-      & .rt-BaseMenuItem {
+      & :where(.rt-BaseMenuItem) {
         font-size: var(--font-size-1);
         line-height: var(--line-height-1);
         letter-spacing: var(--letter-spacing-1);
       }
     }
 
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --base-menu-padding: var(--space-2);
       --base-menu-item-height: var(--space-6);
 
-      & .rt-BaseMenuItem {
+      & :where(.rt-BaseMenuItem) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
         letter-spacing: var(--letter-spacing-2);
@@ -159,19 +154,20 @@
   --base-menu-bg: var(--color-panel-solid);
   box-shadow: var(--shadow-5);
 }
-.rt-BaseMenuItem[data-accent-color] {
+.rt-BaseMenuItem:where([data-accent-color]) {
   color: var(--accent-a11);
 }
-.rt-BaseMenuItem[data-disabled] {
+.rt-BaseMenuItem:where([data-disabled]) {
   color: var(--gray-a8);
 }
 .rt-BaseMenuShortcut {
   color: var(--gray-a11);
 }
-.rt-BaseMenuItem[data-disabled] .rt-BaseMenuShortcut,
-.rt-BaseMenuItem[data-highlighted] .rt-BaseMenuShortcut,
-.rt-BaseMenuSubTrigger[data-state='open'] .rt-BaseMenuShortcut {
-  color: inherit;
+.rt-BaseMenuItem:where([data-disabled], [data-highlighted]),
+.rt-BaseMenuSubTrigger:where([data-state='open']) {
+  & :where(.rt-BaseMenuShortcut) {
+    color: inherit;
+  }
 }
 .rt-BaseMenuLabel {
   color: var(--gray-a11);
@@ -182,29 +178,28 @@
 
 /* solid */
 
-.rt-BaseMenuContent.rt-variant-solid {
-  & .rt-BaseMenuSubTrigger[data-state='open'] {
+.rt-BaseMenuContent:where(.rt-variant-solid) {
+  & :where(.rt-BaseMenuSubTrigger[data-state='open']) {
     background-color: var(--gray-a3);
   }
-  & .rt-BaseMenuSubTriggerIcon {
-    color: var(--gray-12);
-  }
-  & .rt-BaseMenuItem[data-highlighted] {
+  & :where(.rt-BaseMenuItem[data-highlighted]) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
-    & .rt-BaseMenuSubTriggerIcon {
+
+    & :where(.rt-BaseMenuSubTriggerIcon) {
       color: var(--accent-9-contrast);
     }
   }
   &:where(.rt-high-contrast) {
-    & .rt-BaseMenuItem[data-highlighted] {
+    & :where(.rt-BaseMenuItem[data-highlighted]) {
       background-color: var(--accent-12);
       color: var(--accent-1);
-      & .rt-BaseMenuSubTriggerIcon {
+
+      & :where(.rt-BaseMenuSubTriggerIcon) {
         color: var(--accent-1);
       }
 
-      &[data-accent-color] {
+      &:where([data-accent-color]) {
         background-color: var(--accent-9);
         color: var(--accent-9-contrast);
       }
@@ -214,16 +209,14 @@
 
 /* soft */
 
-.rt-BaseMenuContent.rt-variant-soft {
-  & .rt-BaseMenuSubTrigger[data-state='open'] {
+.rt-BaseMenuContent:where(.rt-variant-soft) {
+  & :where(.rt-BaseMenuSubTrigger[data-state='open']) {
     background-color: var(--accent-a3);
   }
-  & .rt-BaseMenuSubTriggerIcon {
-    color: var(--gray-12);
-  }
-  & .rt-BaseMenuItem[data-highlighted] {
+  & :where(.rt-BaseMenuItem[data-highlighted]) {
     background-color: var(--accent-a5);
-    &[data-accent-color] {
+
+    &:where([data-accent-color]) {
       color: var(--accent-12);
     }
   }

--- a/packages/radix-ui-themes/src/components/button.css
+++ b/packages/radix-ui-themes/src/components/button.css
@@ -2,7 +2,8 @@
 
 .rt-Button {
   &:where(:not(.rt-variant-ghost)) {
-    & svg {
+    /* stylelint-disable-next-line */
+    & :where(svg) {
       opacity: 0.9;
     }
   }
@@ -46,7 +47,7 @@
 
 @breakpoints {
   .rt-Button {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       gap: var(--space-1);
       font-size: var(--font-size-1);
       line-height: var(--line-height-1);
@@ -62,7 +63,7 @@
         --button-ghost-padding-y: var(--space-1);
       }
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       gap: var(--space-2);
       font-size: var(--font-size-2);
       line-height: var(--line-height-2);
@@ -78,7 +79,7 @@
         --button-ghost-padding-y: var(--space-1);
       }
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       gap: var(--space-3);
       font-size: var(--font-size-3);
       line-height: var(--line-height-3);
@@ -94,7 +95,7 @@
         --button-ghost-padding-y: calc(var(--space-1) * 1.5);
       }
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       gap: var(--space-3);
       font-size: var(--font-size-4);
       line-height: var(--line-height-4);

--- a/packages/radix-ui-themes/src/components/button.css
+++ b/packages/radix-ui-themes/src/components/button.css
@@ -2,7 +2,7 @@
 
 .rt-Button {
   &:where(:not(.rt-variant-ghost)) {
-    /* stylelint-disable-next-line */
+    /* stylelint-disable-next-line selector-max-type */
     & :where(svg) {
       opacity: 0.9;
     }

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -10,12 +10,7 @@
   align-items: center;
   vertical-align: bottom;
   flex-shrink: 0;
-
   height: var(--line-height);
-
-  & > svg {
-    display: block;
-  }
 }
 
 /***************************************************************************************************
@@ -26,17 +21,17 @@
 
 @breakpoints {
   .rt-CalloutRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       gap: var(--space-2);
       padding: var(--space-3);
       border-radius: var(--radius-3);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       gap: var(--space-3);
       padding: var(--space-4);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       gap: var(--space-4);
       padding: var(--space-5);
       border-radius: var(--radius-5);
@@ -52,19 +47,19 @@
 
 /* soft */
 
-.rt-CalloutRoot.rt-variant-soft {
+.rt-CalloutRoot:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
 }
 
 /* surface */
 
-.rt-CalloutRoot.rt-variant-surface {
+.rt-CalloutRoot:where(.rt-variant-surface) {
   box-shadow: inset 0 0 0 1px var(--accent-a6);
   background-color: var(--accent-a2);
 }
 
 /* outline */
 
-.rt-CalloutRoot.rt-variant-outline {
+.rt-CalloutRoot:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a7);
 }

--- a/packages/radix-ui-themes/src/components/card.css
+++ b/packages/radix-ui-themes/src/components/card.css
@@ -1,3 +1,7 @@
+/* stylelint-disable selector-max-type */
+/* Disable selector-max-type rule to target `button` and `a` tags. */
+/* Make sure these tags are wrapped in `:where()` for 0 specificity. */
+
 .rt-Card {
   --inset-border-radius: var(--card-border-radius);
   --inset-padding: var(--card-padding);
@@ -59,23 +63,23 @@
 
 @breakpoints {
   .rt-Card {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --card-padding: var(--space-3);
       --card-border-radius: var(--radius-4);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --card-padding: var(--space-4);
       --card-border-radius: var(--radius-4);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --card-padding: var(--space-5);
       --card-border-radius: var(--radius-5);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --card-padding: var(--space-6);
       --card-border-radius: var(--radius-5);
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       --card-padding: var(--space-8);
       --card-border-radius: var(--radius-6);
     }
@@ -90,7 +94,7 @@
 
 /* surface */
 
-.rt-Card.rt-variant-surface {
+.rt-Card:where(.rt-variant-surface) {
   --inset-border-width: 1px;
   --card-shadow-border-radius: calc(var(--card-border-radius) - 1px);
   border: 1px solid transparent;
@@ -103,14 +107,15 @@
     /* When possible, use only a half-transparent gray for nicer border blending with inset images in dark mode */
     box-shadow: 0 0 0 1px color-mix(in oklab, var(--gray-a6), var(--gray-6) 25%);
   }
+
   &:where(button, [href]) {
     @media (hover: hover) {
-      &:hover::after {
+      &:where(:hover)::after {
         box-shadow: 0 0 0 1px var(--gray-a8);
         box-shadow: 0 0 0 1px color-mix(in oklab, var(--gray-a8), var(--gray-8) 25%);
       }
     }
-    &:active:not([data-state='open']) {
+    &:where(:active:not([data-state='open'])) {
       &::after {
         box-shadow: 0 0 0 1px var(--gray-a8), 0 0 0 1px var(--gray-a6);
         box-shadow: 0 0 0 1px color-mix(in oklab, var(--gray-a8), var(--gray-8) 25%),
@@ -139,7 +144,7 @@
 }
 /* prettier-ignore */
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --card-classic-box-shadow-hover:
     0 0 0 1px var(--gray-a7),
     0 0 1px 1px var(--gray-a7),
@@ -152,7 +157,7 @@
 /* prettier-ignore */
 @supports (color: color-mix(in oklab, white, black)) {
   :is(.dark, .dark-theme),
-  :is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+  :is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
     --card-classic-box-shadow-hover:
       0 0 0 1px color-mix(in oklab, var(--gray-a7), var(--gray-8)),
       0 0 1px 1px var(--gray-a7),
@@ -163,7 +168,7 @@
   }
 }
 
-.rt-Card.rt-variant-classic {
+.rt-Card:where(.rt-variant-classic) {
   --inset-border-width: 1px;
   --card-shadow-border-radius: calc(var(--card-border-radius) - 1px);
   border: 1px solid transparent;
@@ -200,14 +205,14 @@
 
 /* ghost */
 
-.rt-Card.rt-variant-ghost {
+.rt-Card:where(.rt-variant-ghost) {
   &:where(button, [href]) {
     @media (hover: hover) {
-      &:hover {
+      &:where(:hover) {
         background-color: var(--gray-a3);
       }
     }
-    &:active:not([data-state='open']) {
+    &:where(:active:not([data-state='open'])) {
       background-color: var(--gray-a4);
     }
   }

--- a/packages/radix-ui-themes/src/components/checkbox.css
+++ b/packages/radix-ui-themes/src/components/checkbox.css
@@ -15,6 +15,7 @@
   box-sizing: border-box;
   height: var(--checkbox-size);
   width: var(--checkbox-size);
+
   &:where(:focus-visible) {
     outline: 2px solid var(--accent-a8);
     outline-offset: 2px;
@@ -27,11 +28,11 @@
   justify-content: center;
   height: var(--checkbox-size);
   width: var(--checkbox-size);
+}
 
-  & svg {
-    width: 56.25%;
-    height: 56.25%;
-  }
+.rt-CheckboxIndicatorIcon {
+  width: 56.25%;
+  height: 56.25%;
 }
 
 /***************************************************************************************************
@@ -42,15 +43,15 @@
 
 @breakpoints {
   .rt-CheckboxRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --checkbox-size: var(--space-4);
-      & .rt-CheckboxButton {
+      & :where(.rt-CheckboxButton) {
         border-radius: var(--radius-1);
       }
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --checkbox-size: var(--space-5);
-      & .rt-CheckboxButton {
+      & :where(.rt-CheckboxButton) {
         border-radius: var(--radius-2);
       }
     }
@@ -65,7 +66,7 @@
 
 /* surface */
 
-.rt-CheckboxButton.rt-variant-surface {
+.rt-CheckboxButton:where(.rt-variant-surface) {
   &:where([data-state='unchecked']) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
@@ -89,7 +90,7 @@
 
 /* classic */
 
-.rt-CheckboxButton.rt-variant-classic {
+.rt-CheckboxButton:where(.rt-variant-classic) {
   &:where([data-state='unchecked']) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1);
@@ -113,7 +114,7 @@
 
 /* soft */
 
-.rt-CheckboxButton.rt-variant-soft {
+.rt-CheckboxButton:where(.rt-variant-soft) {
   background-color: var(--accent-a5);
   &:where([data-state='checked']) {
     color: var(--accent-11);

--- a/packages/radix-ui-themes/src/components/checkbox.tsx
+++ b/packages/radix-ui-themes/src/components/checkbox.tsx
@@ -45,7 +45,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>((props, forwar
         })}
       >
         <CheckboxPrimitive.Indicator className="rt-CheckboxIndicator">
-          <ThickCheckIcon />
+          <ThickCheckIcon className="rt-CheckboxIndicatorIcon" />
         </CheckboxPrimitive.Indicator>
       </CheckboxPrimitive.Root>
     </span>

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -19,47 +19,47 @@
 
 @breakpoints {
   .rt-Code {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       font-size: calc(var(--font-size-1) * var(--code-font-size-adjust));
       line-height: var(--line-height-1);
       --letter-spacing: var(--letter-spacing-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       font-size: calc(var(--font-size-2) * var(--code-font-size-adjust));
       line-height: var(--line-height-2);
       --letter-spacing: var(--letter-spacing-2);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       font-size: calc(var(--font-size-3) * var(--code-font-size-adjust));
       line-height: var(--line-height-3);
       --letter-spacing: var(--letter-spacing-3);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       font-size: calc(var(--font-size-4) * var(--code-font-size-adjust));
       line-height: var(--line-height-4);
       --letter-spacing: var(--letter-spacing-4);
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       font-size: calc(var(--font-size-5) * var(--code-font-size-adjust));
       line-height: var(--line-height-5);
       --letter-spacing: var(--letter-spacing-5);
     }
-    &.rt-r-size-6 {
+    &:where(.rt-r-size-6) {
       font-size: calc(var(--font-size-6) * var(--code-font-size-adjust));
       line-height: var(--line-height-6);
       --letter-spacing: var(--letter-spacing-6);
     }
-    &.rt-r-size-7 {
+    &:where(.rt-r-size-7) {
       font-size: calc(var(--font-size-7) * var(--code-font-size-adjust));
       line-height: var(--line-height-7);
       --letter-spacing: var(--letter-spacing-7);
     }
-    &.rt-r-size-8 {
+    &:where(.rt-r-size-8) {
       font-size: calc(var(--font-size-8) * var(--code-font-size-adjust));
       line-height: var(--line-height-8);
       --letter-spacing: var(--letter-spacing-8);
     }
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-9) {
       font-size: calc(var(--font-size-9) * var(--code-font-size-adjust));
       line-height: var(--line-height-9);
       --letter-spacing: var(--letter-spacing-9);
@@ -80,7 +80,7 @@
 
 /* ghost */
 
-.rt-Code.rt-variant-ghost {
+.rt-Code:where(.rt-variant-ghost) {
   color: var(--accent-a11);
 
   &:where(.rt-high-contrast) {
@@ -90,7 +90,7 @@
 
 /* solid */
 
-.rt-Code.rt-variant-solid {
+.rt-Code:where(.rt-variant-solid) {
   background-color: var(--accent-a9);
   color: var(--accent-9-contrast);
 
@@ -102,7 +102,7 @@
 
 /* soft */
 
-.rt-Code.rt-variant-soft {
+.rt-Code:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
   color: var(--accent-a11);
 
@@ -114,7 +114,7 @@
 
 /* outline */
 
-.rt-Code.rt-variant-outline {
+.rt-Code:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
 

--- a/packages/radix-ui-themes/src/components/container.css
+++ b/packages/radix-ui-themes/src/components/container.css
@@ -24,17 +24,17 @@
  ***************************************************************************************************/
 
 @breakpoints {
-  .rt-Container {
-    &.rt-r-size-1 .rt-ContainerInner {
+  .rt-ContainerInner {
+    :where(.rt-Container.rt-r-size-1) & {
       max-width: var(--container-1);
     }
-    &.rt-r-size-2 .rt-ContainerInner {
+    :where(.rt-Container.rt-r-size-2) & {
       max-width: var(--container-2);
     }
-    &.rt-r-size-3 .rt-ContainerInner {
+    :where(.rt-Container.rt-r-size-3) & {
       max-width: var(--container-3);
     }
-    &.rt-r-size-4 .rt-ContainerInner {
+    :where(.rt-Container.rt-r-size-4) & {
       max-width: var(--container-4);
     }
   }

--- a/packages/radix-ui-themes/src/components/dialog.css
+++ b/packages/radix-ui-themes/src/components/dialog.css
@@ -39,19 +39,19 @@
 
 @breakpoints {
   .rt-DialogContent {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --dialog-padding: var(--space-3);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --dialog-padding: var(--space-4);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --dialog-padding: var(--space-5);
       border-radius: var(--radius-5);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --dialog-padding: var(--space-6);
       border-radius: var(--radius-5);
     }
@@ -59,7 +59,7 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  @keyframes DialogOverlayNoop {
+  @keyframes rt-dialog-overlay-no-op {
     from {
       opacity: 1;
     }
@@ -68,25 +68,7 @@
     }
   }
 
-  @keyframes DialogOverlayShow {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes DialogOverlayHide {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 0;
-    }
-  }
-
-  @keyframes DialogContentShow {
+  @keyframes rt-dialog-content-show {
     from {
       opacity: 0;
       transform: translateY(5px) scale(0.97);
@@ -97,7 +79,7 @@
     }
   }
 
-  @keyframes DialogContentHide {
+  @keyframes rt-dialog-content-hide {
     from {
       opacity: 1;
       transform: translateY(0px) scale(1);
@@ -110,24 +92,24 @@
 
   .rt-DialogOverlay {
     /* Keep the overlay mounted until the children have animated */
-    &[data-state='closed'] {
-      animation: DialogOverlayNoop 250ms cubic-bezier(0.16, 1, 0.3, 1);
+    &:where([data-state='closed']) {
+      animation: rt-dialog-overlay-no-op 250ms cubic-bezier(0.16, 1, 0.3, 1);
     }
 
-    &[data-state='open']::after {
-      animation: DialogOverlayShow 400ms cubic-bezier(0.16, 1, 0.3, 1);
+    &:where([data-state='open'])::after {
+      animation: rt-fade-in 400ms cubic-bezier(0.16, 1, 0.3, 1);
     }
-    &[data-state='closed']::after {
-      animation: DialogOverlayHide 250ms cubic-bezier(0.16, 1, 0.3, 1);
+    &:where([data-state='closed'])::after {
+      animation: rt-fade-out 250ms cubic-bezier(0.16, 1, 0.3, 1);
     }
   }
 
   .rt-DialogContent {
-    &[data-state='open'] {
-      animation: DialogContentShow 200ms cubic-bezier(0.16, 1, 0.3, 1);
+    &:where([data-state='open']) {
+      animation: rt-dialog-content-show 200ms cubic-bezier(0.16, 1, 0.3, 1);
     }
-    &[data-state='closed'] {
-      animation: DialogContentHide 150ms cubic-bezier(0.16, 1, 0.3, 1);
+    &:where([data-state='closed']) {
+      animation: rt-dialog-content-hide 150ms cubic-bezier(0.16, 1, 0.3, 1);
     }
   }
 }

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -9,9 +9,8 @@
   &:where([data-accent-color]) {
     color: var(--accent-a11);
 
-    &:where(.rt-high-contrast),
-    & .rt-Text:where(.rt-high-contrast) {
-      color: var(--accent-a12);
+    &:where(.rt-high-contrast) {
+      color: var(--accent-12);
     }
   }
 }
@@ -24,47 +23,47 @@
 
 @breakpoints {
   .rt-Heading {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       font-size: calc(var(--font-size-1) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-1);
       letter-spacing: calc(var(--letter-spacing-1) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       font-size: calc(var(--font-size-2) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-2);
       letter-spacing: calc(var(--letter-spacing-2) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       font-size: calc(var(--font-size-3) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-3);
       letter-spacing: calc(var(--letter-spacing-3) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       font-size: calc(var(--font-size-4) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-4);
       letter-spacing: calc(var(--letter-spacing-4) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       font-size: calc(var(--font-size-5) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-5);
       letter-spacing: calc(var(--letter-spacing-5) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-6 {
+    &:where(.rt-r-size-6) {
       font-size: calc(var(--font-size-6) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-6);
       letter-spacing: calc(var(--letter-spacing-6) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-7 {
+    &:where(.rt-r-size-7) {
       font-size: calc(var(--font-size-7) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-7);
       letter-spacing: calc(var(--letter-spacing-7) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-8 {
+    &:where(.rt-r-size-8) {
       font-size: calc(var(--font-size-8) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-8);
       letter-spacing: calc(var(--letter-spacing-8) + var(--heading-letter-spacing));
     }
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-9) {
       font-size: calc(var(--font-size-9) * var(--heading-font-size-adjust));
       --line-height: var(--heading-line-height-9);
       letter-spacing: calc(var(--letter-spacing-9) + var(--heading-letter-spacing));

--- a/packages/radix-ui-themes/src/components/hover-card.css
+++ b/packages/radix-ui-themes/src/components/hover-card.css
@@ -18,15 +18,15 @@
 
 @breakpoints {
   .rt-HoverCardContent {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --hover-card-padding: var(--space-3);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --hover-card-padding: var(--space-4);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --hover-card-padding: var(--space-5);
       border-radius: var(--radius-5);
     }

--- a/packages/radix-ui-themes/src/components/icon-button.css
+++ b/packages/radix-ui-themes/src/components/icon-button.css
@@ -42,16 +42,16 @@
 
 @breakpoints {
   .rt-IconButton:where(.rt-variant-ghost) {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --icon-button-ghost-padding: var(--space-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --icon-button-ghost-padding: calc(var(--space-1) * 1.5);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --icon-button-ghost-padding: var(--space-2);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --icon-button-ghost-padding: var(--space-3);
     }
   }

--- a/packages/radix-ui-themes/src/components/inset.css
+++ b/packages/radix-ui-themes/src/components/inset.css
@@ -18,16 +18,16 @@
 
 @breakpoints {
   .rt-Inset {
-    &.rt-r-clip-border-box {
+    &:where(.rt-r-clip-border-box) {
       /* prettier-ignore */
       --inset-border-radius-calc: calc(var(--inset-border-radius, 0px) - var(--inset-border-width, 0px));
       --inset-padding-calc: var(--inset-padding, 0px);
     }
-    &.rt-r-clip-padding-box {
+    &:where(.rt-r-clip-padding-box) {
       --inset-border-radius-calc: var(--inset-border-radius, 0px);
       --inset-padding-calc: calc(var(--inset-padding, 0px) + var(--inset-border-width, 0px));
     }
-    &.rt-r-side-top {
+    &:where(.rt-r-side-top) {
       --margin-top-override: calc(var(--margin-top) - var(--inset-padding-calc));
       --margin-left-override: calc(var(--margin-left) - var(--inset-padding-calc));
       --margin-right-override: calc(var(--margin-right) - var(--inset-padding-calc));
@@ -37,7 +37,7 @@
       border-top-left-radius: var(--inset-border-radius-calc);
       border-top-right-radius: var(--inset-border-radius-calc);
     }
-    &.rt-r-side-bottom {
+    &:where(.rt-r-side-bottom) {
       --margin-left-override: calc(var(--margin-left) - var(--inset-padding-calc));
       --margin-right-override: calc(var(--margin-right) - var(--inset-padding-calc));
       --margin-bottom-override: calc(var(--margin-bottom) - var(--inset-padding-calc));
@@ -47,7 +47,7 @@
       border-bottom-left-radius: var(--inset-border-radius-calc);
       border-bottom-right-radius: var(--inset-border-radius-calc);
     }
-    &.rt-r-side-left {
+    &:where(.rt-r-side-left) {
       --margin-top-override: calc(var(--margin-top) - var(--inset-padding-calc));
       --margin-bottom-override: calc(var(--margin-bottom) - var(--inset-padding-calc));
       --margin-left-override: calc(var(--margin-left) - var(--inset-padding-calc));
@@ -57,7 +57,7 @@
       border-top-left-radius: var(--inset-border-radius-calc);
       border-bottom-left-radius: var(--inset-border-radius-calc);
     }
-    &.rt-r-side-right {
+    &:where(.rt-r-side-right) {
       --margin-top-override: calc(var(--margin-top) - var(--inset-padding-calc));
       --margin-bottom-override: calc(var(--margin-bottom) - var(--inset-padding-calc));
       --margin-right-override: calc(var(--margin-right) - var(--inset-padding-calc));
@@ -67,19 +67,19 @@
       border-top-right-radius: var(--inset-border-radius-calc);
       border-bottom-right-radius: var(--inset-border-radius-calc);
     }
-    &.rt-r-side-x {
+    &:where(.rt-r-side-x) {
       --margin-left-override: calc(var(--margin-left) - var(--inset-padding-calc));
       --margin-right-override: calc(var(--margin-right) - var(--inset-padding-calc));
       margin-left: var(--margin-left-override);
       margin-right: var(--margin-right-override);
     }
-    &.rt-r-side-y {
+    &:where(.rt-r-side-y) {
       --margin-top-override: calc(var(--margin-top) - var(--inset-padding-calc));
       --margin-bottom-override: calc(var(--margin-bottom) - var(--inset-padding-calc));
       margin-top: var(--margin-top-override);
       margin-bottom: var(--margin-bottom-override);
     }
-    &.rt-r-side-all {
+    &:where(.rt-r-side-all) {
       --margin-top-override: calc(var(--margin-top) - var(--inset-padding-calc));
       --margin-right-override: calc(var(--margin-right) - var(--inset-padding-calc));
       --margin-bottom-override: calc(var(--margin-bottom) - var(--inset-padding-calc));

--- a/packages/radix-ui-themes/src/components/kbd.css
+++ b/packages/radix-ui-themes/src/components/kbd.css
@@ -9,7 +9,7 @@
     0 0.08em 0.17em var(--gray-a7);
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   /* prettier-ignore */
   --kbd-shadow:
     inset 0 -0.05em 0.5em var(--gray-a3),
@@ -59,39 +59,39 @@
 
 @breakpoints {
   .rt-Kbd {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       font-size: calc(var(--font-size-1) * 0.8);
       --letter-spacing: var(--letter-spacing-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       font-size: calc(var(--font-size-2) * 0.8);
       --letter-spacing: var(--letter-spacing-2);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       font-size: calc(var(--font-size-3) * 0.8);
       --letter-spacing: var(--letter-spacing-3);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       font-size: calc(var(--font-size-4) * 0.8);
       --letter-spacing: var(--letter-spacing-4);
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       font-size: calc(var(--font-size-5) * 0.8);
       --letter-spacing: var(--letter-spacing-5);
     }
-    &.rt-r-size-6 {
+    &:where(.rt-r-size-6) {
       font-size: calc(var(--font-size-6) * 0.8);
       --letter-spacing: var(--letter-spacing-6);
     }
-    &.rt-r-size-7 {
+    &:where(.rt-r-size-7) {
       font-size: calc(var(--font-size-7) * 0.8);
       --letter-spacing: var(--letter-spacing-7);
     }
-    &.rt-r-size-8 {
+    &:where(.rt-r-size-8) {
       font-size: calc(var(--font-size-8) * 0.8);
       --letter-spacing: var(--letter-spacing-8);
     }
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-9) {
       font-size: calc(var(--font-size-9) * 0.8);
       --letter-spacing: var(--letter-spacing-9);
     }

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -3,15 +3,15 @@
   color: var(--accent-a11);
   border-radius: calc(0.07em * var(--radius-factor));
 
-  &:focus-visible {
+  &:where(:focus-visible) {
     outline-color: var(--accent-a8);
     outline-width: 2px;
     outline-style: solid;
     outline-offset: 2px;
   }
 
-  &.rt-high-contrast,
-  .rt-Text:where([data-accent-color]):not(.rt-high-contrast) & {
+  &:where(.rt-high-contrast),
+  :where(.rt-Text, .rt-Heading):where([data-accent-color]:not(.rt-high-contrast)) & {
     color: var(--accent-12);
   }
 }
@@ -24,9 +24,9 @@
 
 @breakpoints {
   .rt-Link {
-    &.rt-r-size-7,
-    &.rt-r-size-8,
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-7),
+    &:where(.rt-r-size-8),
+    &:where(.rt-r-size-9) {
       text-decoration-thickness: 2px;
     }
   }
@@ -54,13 +54,13 @@
 
   &:where(.rt-underline-auto) {
     @media (hover: hover) {
-      &:hover {
+      &:where(:hover) {
         text-decoration-line: underline;
       }
     }
 
-    &.rt-high-contrast,
-    :where(.rt-Text:where([data-accent-color])):not(.rt-high-contrast) & {
+    &:where(.rt-high-contrast),
+    :where(.rt-Text, .rt-Heading):where([data-accent-color]:not(.rt-high-contrast)) & {
       text-decoration-line: underline;
       text-decoration-color: var(--accent-a6);
 
@@ -75,7 +75,7 @@
 
   &:where(.rt-underline-hover) {
     @media (hover: hover) {
-      &:hover {
+      &:where(:hover) {
         text-decoration-line: underline;
       }
     }
@@ -88,6 +88,6 @@
 
 /* all focused states underline */
 
-.rt-Link:focus-visible {
+.rt-Link:where(:focus-visible) {
   text-decoration-line: none;
 }

--- a/packages/radix-ui-themes/src/components/popover.css
+++ b/packages/radix-ui-themes/src/components/popover.css
@@ -20,19 +20,19 @@
 
 @breakpoints {
   .rt-PopoverContent {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --popover-padding: var(--space-3);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --popover-padding: var(--space-4);
       border-radius: var(--radius-4);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --popover-padding: var(--space-5);
       border-radius: var(--radius-5);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --popover-padding: var(--space-6);
       border-radius: var(--radius-5);
     }

--- a/packages/radix-ui-themes/src/components/radio-group.css
+++ b/packages/radix-ui-themes/src/components/radio-group.css
@@ -41,11 +41,11 @@
 
 @breakpoints {
   .rt-RadioGroupRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --radio-group-item-size: var(--space-4);
       --radio-group-indicator-size: calc(6px * var(--scaling));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --radio-group-item-size: var(--space-5);
       --radio-group-indicator-size: calc(10px * var(--scaling));
     }
@@ -60,7 +60,7 @@
 
 /* surface */
 
-.rt-RadioGroupRoot.rt-variant-surface {
+.rt-RadioGroupRoot:where(.rt-variant-surface) {
   :where(.rt-RadioGroupButton[data-state='unchecked']) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
@@ -69,7 +69,7 @@
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
   }
-  &:where(.rt-high-contrast .rt-RadioGroupButton[data-state='checked']) {
+  &:where(.rt-high-contrast) :where(.rt-RadioGroupButton[data-state='checked']) {
     background-color: var(--accent-12);
     color: var(--accent-1);
   }
@@ -83,7 +83,7 @@
 
 /* classic */
 
-.rt-RadioGroupRoot.rt-variant-classic {
+.rt-RadioGroupRoot:where(.rt-variant-classic) {
   :where(.rt-RadioGroupButton[data-state='unchecked']) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a3), var(--shadow-1);
@@ -92,7 +92,7 @@
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
   }
-  &:where(.rt-high-contrast .rt-RadioGroupButton[data-state='checked']) {
+  &:where(.rt-high-contrast) :where(.rt-RadioGroupButton[data-state='checked']) {
     background-color: var(--accent-12);
     color: var(--accent-1);
   }
@@ -106,14 +106,14 @@
 
 /* soft */
 
-.rt-RadioGroupRoot.rt-variant-soft {
+.rt-RadioGroupRoot:where(.rt-variant-soft) {
   :where(.rt-RadioGroupButton) {
     background-color: var(--accent-a5);
   }
   :where(.rt-RadioGroupButton[data-state='checked']) {
     color: var(--accent-11);
   }
-  &:where(.rt-high-contrast .rt-RadioGroupButton[data-state='checked']) {
+  &:where(.rt-high-contrast) :where(.rt-RadioGroupButton[data-state='checked']) {
     color: var(--accent-12);
   }
   & :where(.rt-RadioGroupButton[data-disabled]) {

--- a/packages/radix-ui-themes/src/components/scroll-area.css
+++ b/packages/radix-ui-themes/src/components/scroll-area.css
@@ -1,9 +1,15 @@
-.rt-ScrollAreaRoot {
-  --scrollarea-scrollbar-margin-top: var(--space-1);
-  --scrollarea-scrollbar-margin-bottom: var(--space-1);
-  --scrollarea-scrollbar-margin-left: var(--space-1);
-  --scrollarea-scrollbar-margin-right: var(--space-1);
+.radix-themes {
+  --scrollarea-scrollbar-horizontal-margin-top: var(--space-1);
+  --scrollarea-scrollbar-horizontal-margin-bottom: var(--space-1);
+  --scrollarea-scrollbar-horizontal-margin-left: var(--space-1);
+  --scrollarea-scrollbar-horizontal-margin-right: var(--space-1);
+  --scrollarea-scrollbar-vertical-margin-top: var(--space-1);
+  --scrollarea-scrollbar-vertical-margin-bottom: var(--space-1);
+  --scrollarea-scrollbar-vertical-margin-left: var(--space-1);
+  --scrollarea-scrollbar-vertical-margin-right: var(--space-1);
+}
 
+.rt-ScrollAreaRoot {
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -17,14 +23,14 @@
 
   /* Stop Chrome back/forward two-finger swipe */
   overscroll-behavior-x: contain;
-}
 
-.rt-ScrollAreaViewport:focus-visible + .rt-ScrollAreaViewportFocusRing {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  outline: 2px solid var(--accent-8);
-  outline-offset: -2px;
+  &:where(:focus-visible) + :where(.rt-ScrollAreaViewportFocusRing) {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    outline: 2px solid var(--accent-8);
+    outline-offset: -2px;
+  }
 }
 
 .rt-ScrollAreaScrollbar {
@@ -34,11 +40,11 @@
   /* Disable browser handling of all panning and zooming gestures on touch devices */
   touch-action: none;
 
-  &[data-orientation='vertical'] {
+  &:where([data-orientation='vertical']) {
     flex-direction: column;
     width: var(--scrollarea-scrollbar-size);
   }
-  &[data-orientation='horizontal'] {
+  &:where([data-orientation='horizontal']) {
     flex-direction: row;
     height: var(--scrollarea-scrollbar-size);
   }
@@ -55,8 +61,8 @@
     transform: translate(-50%, -50%);
     width: 100%;
     height: 100%;
-    min-width: 16px;
-    min-height: 16px;
+    min-width: var(--space-4);
+    min-height: var(--space-4);
   }
 }
 
@@ -68,15 +74,15 @@
 
 @breakpoints {
   .rt-ScrollAreaScrollbar {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --scrollarea-scrollbar-size: var(--space-1);
       --scrollarea-scrollbar-radius: max(var(--radius-1), var(--radius-full));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --scrollarea-scrollbar-size: var(--space-2);
       --scrollarea-scrollbar-radius: max(var(--radius-1), var(--radius-full));
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --scrollarea-scrollbar-size: var(--space-3);
       --scrollarea-scrollbar-radius: max(var(--radius-1), var(--radius-full));
     }
@@ -92,19 +98,27 @@
 .rt-ScrollAreaScrollbar {
   background-color: var(--gray-a3);
   border-radius: var(--scrollarea-scrollbar-radius);
-  margin-top: var(--scrollarea-scrollbar-margin-top);
-  margin-bottom: var(--scrollarea-scrollbar-margin-bottom);
-  margin-left: var(--scrollarea-scrollbar-margin-left);
-  margin-right: var(--scrollarea-scrollbar-margin-right);
 
   animation-duration: 150ms;
   animation-timing-function: ease-out;
 
-  &[data-state='visible'] {
-    animation-name: fadeIn;
+  &:where([data-state='visible']) {
+    animation-name: rt-fade-in;
   }
-  &[data-state='hidden'] {
-    animation-name: fadeOut;
+  &:where([data-state='hidden']) {
+    animation-name: rt-fade-out;
+  }
+  &:where([data-orientation='horizontal']) {
+    margin-top: var(--scrollarea-scrollbar-horizontal-margin-top);
+    margin-bottom: var(--scrollarea-scrollbar-horizontal-margin-bottom);
+    margin-left: var(--scrollarea-scrollbar-horizontal-margin-left);
+    margin-right: var(--scrollarea-scrollbar-horizontal-margin-right);
+  }
+  &:where([data-orientation='vertical']) {
+    margin-top: var(--scrollarea-scrollbar-vertical-margin-top);
+    margin-bottom: var(--scrollarea-scrollbar-vertical-margin-bottom);
+    margin-left: var(--scrollarea-scrollbar-vertical-margin-left);
+    margin-right: var(--scrollarea-scrollbar-vertical-margin-right);
   }
 }
 
@@ -114,7 +128,7 @@
   transition: background-color 100ms;
 
   @media (hover: hover) {
-    &:hover {
+    &:where(:hover) {
       background-color: var(--gray-a9);
     }
   }

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -33,7 +33,7 @@
   --select-content-radius: min(var(--select-content-corner-height), max(var(--radius-3), var(--radius-full)));
   --select-content-corner-height: calc(var(--select-item-height) / 2 + var(--select-content-padding));
   --select-content-scrollbar-margin: max(calc(var(--select-content-radius) / 1.5), var(--select-content-padding));
-  --scrollarea-scrollbar-vertical-margin-top: var(--select-content-scroll-barmargin);
+  --scrollarea-scrollbar-vertical-margin-top: var(--select-content-scrollbar-margin);
   --scrollarea-scrollbar-vertical-margin-bottom: var(--select-content-scrollbar-margin);
   --scrollarea-scrollbar-horizontal-margin-left: var(--select-content-scrollbar-margin);
   --scrollarea-scrollbar-horizontal-margin-right: var(--select-content-scrollbar-margin);

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -23,33 +23,29 @@
 .rt-SelectIcon {
   flex-shrink: 0;
 
-  .rt-SelectTrigger:where(:not(.rt-variant-ghost)) & {
+  :where(.rt-SelectTrigger:not(.rt-variant-ghost)) & {
     opacity: 0.9;
   }
 }
 
+/* prettier-ignore */
 .rt-SelectContent {
+  --select-content-radius: min(var(--select-content-corner-height), max(var(--radius-3), var(--radius-full)));
+  --select-content-corner-height: calc(var(--select-item-height) / 2 + var(--select-content-padding));
+  --select-content-scrollbar-margin: max(calc(var(--select-content-radius) / 1.5), var(--select-content-padding));
+  --scrollarea-scrollbar-vertical-margin-top: var(--select-content-scroll-barmargin);
+  --scrollarea-scrollbar-vertical-margin-bottom: var(--select-content-scrollbar-margin);
+  --scrollarea-scrollbar-horizontal-margin-left: var(--select-content-scrollbar-margin);
+  --scrollarea-scrollbar-horizontal-margin-right: var(--select-content-scrollbar-margin);
+
   overflow: hidden;
   background-color: var(--select-content-bg);
-
-  /* prettier-ignore */
-  --select-content-radius:
-    min((var(--select-item-height) / 2 + var(--select-content-padding)),
-    max(var(--radius-3), var(--radius-full)));
   border-radius: var(--select-content-radius);
 
-  &[data-side] {
+  &:where([data-side]) {
     min-width: var(--radix-select-trigger-width);
     max-height: var(--radix-select-content-available-height);
     transform-origin: var(--radix-select-content-transform-origin);
-  }
-  & .rt-ScrollAreaScrollbar {
-    --select-content-scrollbar-margin: max(
-      calc(var(--select-content-radius) / 1.5),
-      var(--select-content-padding)
-    );
-    margin-top: var(--select-content-scrollbar-margin);
-    margin-bottom: var(--select-content-scrollbar-margin);
   }
 }
 
@@ -57,8 +53,8 @@
   box-sizing: border-box;
   padding: var(--select-content-padding);
 
-  .rt-SelectContent:has(.rt-ScrollAreaScrollbar[data-orientation='vertical']) & {
-    padding-right: 12px;
+  :where(.rt-SelectContent:has(.rt-ScrollAreaScrollbar[data-orientation='vertical'])) & {
+    padding-right: var(--space-3);
   }
 }
 
@@ -105,7 +101,7 @@
   user-select: none;
   cursor: default;
 
-  &:not(:first-child) {
+  &:where(:not(:first-child)) {
     margin-top: var(--space-2);
   }
 }
@@ -155,7 +151,7 @@
 
 @breakpoints {
   .rt-SelectTrigger {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --select-trigger-height: var(--space-5);
       gap: var(--space-1);
       font-size: var(--font-size-1);
@@ -172,7 +168,7 @@
         --select-trigger-ghost-padding-y: var(--space-1);
       }
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --select-trigger-height: var(--space-6);
       gap: calc(var(--space-1) * 1.5);
       font-size: var(--font-size-2);
@@ -189,7 +185,7 @@
         --select-trigger-ghost-padding-y: var(--space-1);
       }
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --select-trigger-height: var(--space-7);
       gap: var(--space-2);
       font-size: var(--font-size-3);
@@ -205,7 +201,7 @@
         --select-trigger-ghost-padding-x: var(--space-3);
         --select-trigger-ghost-padding-y: calc(var(--space-1) * 1.5);
       }
-      & .rt-SelectIcon {
+      & :where(.rt-SelectIcon) {
         width: 11px;
         height: 11px;
       }
@@ -221,36 +217,36 @@
 
 @breakpoints {
   .rt-SelectContent {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --select-content-padding: var(--space-1);
       --select-item-height: var(--space-5);
 
-      & .rt-SelectItem {
+      & :where(.rt-SelectItem) {
         font-size: var(--font-size-1);
         line-height: var(--line-height-1);
         letter-spacing: var(--letter-spacing-1);
       }
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --select-content-padding: var(--space-2);
       --select-item-height: var(--space-6);
 
-      & .rt-SelectItem {
+      & :where(.rt-SelectItem) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
         letter-spacing: var(--letter-spacing-2);
       }
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --select-content-padding: var(--space-2);
       --select-item-height: var(--space-7);
 
-      & .rt-SelectLabel {
+      & :where(.rt-SelectLabel) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
         letter-spacing: var(--letter-spacing-2);
       }
-      & .rt-SelectItem {
+      & :where(.rt-SelectItem) {
         font-size: var(--font-size-3);
         line-height: var(--line-height-3);
         letter-spacing: var(--letter-spacing-3);
@@ -264,15 +260,6 @@
  * TRIGGER VARIANTS                                                                                *
  *                                                                                                 *
  ***************************************************************************************************/
-
-.rt-SelectTrigger {
-  &[data-placeholder] {
-    /* target value */
-    & > span > span {
-      color: var(--gray-a10);
-    }
-  }
-}
 
 /* surface */
 
@@ -295,6 +282,11 @@
     background-color: var(--gray-a2);
     box-shadow: inset 0 0 0 1px var(--gray-a6);
   }
+  &:where([data-placeholder]) {
+    & :where(.rt-SelectTriggerInner) {
+      color: var(--gray-a10);
+    }
+  }
 }
 
 /* classic */
@@ -310,7 +302,7 @@
 
 /* prettier-ignore */
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --select-trigger__classic__box-shadow:
     inset 0 0 0 1px var(--white-a4),
     inset 0 1px 1px var(--white-a4),
@@ -366,6 +358,11 @@
         linear-gradient(var(--color-surface), transparent);
     }
   }
+  &:where([data-placeholder]) {
+    & :where(.rt-SelectTriggerInner) {
+      color: var(--gray-a10);
+    }
+  }
 }
 
 /* soft / ghost */
@@ -374,9 +371,8 @@
 .rt-SelectTrigger:where(.rt-variant-ghost) {
   color: var(--accent-12);
 
-  &[data-placeholder] {
-    /* target value */
-    & > span > span {
+  &:where([data-placeholder]) {
+    & :where(.rt-SelectTriggerInner) {
       color: var(--accent-12);
       opacity: 0.6;
     }
@@ -428,7 +424,7 @@
   box-shadow: var(--shadow-5);
 }
 
-.rt-SelectItem[data-disabled] {
+.rt-SelectItem:where([data-disabled]) {
   color: var(--gray-a8);
 }
 
@@ -442,12 +438,12 @@
 
 /* solid */
 
-.rt-SelectContent.rt-variant-solid {
-  & .rt-SelectItem[data-highlighted] {
+.rt-SelectContent:where(.rt-variant-solid) {
+  & :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
   }
-  &:where(.rt-high-contrast) .rt-SelectItem[data-highlighted] {
+  &:where(.rt-high-contrast) :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-12);
     color: var(--accent-1);
   }
@@ -455,8 +451,8 @@
 
 /* soft */
 
-.rt-SelectContent.rt-variant-soft {
-  & .rt-SelectItem[data-highlighted] {
+.rt-SelectContent:where(.rt-variant-soft) {
+  & :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-a5);
   }
 }

--- a/packages/radix-ui-themes/src/components/separator.css
+++ b/packages/radix-ui-themes/src/components/separator.css
@@ -1,11 +1,11 @@
 .rt-Separator {
   background-color: var(--accent-a6);
 
-  &[data-orientation='vertical'] {
+  &:where([data-orientation='vertical']) {
     width: 1px;
     height: var(--separator-size);
   }
-  &[data-orientation='horizontal'] {
+  &:where([data-orientation='horizontal']) {
     width: var(--separator-size);
     height: 1px;
   }
@@ -19,16 +19,16 @@
 
 @breakpoints {
   .rt-Separator {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --separator-size: var(--space-4);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --separator-size: var(--space-6);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --separator-size: var(--space-9);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       --separator-size: 100%;
     }
   }

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -11,10 +11,10 @@
   /* disable browser handling of all panning and zooming gestures on touch devices */
   touch-action: none;
 
-  &[data-orientation='horizontal'] {
+  &:where([data-orientation='horizontal']) {
     height: var(--slider-thumb-size);
   }
-  &[data-orientation='vertical'] {
+  &:where([data-orientation='vertical']) {
     height: 100%;
     flex-direction: column;
     width: var(--slider-thumb-size);
@@ -27,10 +27,10 @@
   border-radius: var(--radius-1);
   overflow: hidden;
 
-  &[data-orientation='horizontal'] {
+  &:where([data-orientation='horizontal']) {
     height: var(--slider-track-size);
   }
-  &[data-orientation='vertical'] {
+  &:where([data-orientation='vertical']) {
     width: var(--slider-track-size);
   }
 }
@@ -39,11 +39,11 @@
   position: absolute;
   border-radius: inherit;
 
-  &[data-orientation='horizontal'] {
+  &:where([data-orientation='horizontal']) {
     height: 100%;
   }
 
-  &[data-orientation='vertical'] {
+  &:where([data-orientation='vertical']) {
     width: 100%;
   }
 }
@@ -88,15 +88,15 @@
 
 @breakpoints {
   .rt-SliderRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --slider-track-size: calc(var(--space-1) * 1.5);
       --slider-thumb-radius: max(var(--radius-1), var(--radius-full));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --slider-track-size: var(--space-2);
       --slider-thumb-radius: max(var(--radius-2), var(--radius-full));
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --slider-track-size: var(--space-3);
       --slider-thumb-radius: max(var(--radius-3), var(--radius-full));
     }
@@ -111,8 +111,8 @@
 
 /* surface */
 
-.rt-SliderRoot.rt-variant-surface {
-  & .rt-SliderTrack {
+.rt-SliderRoot:where(.rt-variant-surface) {
+  & :where(.rt-SliderTrack) {
     background-color: var(--gray-a3);
     box-shadow: inset 0 0 0 1px var(--gray-a5);
 
@@ -121,12 +121,12 @@
     }
   }
 
-  & .rt-SliderRange {
+  & :where(.rt-SliderRange) {
     background-color: var(--accent-9);
     box-shadow: inset 0 0 0 1px var(--gray-a5);
   }
 
-  & .rt-SliderThumb {
+  & :where(.rt-SliderThumb) {
     --slider-thumb-shadow: 0 0 0 1px var(--black-a3);
 
     &:where([data-disabled])::after {
@@ -138,8 +138,8 @@
 
 /* classic */
 
-.rt-SliderRoot.rt-variant-classic {
-  & .rt-SliderTrack {
+.rt-SliderRoot:where(.rt-variant-classic) {
+  & :where(.rt-SliderTrack) {
     background-color: var(--gray-a3);
     position: relative;
 
@@ -155,13 +155,13 @@
     }
   }
 
-  & .rt-SliderRange {
+  & :where(.rt-SliderRange) {
     background-color: var(--accent-9);
     /* range shadow shouldn't change between light and dark mode because of the coloured fill */
     box-shadow: inset 0 0 0 1px var(--gray-a6), inset 0 1.5px 2px 0 var(--black-a2);
   }
 
-  & .rt-SliderThumb {
+  & :where(.rt-SliderThumb) {
     /* prettier-ignore */
     --slider-thumb-shadow:
       0 0 0 1px var(--black-a3),
@@ -177,8 +177,8 @@
 
 /* soft */
 
-.rt-SliderRoot.rt-variant-soft {
-  & .rt-SliderTrack {
+.rt-SliderRoot:where(.rt-variant-soft) {
+  & :where(.rt-SliderTrack) {
     background-color: var(--gray-a3);
 
     /* blend gray with accent */
@@ -190,11 +190,11 @@
     }
   }
 
-  & .rt-SliderRange {
+  & :where(.rt-SliderRange) {
     background-color: var(--accent-a7);
   }
 
-  & .rt-SliderThumb {
+  & :where(.rt-SliderThumb) {
     --slider-thumb-shadow: 0 0 0 1px var(--black-a3), 0 0 0 1px var(--gray-a2),
       0 0 0 1px var(--accent-a2), 0 1px 2px var(--gray-a4), 0 1px 3px -0.5px var(--gray-a3);
 
@@ -215,11 +215,11 @@
   );
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --slider-range-background-image__high-contrast: none;
 }
-.rt-SliderRoot.rt-high-contrast {
-  & .rt-SliderRange {
+.rt-SliderRoot:where(.rt-high-contrast) {
+  & :where(.rt-SliderRange) {
     /* blend black and accent */
     background-image: var(--slider-range-background-image__high-contrast);
   }
@@ -229,17 +229,18 @@
   --slider-blend-mode__disabled: multiply;
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --slider-blend-mode__disabled: screen;
 }
 
 /* all disabled Sliders */
 
-.rt-SliderRoot[data-disabled] {
-  cursor: not-allowed;
-  mix-blend-mode: var(--slider-blend-mode__disabled);
-
-  & .rt-SliderRange[data-disabled] {
+[data-disabled] {
+  .rt-SliderRoot:where(&) {
+    cursor: not-allowed;
+    mix-blend-mode: var(--slider-blend-mode__disabled);
+  }
+  .rt-SliderRange:where(&) {
     background-color: transparent;
     box-shadow: none;
   }

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -6,7 +6,7 @@
 }
 
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --switch-blend-mode__disabled: screen;
   --switch-button-overlay__high-contrast-checked: transparent;
   --switch-button-filter__high-contrast-checked-active: brightness(1.08);
@@ -91,15 +91,15 @@
 
 @breakpoints {
   .rt-SwitchRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --switch-height: var(--space-4);
       --switch-radius: max(var(--radius-2), var(--radius-full));
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --switch-height: var(--space-5);
       --switch-radius: max(var(--radius-3), var(--radius-full));
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --switch-height: var(--space-6);
       --switch-radius: max(var(--radius-4), var(--radius-full));
     }
@@ -119,12 +119,12 @@
 }
 
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --switch-button-filter__surface-checked-active: brightness(1.08);
 }
 
-.rt-SwitchRoot.rt-variant-surface {
-  & .rt-SwitchButton {
+.rt-SwitchRoot:where(.rt-variant-surface) {
+  & :where(.rt-SwitchButton) {
     &::before {
       background-color: var(--gray-a3);
       background-image: linear-gradient(to right, var(--accent-9) 40%, transparent 60%);
@@ -160,7 +160,7 @@
     }
   }
 
-  & .rt-SwitchThumb {
+  & :where(.rt-SwitchThumb) {
     &:where([data-state='unchecked']) {
       box-shadow: 0 0 1px 1px var(--black-a2), 0 1px 1px var(--black-a1),
         0 2px 4px -1px var(--black-a1);
@@ -184,12 +184,12 @@
   --switch-button-filter__surface-checked-active: brightness(0.92) saturate(1.1);
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --switch-button-filter__surface-checked-active: brightness(1.08);
 }
 
-.rt-SwitchRoot.rt-variant-classic {
-  & .rt-SwitchButton {
+.rt-SwitchRoot:where(.rt-variant-classic) {
+  & :where(.rt-SwitchButton) {
     &::before {
       background-image: linear-gradient(to right, var(--accent-9) 40%, transparent 60%);
       background-color: var(--gray-a4);
@@ -231,7 +231,7 @@
     }
   }
 
-  & .rt-SwitchThumb {
+  & :where(.rt-SwitchThumb) {
     &:where([data-state='unchecked']) {
       box-shadow: 0 1px 3px var(--black-a3), 0 2px 4px -1px var(--black-a1),
         0 0 0 1px var(--black-a2);
@@ -255,12 +255,12 @@
   --switch-button-filter__soft-checked-active: contrast(1.2) brightness(0.75) saturate(1.1);
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --switch-button-filter__soft-checked-active: brightness(1.08);
 }
 
-.rt-SwitchRoot.rt-variant-soft {
-  & .rt-SwitchButton {
+.rt-SwitchRoot:where(.rt-variant-soft) {
+  & :where(.rt-SwitchButton) {
     /* prettier-ignore */
     &::before {
       background-image:
@@ -300,7 +300,7 @@
     }
   }
 
-  & .rt-SwitchThumb {
+  & :where(.rt-SwitchThumb) {
     box-shadow: 0 0 0 1px var(--accent-a3), 0 1px 3px var(--accent-a4),
       0 2px 4px -1px var(--accent-a3);
     filter: saturate(0.45);

--- a/packages/radix-ui-themes/src/components/table.css
+++ b/packages/radix-ui-themes/src/components/table.css
@@ -35,6 +35,14 @@
   padding: var(--table-cell-padding);
   /* Works as min-height */
   height: var(--table-cell-min-height);
+
+  /* Inset with Table */
+  .rt-Inset :where(&:first-child) {
+    padding-left: var(--inset-padding, var(--table-cell-padding));
+  }
+  .rt-Inset :where(&:last-child) {
+    padding-right: var(--inset-padding, var(--table-cell-padding));
+  }
 }
 .rt-TableColumnHeaderCell {
   font-weight: bold;
@@ -119,18 +127,4 @@
 .rt-TableRoot:where(.rt-variant-ghost) {
   --scrollarea-scrollbar-horizontal-margin-left: 0;
   --scrollarea-scrollbar-horizontal-margin-right: 0;
-}
-
-/***************************************************************************************************
- *                                                                                                 *
- * Inset > Table                                                                                   *
- *                                                                                                 *
- ***************************************************************************************************/
-
-.rt-Inset > :where(.rt-TableRoot) :where(.rt-TableCell:first-child) {
-  padding-left: var(--inset-padding);
-}
-
-.rt-Inset > :where(.rt-TableRoot) :where(.rt-TableCell:last-child) {
-  padding-right: var(--inset-padding);
 }

--- a/packages/radix-ui-themes/src/components/table.css
+++ b/packages/radix-ui-themes/src/components/table.css
@@ -51,32 +51,32 @@
 
 @breakpoints {
   .rt-TableRoot {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       --table-border-radius: var(--radius-3);
       --table-cell-padding: var(--space-2);
       --table-cell-min-height: calc(36px * var(--scaling));
 
-      & .rt-TableRootTable {
+      & :where(.rt-TableRootTable) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
       }
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       --table-border-radius: var(--radius-4);
       --table-cell-padding: var(--space-3);
       --table-cell-min-height: calc(44px * var(--scaling));
 
-      & .rt-TableRootTable {
+      & :where(.rt-TableRootTable) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
       }
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       --table-border-radius: var(--radius-4);
       --table-cell-padding: var(--space-3) var(--space-4);
-      --table-cell-min-height: calc(48px * var(--scaling));
+      --table-cell-min-height: var(--space-8);
 
-      .rt-TableRootTable {
+      & :where(.rt-TableRootTable) {
         font-size: var(--font-size-3);
         line-height: var(--line-height-3);
       }
@@ -92,7 +92,7 @@
 
 /* surface */
 
-.rt-TableRoot.rt-variant-surface {
+.rt-TableRoot:where(.rt-variant-surface) {
   border: 1px solid var(--gray-a5);
   border-radius: var(--table-border-radius);
   background-color: var(--color-panel);
@@ -102,14 +102,13 @@
   /* When possible, use half-transparent gray for nicer border blending with the background */
   border-color: color-mix(in oklab, var(--gray-a5), var(--gray-6));
 
-  & .rt-TableRootTable {
+  & :where(.rt-TableRootTable) {
     overflow: hidden;
 
     & :where(.rt-TableHeader) {
       --table-row-background: var(--gray-a2);
     }
-
-    & :where(.rt-TableBody .rt-TableRow:last-child) {
+    & :where(.rt-TableBody) :where(.rt-TableRow:last-child) {
       --table-row-border-bottom: none;
     }
   }
@@ -117,11 +116,9 @@
 
 /* ghost */
 
-.rt-TableRoot.rt-variant-ghost {
-  .rt-ScrollAreaScrollbar[data-orientation='horizontal'] {
-    --scrollarea-scrollbar-margin-left: 0;
-    --scrollarea-scrollbar-margin-right: 0;
-  }
+.rt-TableRoot:where(.rt-variant-ghost) {
+  --scrollarea-scrollbar-horizontal-margin-left: 0;
+  --scrollarea-scrollbar-horizontal-margin-right: 0;
 }
 
 /***************************************************************************************************
@@ -130,10 +127,10 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-.rt-Inset > .rt-TableRoot .rt-TableCell:first-child {
+.rt-Inset > :where(.rt-TableRoot) :where(.rt-TableCell:first-child) {
   padding-left: var(--inset-padding);
 }
 
-.rt-Inset > .rt-TableRoot .rt-TableCell:last-child {
+.rt-Inset > :where(.rt-TableRoot) :where(.rt-TableCell:last-child) {
   padding-right: var(--inset-padding);
 }

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -29,7 +29,7 @@
 .rt-TabsTriggerInner {
   position: absolute;
 
-  .rt-TabsTrigger[data-state='active'] & {
+  :where(.rt-TabsTrigger[data-state='active']) & {
     font-weight: var(--font-weight-medium);
     letter-spacing: -0.01em;
   }
@@ -64,7 +64,7 @@
 
 @breakpoints {
   .rt-TabsList {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       height: var(--space-6);
       font-size: var(--font-size-1);
       line-height: var(--line-height-1);
@@ -74,7 +74,7 @@
       --tabs-trigger-inner-padding-y: calc(var(--space-1) * 0.5);
       --tabs-trigger-inner-radius: var(--radius-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       height: var(--space-7);
       font-size: var(--font-size-2);
       line-height: var(--line-height-2);
@@ -101,24 +101,24 @@
   color: var(--gray-a11);
 
   @media (hover: hover) {
-    &:hover {
+    &:where(:hover) {
       color: var(--gray-12);
     }
-    &:hover .rt-TabsTriggerInner {
+    &:where(:hover) :where(.rt-TabsTriggerInner) {
       background-color: var(--gray-a3);
     }
-    &:focus-visible:hover .rt-TabsTriggerInner {
+    &:where(:focus-visible:hover) :where(.rt-TabsTriggerInner) {
       background-color: var(--accent-a3);
     }
   }
-  &[data-state='active'] {
+  &:where([data-state='active']) {
     color: var(--gray-12);
   }
-  &:focus-visible .rt-TabsTriggerInner {
+  &:where(:focus-visible) :where(.rt-TabsTriggerInner) {
     outline: 2px solid var(--accent-8);
     outline-offset: -2px;
   }
-  &[data-state='active']::before {
+  &:where([data-state='active'])::before {
     box-sizing: border-box;
     content: '';
     height: 2px;
@@ -130,6 +130,6 @@
   }
 }
 
-.rt-TabsContent:focus-visible {
+.rt-TabsContent:where(:focus-visible) {
   outline: 2px solid var(--accent-8);
 }

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -50,11 +50,10 @@
   &::-webkit-scrollbar-thumb {
     background-color: var(--gray-a8);
   }
-}
-
-@media (hover: hover) {
-  :where(.rt-TextAreaInput:not(:disabled))::-webkit-scrollbar-thumb:hover {
-    background-color: var(--gray-a9);
+  @media (hover: hover) {
+    :where(&:not(:disabled))::-webkit-scrollbar-thumb:hover {
+      background-color: var(--gray-a9);
+    }
   }
 }
 

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -23,7 +23,7 @@
   flex-grow: 1;
   z-index: 1;
 
-  &:focus {
+  &:where(:focus) {
     outline: 2px solid var(--accent-8);
     outline-offset: -1px;
   }
@@ -35,14 +35,14 @@
     scrollbar-width: thin;
   }
   &::-webkit-scrollbar {
-    width: 12px;
-    height: 12px;
+    width: var(--space-3);
+    height: var(--space-3);
   }
   &::-webkit-scrollbar-track,
   &::-webkit-scrollbar-thumb {
     background-clip: content-box;
-    border: 4px solid transparent;
-    border-radius: 12px;
+    border: var(--space-1) solid transparent;
+    border-radius: var(--space-3);
   }
   &::-webkit-scrollbar-track {
     background-color: var(--gray-a3);
@@ -50,10 +50,11 @@
   &::-webkit-scrollbar-thumb {
     background-color: var(--gray-a8);
   }
-  @media (hover: hover) {
-    &:not(:disabled)::-webkit-scrollbar-thumb:hover {
-      background-color: var(--gray-a9);
-    }
+}
+
+@media (hover: hover) {
+  :where(.rt-TextAreaInput:not(:disabled))::-webkit-scrollbar-thumb:hover {
+    background-color: var(--gray-a9);
   }
 }
 
@@ -75,6 +76,7 @@
     &:where(.rt-r-size-1) {
       min-height: var(--space-8);
       border-radius: var(--radius-2);
+
       & :where(.rt-TextAreaInput) {
         font-size: var(--font-size-1);
         line-height: var(--line-height-1);
@@ -85,6 +87,7 @@
     &:where(.rt-r-size-2) {
       min-height: var(--space-9);
       border-radius: var(--radius-2);
+
       & :where(.rt-TextAreaInput) {
         font-size: var(--font-size-2);
         line-height: var(--line-height-2);
@@ -95,6 +98,7 @@
     &:where(.rt-r-size-3) {
       min-height: 80px;
       border-radius: var(--radius-3);
+
       & :where(.rt-TextAreaInput) {
         font-size: var(--font-size-3);
         line-height: var(--line-height-3);
@@ -117,7 +121,7 @@
     color: var(--gray-12);
     /* Clip text to inner shadow */
     border: 1px solid transparent;
-    & + .rt-TextAreaChrome {
+    & + :where(.rt-TextAreaChrome) {
       padding: 1px;
       background-clip: content-box;
       box-shadow: inset 0 0 0 1px var(--gray-a7);
@@ -130,19 +134,17 @@
       opacity: 1;
     }
 
-    &:autofill,
-    &[data-com-onepassword-filled] {
+    &:where(:autofill, [data-com-onepassword-filled]) {
       /* Reliably removes native autofill colors */
       background-clip: text;
       -webkit-text-fill-color: var(--gray-12);
-      & + .rt-TextAreaChrome {
+      & + :where(.rt-TextAreaChrome) {
         background-color: var(--accent-a4);
       }
     }
 
-    &:disabled,
-    &:read-only {
-      & + .rt-TextAreaChrome {
+    &:where(:disabled, :read-only) {
+      & + :where(.rt-TextAreaChrome) {
         /* Blend with grey */
         background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
       }
@@ -151,11 +153,11 @@
 }
 
 /* classic */
-.rt-TextAreaRoot:where(.rt-variant-classic) .rt-TextAreaInput {
+.rt-TextAreaRoot:where(.rt-variant-classic) :where(.rt-TextAreaInput) {
   color: var(--gray-12);
   /* Clip text to inner shadow */
   border: 1px solid transparent;
-  & + .rt-TextAreaChrome {
+  & + :where(.rt-TextAreaChrome) {
     padding: 1px;
     background-clip: content-box;
     background-color: var(--color-surface);
@@ -168,19 +170,16 @@
     opacity: 1;
   }
 
-  &:autofill,
-  &[data-com-onepassword-filled] {
+  &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--gray-12);
-    & + .rt-TextAreaChrome {
+    & + :where(.rt-TextAreaChrome) {
       background-color: var(--accent-a4);
     }
   }
-
-  &:disabled,
-  &:read-only {
-    & + .rt-TextAreaChrome {
+  &:where(:disabled, :read-only) {
+    & + :where(.rt-TextAreaChrome) {
       /* Blend with grey */
       background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
     }
@@ -188,9 +187,9 @@
 }
 
 /* soft */
-.rt-TextAreaRoot:where(.rt-variant-soft) .rt-TextAreaInput {
+.rt-TextAreaRoot:where(.rt-variant-soft) :where(.rt-TextAreaInput) {
   color: var(--accent-12);
-  & + .rt-TextAreaChrome {
+  & + :where(.rt-TextAreaChrome) {
     background-color: var(--accent-a3);
   }
 
@@ -203,19 +202,16 @@
     opacity: 0.65;
   }
 
-  &:autofill,
-  &[data-com-onepassword-filled] {
+  &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--accent-12);
-    & + .rt-TextAreaChrome {
+    & + :where(.rt-TextAreaChrome) {
       background-color: var(--accent-a5);
     }
   }
-
-  &:disabled,
-  &:read-only {
-    & + .rt-TextAreaChrome {
+  &:where(:disabled, :read-only) {
+    & + :where(.rt-TextAreaChrome) {
       background-color: var(--gray-a4);
     }
   }
@@ -223,19 +219,18 @@
 
 /* all disabled and read-only textareas */
 .rt-TextAreaInput {
-  &:disabled,
-  &:read-only {
+  &:where(:disabled, :read-only) {
     cursor: text;
     color: var(--gray-a11);
     /* Safari */
     -webkit-text-fill-color: var(--gray-a11);
-    &:focus {
+    &:where(:focus) {
       outline: 2px solid var(--gray-8);
     }
     &::placeholder {
       opacity: 0.5;
     }
-    &:placeholder-shown {
+    &:where(:placeholder-shown) {
       cursor: default;
     }
     &::selection {

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -11,20 +11,20 @@
   outline: none;
   font-family: inherit;
   background-color: transparent;
-
   position: relative;
   z-index: 1;
-
-  &:focus + .rt-TextFieldChrome {
-    outline: 2px solid var(--accent-8);
-    outline-offset: -1px;
-  }
 }
+
 .rt-TextFieldChrome {
   position: absolute;
   inset: 0;
   z-index: 0;
   pointer-events: none;
+
+  :where(.rt-TextFieldInput:focus) + & {
+    outline: 2px solid var(--accent-8);
+    outline-offset: -1px;
+  }
 }
 
 .rt-TextFieldSlot {
@@ -32,10 +32,10 @@
   z-index: 1;
   color: var(--gray-a11);
 
-  &[data-accent-color] {
+  &:where([data-accent-color]) {
     color: var(--accent-a11);
   }
-  &:empty {
+  &:where(:empty) {
     display: none;
   }
 }
@@ -60,10 +60,6 @@
   box-sizing: border-box;
   padding: 0;
   width: 100%;
-}
-/* Ensure no padding on input when there's a slot before it */
-.rt-TextFieldRoot .rt-TextFieldSlot + .rt-TextFieldInput {
-  text-indent: 0;
 }
 
 @breakpoints {
@@ -97,7 +93,7 @@
       padding-top: 0.5px;
       padding-bottom: 1px;
 
-      & + .rt-TextFieldChrome {
+      & + :where(.rt-TextFieldChrome) {
         border-radius: max(var(--radius-2), var(--radius-full));
       }
     }
@@ -113,7 +109,7 @@
       padding-top: 0px;
       padding-bottom: 1px;
 
-      & + .rt-TextFieldChrome {
+      & + :where(.rt-TextFieldChrome) {
         border-radius: max(var(--radius-2), var(--radius-full));
       }
     }
@@ -129,10 +125,17 @@
       padding-top: 0.5px;
       padding-bottom: 1px;
 
-      & + .rt-TextFieldChrome {
+      & + :where(.rt-TextFieldChrome) {
         border-radius: max(var(--radius-3), var(--radius-full));
       }
     }
+  }
+}
+
+/* Ensure no padding on input when there's a slot before it */
+.rt-TextFieldInput {
+  :where(.rt-TextFieldSlot) + & {
+    text-indent: 0;
   }
 }
 
@@ -150,11 +153,11 @@
   /* Don't overlap text with the inset shadow */
   padding-left: 1px;
   padding-right: 1px;
-  .rt-TextFieldSlot + & {
+  :where(.rt-TextFieldSlot) + & {
     padding-left: 0;
   }
 
-  & + .rt-TextFieldChrome {
+  & + :where(.rt-TextFieldChrome) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
 
@@ -167,20 +170,18 @@
     /* Firefox */
     opacity: 1;
   }
-  &:autofill,
-  &[data-com-onepassword-filled] {
+  &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--gray-12);
 
-    & + .rt-TextFieldChrome {
+    & + :where(.rt-TextFieldChrome) {
       background-color: var(--accent-a4);
       box-shadow: inset 0 0 0 1px var(--gray-a7), inset 0 0 0 1px var(--accent-a4);
     }
   }
-  &:disabled,
-  &:read-only {
-    & + .rt-TextFieldChrome {
+  &:where(:disabled, :read-only) {
+    & + :where(.rt-TextFieldChrome) {
       /* Blend with grey */
       background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
     }
@@ -195,11 +196,11 @@
   /* Don't overlap text with inset shadow */
   padding-left: 1px;
   padding-right: 1px;
-  .rt-TextFieldSlot + & {
+  :where(.rt-TextFieldSlot) + & {
     padding-left: 0;
   }
 
-  & + .rt-TextFieldChrome {
+  & + :where(.rt-TextFieldChrome) {
     background-color: var(--color-surface);
     box-shadow: var(--shadow-1);
 
@@ -212,20 +213,18 @@
     /* Firefox */
     opacity: 1;
   }
-  &:autofill,
-  &[data-com-onepassword-filled] {
+  &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--gray-12);
 
-    & + .rt-TextFieldChrome {
+    & + :where(.rt-TextFieldChrome) {
       background-color: var(--accent-a4);
       box-shadow: var(--shadow-1), inset 0 0 0 1px var(--accent-a4);
     }
   }
-  &:disabled,
-  &:read-only {
-    & + .rt-TextFieldChrome {
+  &:where(:disabled, :read-only) {
+    & + :where(.rt-TextFieldChrome) {
       /* Blend with grey */
       background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
     }
@@ -236,26 +235,24 @@
 .rt-TextFieldInput:where(.rt-variant-soft) {
   color: var(--accent-12);
 
-  & + .rt-TextFieldChrome {
+  & + :where(.rt-TextFieldChrome) {
     background-color: var(--accent-a3);
   }
   &::placeholder {
     color: var(--accent-12);
     opacity: 0.6;
   }
-  &:autofill,
-  &[data-com-onepassword-filled] {
+  &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--accent-12);
 
-    & + .rt-TextFieldChrome {
+    & + :where(.rt-TextFieldChrome) {
       background-color: var(--accent-a5);
     }
   }
-  &:disabled,
-  &:read-only {
-    & + .rt-TextFieldChrome {
+  &:where(:disabled, :read-only) {
+    & + :where(.rt-TextFieldChrome) {
       background-color: var(--gray-a4);
     }
   }
@@ -267,20 +264,19 @@
 /* all disabled and read-only text fields */
 
 .rt-TextFieldInput {
-  &:disabled,
-  &:read-only {
+  &:where(:disabled, :read-only) {
     cursor: text;
     color: var(--gray-a11);
     /* Safari */
     -webkit-text-fill-color: var(--gray-a11);
 
-    &:focus + .rt-TextFieldChrome {
+    &:where(:focus) + :where(.rt-TextFieldChrome) {
       outline: 2px solid var(--gray-8);
     }
     &::placeholder {
       opacity: 0.5;
     }
-    &:placeholder-shown {
+    &:where(:placeholder-shown) {
       cursor: default;
     }
     &::selection {
@@ -288,10 +284,10 @@
     }
 
     /* Cursor in gaps around slots, as an enhancement */
-    .rt-TextFieldRoot:has(&) {
+    .rt-TextFieldRoot:where(:has(&)) {
       cursor: text;
     }
-    .rt-TextFieldRoot:has(&:placeholder-shown) {
+    .rt-TextFieldRoot:where(:has(&:placeholder-shown)) {
       cursor: default;
     }
   }

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -2,14 +2,15 @@
   margin: 0;
   line-height: var(--line-height, var(--default-line-height));
   letter-spacing: var(--letter-spacing, inherit);
+}
 
-  &:where([data-accent-color]) {
+:where([data-accent-color]) {
+  &.rt-Text {
     color: var(--accent-a11);
-
-    &:where(.rt-high-contrast),
-    & .rt-Text:where(.rt-high-contrast) {
-      color: var(--accent-a12);
-    }
+  }
+  &.rt-Text:where(.rt-high-contrast),
+  &:where(.rt-Text, .rt-Heading) .rt-Text:where(.rt-high-contrast) {
+    color: var(--accent-12);
   }
 }
 
@@ -21,47 +22,47 @@
 
 @breakpoints {
   .rt-Text {
-    &.rt-r-size-1 {
+    &:where(.rt-r-size-1) {
       font-size: var(--font-size-1);
       --line-height: var(--line-height-1);
       --letter-spacing: var(--letter-spacing-1);
     }
-    &.rt-r-size-2 {
+    &:where(.rt-r-size-2) {
       font-size: var(--font-size-2);
       --line-height: var(--line-height-2);
       --letter-spacing: var(--letter-spacing-2);
     }
-    &.rt-r-size-3 {
+    &:where(.rt-r-size-3) {
       font-size: var(--font-size-3);
       --line-height: var(--line-height-3);
       --letter-spacing: var(--letter-spacing-3);
     }
-    &.rt-r-size-4 {
+    &:where(.rt-r-size-4) {
       font-size: var(--font-size-4);
       --line-height: var(--line-height-4);
       --letter-spacing: var(--letter-spacing-4);
     }
-    &.rt-r-size-5 {
+    &:where(.rt-r-size-5) {
       font-size: var(--font-size-5);
       --line-height: var(--line-height-5);
       --letter-spacing: var(--letter-spacing-5);
     }
-    &.rt-r-size-6 {
+    &:where(.rt-r-size-6) {
       font-size: var(--font-size-6);
       --line-height: var(--line-height-6);
       --letter-spacing: var(--letter-spacing-6);
     }
-    &.rt-r-size-7 {
+    &:where(.rt-r-size-7) {
       font-size: var(--font-size-7);
       --line-height: var(--line-height-7);
       --letter-spacing: var(--letter-spacing-7);
     }
-    &.rt-r-size-8 {
+    &:where(.rt-r-size-8) {
       font-size: var(--font-size-8);
       --line-height: var(--line-height-8);
       --letter-spacing: var(--letter-spacing-8);
     }
-    &.rt-r-size-9 {
+    &:where(.rt-r-size-9) {
       font-size: var(--font-size-9);
       --line-height: var(--line-height-9);
       --letter-spacing: var(--letter-spacing-9);

--- a/packages/radix-ui-themes/src/components/tooltip.css
+++ b/packages/radix-ui-themes/src/components/tooltip.css
@@ -9,18 +9,20 @@
   animation-duration: 200ms;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 
-  &[data-state='delayed-open'] {
-    &[data-side='top'] {
-      animation-name: slideUpAndFadeIn;
-    }
-    &[data-side='bottom'] {
-      animation-name: slideDownAndFadeIn;
-    }
-    &[data-side='left'] {
-      animation-name: slideLeftAndFadeIn;
-    }
-    &[data-side='right'] {
-      animation-name: slideRightAndFadeIn;
+  @media (prefers-reduced-motion: no-preference) {
+    &:where([data-state='delayed-open']) {
+      &:where([data-side='top']) {
+        animation-name: rt-slide-up, rt-fade-in;
+      }
+      &:where([data-side='bottom']) {
+        animation-name: rt-slide-down, rt-fade-in;
+      }
+      &:where([data-side='left']) {
+        animation-name: rt-slide-left, rt-fade-in;
+      }
+      &:where([data-side='right']) {
+        animation-name: rt-slide-right, rt-fade-in;
+      }
     }
   }
 }
@@ -41,11 +43,11 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-.rt-TooltipContent.rt-multiline {
+.rt-TooltipContent:where(.rt-multiline) {
   max-width: 250px;
   border-radius: var(--radius-2);
 
-  & .rt-TooltipText {
+  & :where(.rt-TooltipText) {
     line-height: var(--default-line-height);
   }
 }

--- a/packages/radix-ui-themes/src/styles/animations.css
+++ b/packages/radix-ui-themes/src/styles/animations.css
@@ -1,144 +1,93 @@
+@keyframes rt-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes rt-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes rt-slide-up {
+  from {
+    transform: translateY(4px) scale(0.97);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes rt-slide-down {
+  from {
+    transform: translateY(-4px) scale(0.97);
+  }
+  to {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes rt-slide-left {
+  from {
+    transform: translateX(4px) scale(0.97);
+  }
+  to {
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes rt-slide-right {
+  from {
+    transform: translateX(-4px) scale(0.97);
+  }
+  to {
+    transform: translateX(0) scale(1);
+  }
+}
+
 @media (prefers-reduced-motion: no-preference) {
-  @keyframes slideUpAndFadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(4px) scale(0.97);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-
-  @keyframes slideUpAndFadeOut {
-    from {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-    to {
-      opacity: 0;
-      transform: translateY(-4px) scale(0.97);
-    }
-  }
-
-  @keyframes slideDownAndFadeIn {
-    from {
-      opacity: 0;
-      transform: translateY(-4px) scale(0.97);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-  }
-
-  @keyframes slideDownAndFadeOut {
-    from {
-      opacity: 1;
-      transform: translateY(0) scale(1);
-    }
-    to {
-      opacity: 0;
-      transform: translateY(4px) scale(0.97);
-    }
-  }
-
-  @keyframes slideLeftAndFadeIn {
-    from {
-      opacity: 0;
-      transform: translateX(4px) scale(0.97);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-  }
-
-  @keyframes slideLeftAndFadeOut {
-    from {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-    to {
-      opacity: 0;
-      transform: translateX(-4px) scale(0.97);
-    }
-  }
-
-  @keyframes slideRightAndFadeIn {
-    from {
-      opacity: 0;
-      transform: translateX(-4px) scale(0.97);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-  }
-
-  @keyframes slideRightAndFadeOut {
-    from {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-    to {
-      opacity: 0;
-      transform: translateX(4px) scale(0.97);
-    }
-  }
-
   .rt-PopperContent {
-    animation-duration: 300ms;
     animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 
-    &[data-state='open'] {
-      &[data-side='top'] {
-        animation-name: slideUpAndFadeIn;
+    &:where([data-state='open']) {
+      animation-duration: 300ms;
+
+      &:where([data-side='top']) {
+        animation-name: rt-slide-up, rt-fade-in;
       }
-      &[data-side='bottom'] {
-        animation-name: slideDownAndFadeIn;
+      &:where([data-side='bottom']) {
+        animation-name: rt-slide-down, rt-fade-in;
       }
-      &[data-side='left'] {
-        animation-name: slideLeftAndFadeIn;
+      &:where([data-side='left']) {
+        animation-name: rt-slide-left, rt-fade-in;
       }
-      &[data-side='right'] {
-        animation-name: slideRightAndFadeIn;
+      &:where([data-side='right']) {
+        animation-name: rt-slide-right, rt-fade-in;
       }
     }
 
-    &[data-state='closed'] {
+    &:where([data-state='closed']) {
       animation-duration: 150ms;
 
-      &[data-side='top'] {
-        animation-name: slideDownAndFadeOut;
+      &:where([data-side='top']) {
+        animation-name: rt-slide-down, rt-fade-out;
       }
-      &[data-side='bottom'] {
-        animation-name: slideUpAndFadeOut;
+      &:where([data-side='bottom']) {
+        animation-name: rt-slide-up, rt-fade-out;
       }
-      &[data-side='left'] {
-        animation-name: slideRightAndFadeOut;
+      &:where([data-side='left']) {
+        animation-name: rt-slide-right, rt-fade-out;
       }
-      &[data-side='right'] {
-        animation-name: slideRightAndFadeOut;
+      &:where([data-side='right']) {
+        animation-name: rt-slide-right, rt-fade-out;
       }
-    }
-  }
-
-  @keyframes fadeIn {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
-
-  @keyframes fadeOut {
-    from {
-      opacity: 1;
-    }
-    to {
-      opacity: 0;
     }
   }
 }

--- a/packages/radix-ui-themes/src/styles/reset.css
+++ b/packages/radix-ui-themes/src/styles/reset.css
@@ -1,4 +1,4 @@
-.radix-themes[data-is-root-theme='true'] {
+.radix-themes:where([data-is-root-theme='true']) {
   /* create new stacking context on the root `Theme` so layered components work out of the box */
   position: relative;
   z-index: 0;

--- a/packages/radix-ui-themes/src/styles/reset.css
+++ b/packages/radix-ui-themes/src/styles/reset.css
@@ -1,3 +1,7 @@
+/* stylelint-disable selector-max-type */
+/* Disable selector-max-type rule to target individual element types. */
+/* Make sure these tags are wrapped in `:where()` for 0 specificity. */
+
 .radix-themes:where([data-is-root-theme='true']) {
   /* create new stacking context on the root `Theme` so layered components work out of the box */
   position: relative;

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -342,6 +342,7 @@
   --accent-a11: var(--tomato-a11);
   --accent-a12: var(--tomato-a12);
 }
+
 [data-accent-color='red'] {
   --color-surface-accent: var(--red-surface);
 
@@ -372,6 +373,7 @@
   --accent-a11: var(--red-a11);
   --accent-a12: var(--red-a12);
 }
+
 [data-accent-color='ruby'] {
   --color-surface-accent: var(--ruby-surface);
 
@@ -402,6 +404,7 @@
   --accent-a11: var(--ruby-a11);
   --accent-a12: var(--ruby-a12);
 }
+
 [data-accent-color='crimson'] {
   --color-surface-accent: var(--crimson-surface);
 
@@ -432,6 +435,7 @@
   --accent-a11: var(--crimson-a11);
   --accent-a12: var(--crimson-a12);
 }
+
 [data-accent-color='pink'] {
   --color-surface-accent: var(--pink-surface);
 
@@ -462,6 +466,7 @@
   --accent-a11: var(--pink-a11);
   --accent-a12: var(--pink-a12);
 }
+
 [data-accent-color='plum'] {
   --color-surface-accent: var(--plum-surface);
 
@@ -492,6 +497,7 @@
   --accent-a11: var(--plum-a11);
   --accent-a12: var(--plum-a12);
 }
+
 [data-accent-color='purple'] {
   --color-surface-accent: var(--purple-surface);
 
@@ -522,6 +528,7 @@
   --accent-a11: var(--purple-a11);
   --accent-a12: var(--purple-a12);
 }
+
 [data-accent-color='violet'] {
   --color-surface-accent: var(--violet-surface);
 
@@ -552,6 +559,7 @@
   --accent-a11: var(--violet-a11);
   --accent-a12: var(--violet-a12);
 }
+
 [data-accent-color='iris'] {
   --color-surface-accent: var(--iris-surface);
 
@@ -582,6 +590,7 @@
   --accent-a11: var(--iris-a11);
   --accent-a12: var(--iris-a12);
 }
+
 [data-accent-color='indigo'] {
   --color-surface-accent: var(--indigo-surface);
 
@@ -612,6 +621,7 @@
   --accent-a11: var(--indigo-a11);
   --accent-a12: var(--indigo-a12);
 }
+
 [data-accent-color='blue'] {
   --color-surface-accent: var(--blue-surface);
 
@@ -642,6 +652,7 @@
   --accent-a11: var(--blue-a11);
   --accent-a12: var(--blue-a12);
 }
+
 [data-accent-color='cyan'] {
   --color-surface-accent: var(--cyan-surface);
 
@@ -672,6 +683,7 @@
   --accent-a11: var(--cyan-a11);
   --accent-a12: var(--cyan-a12);
 }
+
 [data-accent-color='teal'] {
   --color-surface-accent: var(--teal-surface);
 
@@ -702,6 +714,7 @@
   --accent-a11: var(--teal-a11);
   --accent-a12: var(--teal-a12);
 }
+
 [data-accent-color='jade'] {
   --color-surface-accent: var(--jade-surface);
 
@@ -732,6 +745,7 @@
   --accent-a11: var(--jade-a11);
   --accent-a12: var(--jade-a12);
 }
+
 [data-accent-color='green'] {
   --color-surface-accent: var(--green-surface);
 
@@ -762,6 +776,7 @@
   --accent-a11: var(--green-a11);
   --accent-a12: var(--green-a12);
 }
+
 [data-accent-color='grass'] {
   --color-surface-accent: var(--grass-surface);
 
@@ -792,6 +807,7 @@
   --accent-a11: var(--grass-a11);
   --accent-a12: var(--grass-a12);
 }
+
 [data-accent-color='orange'] {
   --color-surface-accent: var(--orange-surface);
 
@@ -822,6 +838,7 @@
   --accent-a11: var(--orange-a11);
   --accent-a12: var(--orange-a12);
 }
+
 [data-accent-color='brown'] {
   --color-surface-accent: var(--brown-surface);
 
@@ -852,6 +869,7 @@
   --accent-a11: var(--brown-a11);
   --accent-a12: var(--brown-a12);
 }
+
 [data-accent-color='sky'] {
   --color-surface-accent: var(--sky-surface);
 
@@ -882,6 +900,7 @@
   --accent-a11: var(--sky-a11);
   --accent-a12: var(--sky-a12);
 }
+
 [data-accent-color='mint'] {
   --color-surface-accent: var(--mint-surface);
 
@@ -912,6 +931,7 @@
   --accent-a11: var(--mint-a11);
   --accent-a12: var(--mint-a12);
 }
+
 [data-accent-color='lime'] {
   --color-surface-accent: var(--lime-surface);
 
@@ -942,6 +962,7 @@
   --accent-a11: var(--lime-a11);
   --accent-a12: var(--lime-a12);
 }
+
 [data-accent-color='yellow'] {
   --color-surface-accent: var(--yellow-surface);
 
@@ -972,6 +993,7 @@
   --accent-a11: var(--yellow-a11);
   --accent-a12: var(--yellow-a12);
 }
+
 [data-accent-color='amber'] {
   --color-surface-accent: var(--amber-surface);
 
@@ -1002,6 +1024,7 @@
   --accent-a11: var(--amber-a11);
   --accent-a12: var(--amber-a12);
 }
+
 [data-accent-color='gold'] {
   --color-surface-accent: var(--gold-surface);
 
@@ -1032,6 +1055,7 @@
   --accent-a11: var(--gold-a11);
   --accent-a12: var(--gold-a12);
 }
+
 [data-accent-color='bronze'] {
   --color-surface-accent: var(--bronze-surface);
 
@@ -1063,150 +1087,6 @@
   --accent-a12: var(--bronze-a12);
 }
 
-/* gray color */
-
-[data-gray-color='mauve'] {
-  --gray-1: var(--mauve-1);
-  --gray-2: var(--mauve-2);
-  --gray-2-translucent: var(--mauve-2-translucent);
-  --gray-3: var(--mauve-3);
-  --gray-4: var(--mauve-4);
-  --gray-5: var(--mauve-5);
-  --gray-6: var(--mauve-6);
-  --gray-7: var(--mauve-7);
-  --gray-8: var(--mauve-8);
-  --gray-9: var(--mauve-9);
-  --gray-10: var(--mauve-10);
-  --gray-11: var(--mauve-11);
-  --gray-12: var(--mauve-12);
-
-  --gray-a1: var(--mauve-a1);
-  --gray-a2: var(--mauve-a2);
-  --gray-a3: var(--mauve-a3);
-  --gray-a4: var(--mauve-a4);
-  --gray-a5: var(--mauve-a5);
-  --gray-a6: var(--mauve-a6);
-  --gray-a7: var(--mauve-a7);
-  --gray-a8: var(--mauve-a8);
-  --gray-a9: var(--mauve-a9);
-  --gray-a10: var(--mauve-a10);
-  --gray-a11: var(--mauve-a11);
-  --gray-a12: var(--mauve-a12);
-}
-[data-gray-color='slate'] {
-  --gray-1: var(--slate-1);
-  --gray-2: var(--slate-2);
-  --gray-2-translucent: var(--slate-2-translucent);
-  --gray-3: var(--slate-3);
-  --gray-4: var(--slate-4);
-  --gray-5: var(--slate-5);
-  --gray-6: var(--slate-6);
-  --gray-7: var(--slate-7);
-  --gray-8: var(--slate-8);
-  --gray-9: var(--slate-9);
-  --gray-10: var(--slate-10);
-  --gray-11: var(--slate-11);
-  --gray-12: var(--slate-12);
-
-  --gray-a1: var(--slate-a1);
-  --gray-a2: var(--slate-a2);
-  --gray-a3: var(--slate-a3);
-  --gray-a4: var(--slate-a4);
-  --gray-a5: var(--slate-a5);
-  --gray-a6: var(--slate-a6);
-  --gray-a7: var(--slate-a7);
-  --gray-a8: var(--slate-a8);
-  --gray-a9: var(--slate-a9);
-  --gray-a10: var(--slate-a10);
-  --gray-a11: var(--slate-a11);
-  --gray-a12: var(--slate-a12);
-}
-[data-gray-color='sage'] {
-  --gray-1: var(--sage-1);
-  --gray-2: var(--sage-2);
-  --gray-2-translucent: var(--sage-2-translucent);
-  --gray-3: var(--sage-3);
-  --gray-4: var(--sage-4);
-  --gray-5: var(--sage-5);
-  --gray-6: var(--sage-6);
-  --gray-7: var(--sage-7);
-  --gray-8: var(--sage-8);
-  --gray-9: var(--sage-9);
-  --gray-10: var(--sage-10);
-  --gray-11: var(--sage-11);
-  --gray-12: var(--sage-12);
-
-  --gray-a1: var(--sage-a1);
-  --gray-a2: var(--sage-a2);
-  --gray-a3: var(--sage-a3);
-  --gray-a4: var(--sage-a4);
-  --gray-a5: var(--sage-a5);
-  --gray-a6: var(--sage-a6);
-  --gray-a7: var(--sage-a7);
-  --gray-a8: var(--sage-a8);
-  --gray-a9: var(--sage-a9);
-  --gray-a10: var(--sage-a10);
-  --gray-a11: var(--sage-a11);
-  --gray-a12: var(--sage-a12);
-}
-[data-gray-color='olive'] {
-  --gray-1: var(--olive-1);
-  --gray-2: var(--olive-2);
-  --gray-2-translucent: var(--olive-2-translucent);
-  --gray-3: var(--olive-3);
-  --gray-4: var(--olive-4);
-  --gray-5: var(--olive-5);
-  --gray-6: var(--olive-6);
-  --gray-7: var(--olive-7);
-  --gray-8: var(--olive-8);
-  --gray-9: var(--olive-9);
-  --gray-10: var(--olive-10);
-  --gray-11: var(--olive-11);
-  --gray-12: var(--olive-12);
-
-  --gray-a1: var(--olive-a1);
-  --gray-a2: var(--olive-a2);
-  --gray-a3: var(--olive-a3);
-  --gray-a4: var(--olive-a4);
-  --gray-a5: var(--olive-a5);
-  --gray-a6: var(--olive-a6);
-  --gray-a7: var(--olive-a7);
-  --gray-a8: var(--olive-a8);
-  --gray-a9: var(--olive-a9);
-  --gray-a10: var(--olive-a10);
-  --gray-a11: var(--olive-a11);
-  --gray-a12: var(--olive-a12);
-}
-[data-gray-color='sand'] {
-  --gray-1: var(--sand-1);
-  --gray-2: var(--sand-2);
-  --gray-2-translucent: var(--sand-2-translucent);
-  --gray-3: var(--sand-3);
-  --gray-4: var(--sand-4);
-  --gray-5: var(--sand-5);
-  --gray-6: var(--sand-6);
-  --gray-7: var(--sand-7);
-  --gray-8: var(--sand-8);
-  --gray-9: var(--sand-9);
-  --gray-10: var(--sand-10);
-  --gray-11: var(--sand-11);
-  --gray-12: var(--sand-12);
-
-  --gray-a1: var(--sand-a1);
-  --gray-a2: var(--sand-a2);
-  --gray-a3: var(--sand-a3);
-  --gray-a4: var(--sand-a4);
-  --gray-a5: var(--sand-a5);
-  --gray-a6: var(--sand-a6);
-  --gray-a7: var(--sand-a7);
-  --gray-a8: var(--sand-a8);
-  --gray-a9: var(--sand-a9);
-  --gray-a10: var(--sand-a10);
-  --gray-a11: var(--sand-a11);
-  --gray-a12: var(--sand-a12);
-}
-
-/* gray accent color */
 [data-accent-color='gray'] {
   --color-surface-accent: var(--gray-surface);
 
@@ -1236,6 +1116,150 @@
   --accent-a10: var(--gray-a10);
   --accent-a11: var(--gray-a11);
   --accent-a12: var(--gray-a12);
+}
+
+/* gray color overrides */
+.radix-themes {
+  &:where([data-gray-color='mauve']) {
+    --gray-1: var(--mauve-1);
+    --gray-2: var(--mauve-2);
+    --gray-2-translucent: var(--mauve-2-translucent);
+    --gray-3: var(--mauve-3);
+    --gray-4: var(--mauve-4);
+    --gray-5: var(--mauve-5);
+    --gray-6: var(--mauve-6);
+    --gray-7: var(--mauve-7);
+    --gray-8: var(--mauve-8);
+    --gray-9: var(--mauve-9);
+    --gray-10: var(--mauve-10);
+    --gray-11: var(--mauve-11);
+    --gray-12: var(--mauve-12);
+
+    --gray-a1: var(--mauve-a1);
+    --gray-a2: var(--mauve-a2);
+    --gray-a3: var(--mauve-a3);
+    --gray-a4: var(--mauve-a4);
+    --gray-a5: var(--mauve-a5);
+    --gray-a6: var(--mauve-a6);
+    --gray-a7: var(--mauve-a7);
+    --gray-a8: var(--mauve-a8);
+    --gray-a9: var(--mauve-a9);
+    --gray-a10: var(--mauve-a10);
+    --gray-a11: var(--mauve-a11);
+    --gray-a12: var(--mauve-a12);
+  }
+  &:where([data-gray-color='slate']) {
+    --gray-1: var(--slate-1);
+    --gray-2: var(--slate-2);
+    --gray-2-translucent: var(--slate-2-translucent);
+    --gray-3: var(--slate-3);
+    --gray-4: var(--slate-4);
+    --gray-5: var(--slate-5);
+    --gray-6: var(--slate-6);
+    --gray-7: var(--slate-7);
+    --gray-8: var(--slate-8);
+    --gray-9: var(--slate-9);
+    --gray-10: var(--slate-10);
+    --gray-11: var(--slate-11);
+    --gray-12: var(--slate-12);
+
+    --gray-a1: var(--slate-a1);
+    --gray-a2: var(--slate-a2);
+    --gray-a3: var(--slate-a3);
+    --gray-a4: var(--slate-a4);
+    --gray-a5: var(--slate-a5);
+    --gray-a6: var(--slate-a6);
+    --gray-a7: var(--slate-a7);
+    --gray-a8: var(--slate-a8);
+    --gray-a9: var(--slate-a9);
+    --gray-a10: var(--slate-a10);
+    --gray-a11: var(--slate-a11);
+    --gray-a12: var(--slate-a12);
+  }
+  &:where([data-gray-color='sage']) {
+    --gray-1: var(--sage-1);
+    --gray-2: var(--sage-2);
+    --gray-2-translucent: var(--sage-2-translucent);
+    --gray-3: var(--sage-3);
+    --gray-4: var(--sage-4);
+    --gray-5: var(--sage-5);
+    --gray-6: var(--sage-6);
+    --gray-7: var(--sage-7);
+    --gray-8: var(--sage-8);
+    --gray-9: var(--sage-9);
+    --gray-10: var(--sage-10);
+    --gray-11: var(--sage-11);
+    --gray-12: var(--sage-12);
+
+    --gray-a1: var(--sage-a1);
+    --gray-a2: var(--sage-a2);
+    --gray-a3: var(--sage-a3);
+    --gray-a4: var(--sage-a4);
+    --gray-a5: var(--sage-a5);
+    --gray-a6: var(--sage-a6);
+    --gray-a7: var(--sage-a7);
+    --gray-a8: var(--sage-a8);
+    --gray-a9: var(--sage-a9);
+    --gray-a10: var(--sage-a10);
+    --gray-a11: var(--sage-a11);
+    --gray-a12: var(--sage-a12);
+  }
+  &:where([data-gray-color='olive']) {
+    --gray-1: var(--olive-1);
+    --gray-2: var(--olive-2);
+    --gray-2-translucent: var(--olive-2-translucent);
+    --gray-3: var(--olive-3);
+    --gray-4: var(--olive-4);
+    --gray-5: var(--olive-5);
+    --gray-6: var(--olive-6);
+    --gray-7: var(--olive-7);
+    --gray-8: var(--olive-8);
+    --gray-9: var(--olive-9);
+    --gray-10: var(--olive-10);
+    --gray-11: var(--olive-11);
+    --gray-12: var(--olive-12);
+
+    --gray-a1: var(--olive-a1);
+    --gray-a2: var(--olive-a2);
+    --gray-a3: var(--olive-a3);
+    --gray-a4: var(--olive-a4);
+    --gray-a5: var(--olive-a5);
+    --gray-a6: var(--olive-a6);
+    --gray-a7: var(--olive-a7);
+    --gray-a8: var(--olive-a8);
+    --gray-a9: var(--olive-a9);
+    --gray-a10: var(--olive-a10);
+    --gray-a11: var(--olive-a11);
+    --gray-a12: var(--olive-a12);
+  }
+  &:where([data-gray-color='sand']) {
+    --gray-1: var(--sand-1);
+    --gray-2: var(--sand-2);
+    --gray-2-translucent: var(--sand-2-translucent);
+    --gray-3: var(--sand-3);
+    --gray-4: var(--sand-4);
+    --gray-5: var(--sand-5);
+    --gray-6: var(--sand-6);
+    --gray-7: var(--sand-7);
+    --gray-8: var(--sand-8);
+    --gray-9: var(--sand-9);
+    --gray-10: var(--sand-10);
+    --gray-11: var(--sand-11);
+    --gray-12: var(--sand-12);
+
+    --gray-a1: var(--sand-a1);
+    --gray-a2: var(--sand-a2);
+    --gray-a3: var(--sand-a3);
+    --gray-a4: var(--sand-a4);
+    --gray-a5: var(--sand-a5);
+    --gray-a6: var(--sand-a6);
+    --gray-a7: var(--sand-a7);
+    --gray-a8: var(--sand-a8);
+    --gray-a9: var(--sand-a9);
+    --gray-a10: var(--sand-a10);
+    --gray-a11: var(--sand-a11);
+    --gray-a12: var(--sand-a12);
+  }
 }
 
 /* nested `Theme` background color */

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -202,10 +202,11 @@
   & ::selection {
     background-color: var(--accent-a6);
   }
-  & :where([data-accent-color='gray'])::selection,
-  & :where([data-accent-color='gray']) ::selection {
-    background-color: var(--color-selection-root);
-  }
+}
+
+[data-accent-color='gray']::selection,
+[data-accent-color='gray'] ::selection {
+  background-color: var(--color-selection-root);
 }
 
 /* additional step-9 contrast colors */

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -190,7 +190,7 @@
 }
 
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --color-overlay: rgba(0, 0, 0, 0.75);
   --color-panel-solid: var(--gray-2);
   --color-panel-translucent: var(--gray-2-translucent);
@@ -202,8 +202,8 @@
   & ::selection {
     background-color: var(--accent-a6);
   }
-  & [data-accent-color='gray']::selection,
-  & [data-accent-color='gray'] ::selection {
+  & :where([data-accent-color='gray'])::selection,
+  & :where([data-accent-color='gray']) ::selection {
     background-color: var(--color-selection-root);
   }
 }
@@ -1243,7 +1243,7 @@
   --color-background: white;
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --color-background: var(--gray-1);
 }
 .radix-themes:where([data-has-background='true']) {

--- a/packages/radix-ui-themes/src/styles/tokens/radius.css
+++ b/packages/radix-ui-themes/src/styles/tokens/radius.css
@@ -1,40 +1,33 @@
-.radix-themes {
-  /* default: medium */
+[data-radius] {
+  --radius-1: calc(3px * var(--scaling) * var(--radius-factor));
+  --radius-2: calc(4px * var(--scaling) * var(--radius-factor));
+  --radius-3: calc(6px * var(--scaling) * var(--radius-factor));
+  --radius-4: calc(8px * var(--scaling) * var(--radius-factor));
+  --radius-5: calc(12px * var(--scaling) * var(--radius-factor));
+  --radius-6: calc(16px * var(--scaling) * var(--radius-factor));
+}
+
+[data-radius='none'] {
+  --radius-factor: 0;
+  --radius-full: 0px;
+}
+
+[data-radius='small'] {
+  --radius-factor: 0.5;
+  --radius-full: 0px;
+}
+
+[data-radius='medium'] {
   --radius-factor: 1;
   --radius-full: 0px;
+}
 
-  &:where([data-radius]),
-  & :where([data-radius]) {
-    --radius-1: calc(3px * var(--scaling) * var(--radius-factor));
-    --radius-2: calc(4px * var(--scaling) * var(--radius-factor));
-    --radius-3: calc(6px * var(--scaling) * var(--radius-factor));
-    --radius-4: calc(8px * var(--scaling) * var(--radius-factor));
-    --radius-5: calc(12px * var(--scaling) * var(--radius-factor));
-    --radius-6: calc(16px * var(--scaling) * var(--radius-factor));
-  }
-  &:where([data-radius='none']),
-  & :where([data-radius='none']) {
-    --radius-factor: 0;
-    --radius-full: 0px;
-  }
-  &:where([data-radius='small']),
-  & :where([data-radius='small']) {
-    --radius-factor: 0.5;
-    --radius-full: 0px;
-  }
-  &:where([data-radius='medium']),
-  & :where([data-radius='medium']) {
-    --radius-factor: 1;
-    --radius-full: 0px;
-  }
-  &:where([data-radius='large']),
-  & :where([data-radius='large']) {
-    --radius-factor: 1.5;
-    --radius-full: 0px;
-  }
-  &:where([data-radius='full']),
-  & :where([data-radius='full']) {
-    --radius-factor: 2;
-    --radius-full: 9999px;
-  }
+[data-radius='large'] {
+  --radius-factor: 1.5;
+  --radius-full: 0px;
+}
+
+[data-radius='full'] {
+  --radius-factor: 2;
+  --radius-full: 9999px;
 }

--- a/packages/radix-ui-themes/src/styles/tokens/radius.css
+++ b/packages/radix-ui-themes/src/styles/tokens/radius.css
@@ -4,7 +4,7 @@
   --radius-full: 0px;
 
   &:where([data-radius]),
-  & [data-radius] {
+  & :where([data-radius]) {
     --radius-1: calc(3px * var(--scaling) * var(--radius-factor));
     --radius-2: calc(4px * var(--scaling) * var(--radius-factor));
     --radius-3: calc(6px * var(--scaling) * var(--radius-factor));
@@ -13,27 +13,27 @@
     --radius-6: calc(16px * var(--scaling) * var(--radius-factor));
   }
   &:where([data-radius='none']),
-  & [data-radius='none'] {
+  & :where([data-radius='none']) {
     --radius-factor: 0;
     --radius-full: 0px;
   }
   &:where([data-radius='small']),
-  & [data-radius='small'] {
+  & :where([data-radius='small']) {
     --radius-factor: 0.5;
     --radius-full: 0px;
   }
   &:where([data-radius='medium']),
-  & [data-radius='medium'] {
+  & :where([data-radius='medium']) {
     --radius-factor: 1;
     --radius-full: 0px;
   }
   &:where([data-radius='large']),
-  & [data-radius='large'] {
+  & :where([data-radius='large']) {
     --radius-factor: 1.5;
     --radius-full: 0px;
   }
   &:where([data-radius='full']),
-  & [data-radius='full'] {
+  & :where([data-radius='full']) {
     --radius-factor: 2;
     --radius-full: 9999px;
   }

--- a/packages/radix-ui-themes/src/styles/tokens/shadow.css
+++ b/packages/radix-ui-themes/src/styles/tokens/shadow.css
@@ -35,7 +35,7 @@
 
 /* prettier-ignore */
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --shadow-1:
     inset 0 -1px 1px 0 var(--gray-a3),
     inset 0 0 0 1px var(--gray-a3),
@@ -74,7 +74,7 @@
 /* prettier-ignore */
 @supports (color: color-mix(in oklab, white, black)) {
   :is(.dark, .dark-theme),
-  :is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+  :is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
     --shadow-1:
       inset 0 -1px 1px 0 var(--gray-a3),
       inset 0 0 0 1px var(--gray-a3),

--- a/packages/radix-ui-themes/src/theme-panel.css
+++ b/packages/radix-ui-themes/src/theme-panel.css
@@ -2,63 +2,65 @@
   --theme-panel--focus-ring-color: black;
 }
 :is(.dark, .dark-theme),
-:is(.dark, .dark-theme) .radix-themes:not(.light, .light-theme) {
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --theme-panel--focus-ring-color: white;
 }
 
-.rt-ThemePanelShortcut:focus-visible {
-  outline-style: solid;
-  outline-width: 2px;
-  outline-offset: 2px;
-  outline-color: var(--accent-9);
+.rt-ThemePanelShortcut {
+  &:where(:focus-visible) {
+    outline-style: solid;
+    outline-width: 2px;
+    outline-offset: 2px;
+    outline-color: var(--accent-9);
+  }
 }
 
 .rt-ThemePanelSwatch,
 .rt-ThemePanelRadioCard {
   position: relative;
+}
 
-  & input {
-    appearance: none;
-    margin: 0;
-    outline: none;
-    outline-width: 2px;
-    outline-offset: 2px;
-
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-  }
+.rt-ThemePanelSwatchInput,
+.rt-ThemePanelRadioCardInput {
+  appearance: none;
+  margin: 0;
+  outline: none;
+  outline-width: 2px;
+  outline-offset: 2px;
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
 }
 
 .rt-ThemePanelSwatch {
   width: var(--space-5);
   height: var(--space-5);
   border-radius: 100%;
+}
 
-  & input {
-    &:checked {
-      outline-style: solid;
-      outline-color: var(--theme-panel--focus-ring-color);
-    }
-    &:focus-visible {
-      outline-style: solid;
-      outline-color: var(--accent-9);
-    }
+.rt-ThemePanelSwatchInput {
+  &:where(:checked) {
+    outline-style: solid;
+    outline-color: var(--theme-panel--focus-ring-color);
+  }
+  &:where(:focus-visible) {
+    outline-style: solid;
+    outline-color: var(--accent-9);
   }
 }
 
 .rt-ThemePanelRadioCard {
   border-radius: var(--radius-1);
   box-shadow: 0 0 0 1px var(--gray-7);
+}
 
-  & input {
-    &:checked {
-      box-shadow: inset 0 0 0 1px var(--theme-panel--focus-ring-color),
-        0 0 0 1px var(--theme-panel--focus-ring-color);
-    }
-    &:focus-visible {
-      background-color: var(--accent-a3);
-      box-shadow: inset 0 0 0 1px var(--accent-9), 0 0 0 1px var(--accent-9);
-    }
+.rt-ThemePanelRadioCardInput {
+  &:where(:checked) {
+    box-shadow: inset 0 0 0 1px var(--theme-panel--focus-ring-color),
+      0 0 0 1px var(--theme-panel--focus-ring-color);
+  }
+  &:where(:focus-visible) {
+    background-color: var(--accent-a3);
+    box-shadow: inset 0 0 0 1px var(--accent-9), 0 0 0 1px var(--accent-9);
   }
 }

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -239,6 +239,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       }`}
                     >
                       <input
+                        className="rt-ThemePanelSwatchInput"
                         type="radio"
                         name="accentColor"
                         value={color}
@@ -281,6 +282,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                         }`}
                       >
                         <input
+                          className="rt-ThemePanelSwatchInput"
                           type="radio"
                           name="grayColor"
                           value={gray}
@@ -303,6 +305,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                 {(['light', 'dark'] as const).map((value) => (
                   <label key={value} className="rt-ThemePanelRadioCard">
                     <input
+                      className="rt-ThemePanelRadioCardInput"
                       type="radio"
                       name="appearance"
                       value={value}
@@ -364,6 +367,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                   <Flex key={value} direction="column" align="center">
                     <label className="rt-ThemePanelRadioCard">
                       <input
+                        className="rt-ThemePanelRadioCardInput"
                         type="radio"
                         name="radius"
                         id={`theme-panel-radius-${value}`}
@@ -405,6 +409,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                 {themePropDefs.scaling.values.map((value) => (
                   <label key={value} className="rt-ThemePanelRadioCard">
                     <input
+                      className="rt-ThemePanelRadioCardInput"
                       type="radio"
                       name="scaling"
                       value={value}
@@ -460,6 +465,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                 {themePropDefs.panelBackground.values.map((value) => (
                   <label key={value} className="rt-ThemePanelRadioCard">
                     <input
+                      className="rt-ThemePanelRadioCardInput"
                       type="radio"
                       name="panelBackground"
                       value={value}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.22.13"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.13.tgz#e3c1c099402598483b7a8c46a721d1038803755e"
+  integrity sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==
+  dependencies:
+    "@babel/highlight" "^7.22.13"
+    chalk "^2.4.2"
+
+"@babel/helper-validator-identifier@^7.22.20":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz#c4ae002c61d2879e724581d96665583dbc1dc0e0"
+  integrity sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==
+
+"@babel/highlight@^7.22.13":
+  version "7.22.20"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.20.tgz#4ca92b71d80554b01427815e06f2df965b9c1f54"
+  integrity sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.20"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.13.10", "@babel/runtime@^7.20.7":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
@@ -19,20 +41,40 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.2.0.tgz#1268b07196d1118296443aeff41bca27d94b0981"
   integrity sha512-9BoQ/jSrPq4vv3b9jjLW+PNNv56KlDH5JMx5yASSNrCtvq70FCNZUjXRvbCeR9hYj9ZyhURtqpU/RFIgg6kiOw==
 
+"@csstools/css-parser-algorithms@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz#ec4fc764ba45d2bb7ee2774667e056aa95003f3a"
+  integrity sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==
+
 "@csstools/css-tokenizer@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.1.1.tgz#07ae11a0a06365d7ec686549db7b729bc036528e"
   integrity sha512-GbrTj2Z8MCTUv+52GE0RbFGM527xuXZ0Xa5g0Z+YN573uveS4G0qi6WNOMyz3yrFM/jaILTTwJ0+umx81EzqfA==
+
+"@csstools/css-tokenizer@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz#9d70e6dcbe94e44c7400a2929928db35c4de32b5"
+  integrity sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==
 
 "@csstools/media-query-list-parser@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.0.tgz#6e1a5e12e0d103cd13b94bddb88b878bd6866103"
   integrity sha512-MXkR+TeaS2q9IkpyO6jVCdtA/bfpABJxIrfkLswThFN8EZZgI2RfAHhm6sDNDuYV25d5+b8Lj1fpTccIcSLPsQ==
 
+"@csstools/media-query-list-parser@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.4.tgz#0017f99945f6c16dd81a7aacf6821770933c3a5c"
+  integrity sha512-V/OUXYX91tAC1CDsiY+HotIcJR+vPtzrX8pCplCpT++i8ThZZsq5F5dzZh/bDM3WUOjrvC1ljed1oSJxMfjqhw==
+
 "@csstools/selector-specificity@^2.0.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz#2cbcf822bf3764c9658c4d2e568bd0c0cb748016"
   integrity sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==
+
+"@csstools/selector-specificity@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
+  integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -773,10 +815,20 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/node@^17.0.12":
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
+  integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -873,10 +925,27 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.12.0.tgz#d1a0527323e22f53562c567c00991577dfbe19d1"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
@@ -967,10 +1036,20 @@ array.prototype.tosorted@^1.1.1:
     es-shim-unscopables "^1.0.0"
     get-intrinsic "^1.1.3"
 
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==
+
 ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 autoprefixer@^10.4.14:
   version "10.4.14"
@@ -1005,6 +1084,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+balanced-match@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
+  integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 big-integer@^1.6.44:
   version "1.6.51"
@@ -1075,10 +1159,34 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase-keys@^7.0.0:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-7.0.2.tgz#d048d8c69448745bb0de6fc4c1c52a30dfbe7252"
+  integrity sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==
+  dependencies:
+    camelcase "^6.3.0"
+    map-obj "^4.1.0"
+    quick-lru "^5.1.1"
+    type-fest "^1.2.1"
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001502:
   version "1.0.30001503"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz#88b6ff1b2cf735f1f3361dc1a15b59f0561aa398"
   integrity sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==
+
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -1122,6 +1230,13 @@ cliui@^8.0.1:
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -1129,10 +1244,20 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colord@^2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
+  integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1146,6 +1271,16 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
+cosmiconfig@^8.2.0:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
+  integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
+  dependencies:
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+    path-type "^4.0.0"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -1154,6 +1289,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-functions-list@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.0.tgz#8290b7d064bf483f48d6559c10e98dc4d1ad19ee"
+  integrity sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==
 
 css-in-js-utils@^3.1.0:
   version "3.1.0"
@@ -1169,6 +1309,14 @@ css-tree@^1.1.2:
   dependencies:
     mdn-data "2.0.14"
     source-map "^0.6.1"
+
+css-tree@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1198,6 +1346,24 @@ debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+decamelize-keys@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.1.tgz#04a2d523b2f18d80d0158a43b895d56dff8d19d8"
+  integrity sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
+
+decamelize@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-5.0.1.tgz#db11a92e58c741ef339fb0a2868d8a06a9a7b1e9"
+  integrity sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -1294,6 +1460,13 @@ enhanced-resolve@^5.12.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
 error-stack-parser@^2.0.6:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
@@ -1370,6 +1543,11 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -1664,6 +1842,17 @@ fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
+  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -1683,6 +1872,11 @@ fast-shallow-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz#d4dcaf6472440dcefa6f88b98e3251e27f25628b"
   integrity sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==
+
+fastest-levenshtein@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastest-stable-stringify@^2.0.2:
   version "2.0.2"
@@ -1870,6 +2064,22 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"
+  integrity sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==
+  dependencies:
+    global-prefix "^3.0.0"
+
+global-prefix@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-3.0.0.tgz#fc85f73064df69f50421f47f883fe5b913ba9b97"
+  integrity sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==
+  dependencies:
+    ini "^1.3.5"
+    kind-of "^6.0.2"
+    which "^1.3.1"
+
 globals@^13.19.0:
   version "13.20.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
@@ -1907,6 +2117,11 @@ globby@^13.0.0, globby@^13.1.3:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+globjoin@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
+  integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -1924,10 +2139,20 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+hard-rejection@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
+  integrity sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -1965,6 +2190,18 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hosted-git-info@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
+  integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+html-tags@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.3.1.tgz#a04026a18c882e4bba8a01a3d39cfe465d40b5ce"
+  integrity sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -1980,12 +2217,12 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -1993,10 +2230,20 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -2010,6 +2257,11 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@^1.3.5:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inline-style-prefixer@^6.0.0:
   version "6.0.4"
@@ -2044,6 +2296,11 @@ is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
     get-intrinsic "^1.2.0"
     is-typed-array "^1.1.10"
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -2075,6 +2332,13 @@ is-core-module@^2.11.0, is-core-module@^2.9.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
   integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.5.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
   dependencies:
     has "^1.0.3"
 
@@ -2140,6 +2404,16 @@ is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+  integrity sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -2215,7 +2489,7 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
-"js-tokens@^3.0.0 || ^4.0.0":
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -2227,10 +2501,20 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -2261,6 +2545,16 @@ jsonfile@^6.0.1:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
+kind-of@^6.0.2, kind-of@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+known-css-properties@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.28.0.tgz#8a8be010f368b3036fe6ab0ef4bbbed972bd6274"
+  integrity sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==
+
 language-subtag-registry@~0.3.2:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
@@ -2286,6 +2580,11 @@ lilconfig@^2.0.5:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
   integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
 
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -2297,6 +2596,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -2312,10 +2616,48 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+map-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+  integrity sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==
+
+map-obj@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.3.0.tgz#9304f906e93faae70880da102a9f1df0ea8bb05a"
+  integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
+
+mathml-tag-names@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
+  integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
+meow@^10.1.5:
+  version "10.1.5"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-10.1.5.tgz#be52a1d87b5f5698602b0f32875ee5940904aa7f"
+  integrity sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==
+  dependencies:
+    "@types/minimist" "^1.2.2"
+    camelcase-keys "^7.0.0"
+    decamelize "^5.0.0"
+    decamelize-keys "^1.1.0"
+    hard-rejection "^2.1.0"
+    minimist-options "4.1.0"
+    normalize-package-data "^3.0.2"
+    read-pkg-up "^8.0.0"
+    redent "^4.0.0"
+    trim-newlines "^4.0.2"
+    type-fest "^1.2.2"
+    yargs-parser "^20.2.9"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -2327,7 +2669,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4:
+micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -2345,12 +2687,26 @@ mimic-fn@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
+min-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist-options@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
+  integrity sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
+    kind-of "^6.0.3"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"
@@ -2424,6 +2780,16 @@ node-releases@^2.0.12:
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.12.tgz#35627cc224a23bfb06fb3380f2b3afaaa7eb1039"
   integrity sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==
+
+normalize-package-data@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
+  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
+  dependencies:
+    hosted-git-info "^4.0.1"
+    is-core-module "^2.5.0"
+    semver "^7.3.4"
+    validate-npm-package-license "^3.0.1"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -2573,6 +2939,16 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-json@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2686,7 +3062,17 @@ postcss-reporter@^7.0.0:
     picocolors "^1.0.0"
     thenby "^1.3.4"
 
-postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.4:
+postcss-resolve-nested-selector@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz#29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+  integrity sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==
+
+postcss-safe-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
+  integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
+
+postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.13, postcss-selector-parser@^6.0.4:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
@@ -2712,6 +3098,15 @@ postcss@^8.4.24:
   version "8.4.24"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
   integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
+  dependencies:
+    nanoid "^3.3.6"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
+postcss@^8.4.27:
+  version "8.4.29"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.29.tgz#33bc121cf3b3688d4ddef50be869b2a54185a1dd"
+  integrity sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==
   dependencies:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
@@ -2745,6 +3140,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
 react-dom@^18.1.0, react-dom@^18.2.0:
   version "18.2.0"
@@ -2826,12 +3226,39 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+read-pkg-up@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-8.0.0.tgz#72f595b65e66110f43b052dd9af4de6b10534670"
+  integrity sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==
+  dependencies:
+    find-up "^5.0.0"
+    read-pkg "^6.0.0"
+    type-fest "^1.0.1"
+
+read-pkg@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-6.0.0.tgz#a67a7d6a1c2b0c3cd6aa2ea521f40c458a4a504c"
+  integrity sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^3.0.2"
+    parse-json "^5.2.0"
+    type-fest "^1.0.1"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-4.0.0.tgz#0c0ba7caabb24257ab3bb7a4fd95dd1d5c5681f9"
+  integrity sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==
+  dependencies:
+    indent-string "^5.0.0"
+    strip-indent "^4.0.0"
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
@@ -2852,6 +3279,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
@@ -2861,6 +3293,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-from@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
+  integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
@@ -2949,6 +3386,13 @@ semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
 semver@^7.3.7:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
@@ -2987,6 +3431,11 @@ signal-exit@^3.0.3, signal-exit@^3.0.7:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -3002,7 +3451,16 @@ slash@^5.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
   integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
 
-source-map-js@^1.0.2:
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
+source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
@@ -3021,6 +3479,32 @@ sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+spdx-correct@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.2.0.tgz#4f5ab0668f0059e34f9c00dce331784a12de4e9c"
+  integrity sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
+  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz#7189a474c46f8d47c7b0da4b987bb45e908bd2d5"
+  integrity sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==
 
 stack-generator@^2.0.5:
   version "2.0.10"
@@ -3128,10 +3612,22 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
+strip-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-4.0.0.tgz#b41379433dd06f5eae805e21d631e07ee670d853"
+  integrity sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==
+  dependencies:
+    min-indent "^1.0.1"
+
 strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+style-search@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
 styled-jsx@5.1.1:
   version "5.1.1"
@@ -3140,22 +3636,88 @@ styled-jsx@5.1.1:
   dependencies:
     client-only "0.0.1"
 
+stylelint@^15.10.3:
+  version "15.10.3"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-15.10.3.tgz#995e4512fdad450fb83e13f3472001f6edb6469c"
+  integrity sha512-aBQMMxYvFzJJwkmg+BUUg3YfPyeuCuKo2f+LOw7yYbU8AZMblibwzp9OV4srHVeQldxvSFdz0/Xu8blq2AesiA==
+  dependencies:
+    "@csstools/css-parser-algorithms" "^2.3.1"
+    "@csstools/css-tokenizer" "^2.2.0"
+    "@csstools/media-query-list-parser" "^2.1.4"
+    "@csstools/selector-specificity" "^3.0.0"
+    balanced-match "^2.0.0"
+    colord "^2.9.3"
+    cosmiconfig "^8.2.0"
+    css-functions-list "^3.2.0"
+    css-tree "^2.3.1"
+    debug "^4.3.4"
+    fast-glob "^3.3.1"
+    fastest-levenshtein "^1.0.16"
+    file-entry-cache "^6.0.1"
+    global-modules "^2.0.0"
+    globby "^11.1.0"
+    globjoin "^0.1.4"
+    html-tags "^3.3.1"
+    ignore "^5.2.4"
+    import-lazy "^4.0.0"
+    imurmurhash "^0.1.4"
+    is-plain-object "^5.0.0"
+    known-css-properties "^0.28.0"
+    mathml-tag-names "^2.1.3"
+    meow "^10.1.5"
+    micromatch "^4.0.5"
+    normalize-path "^3.0.0"
+    picocolors "^1.0.0"
+    postcss "^8.4.27"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-safe-parser "^6.0.0"
+    postcss-selector-parser "^6.0.13"
+    postcss-value-parser "^4.2.0"
+    resolve-from "^5.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
+    style-search "^0.1.0"
+    supports-hyperlinks "^3.0.0"
+    svg-tags "^1.0.0"
+    table "^6.8.1"
+    write-file-atomic "^5.0.1"
+
 stylis@^4.0.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
-supports-color@^7.1.0:
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz#c711352a5c89070779b4dad54c05a2f14b15c94b"
+  integrity sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svg-tags@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  integrity sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==
 
 synckit@^0.8.5:
   version "0.8.5"
@@ -3164,6 +3726,17 @@ synckit@^0.8.5:
   dependencies:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
+
+table@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.8.1.tgz#ea2b71359fe03b017a5fbc296204471158080bdf"
+  integrity sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 tapable@^2.2.0:
   version "2.2.1"
@@ -3201,6 +3774,11 @@ toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
+
+trim-newlines@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.1.1.tgz#28c88deb50ed10c7ba6dc2474421904a00139125"
+  integrity sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==
 
 ts-easing@^0.2.0:
   version "0.2.0"
@@ -3288,6 +3866,11 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
+type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
 typed-array-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
@@ -3357,6 +3940,14 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
 watchpack@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
@@ -3388,6 +3979,13 @@ which-typed-array@^1.1.9:
     has-tostringtag "^1.0.0"
     is-typed-array "^1.1.10"
 
+which@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -3414,6 +4012,14 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -3428,6 +4034,11 @@ yaml@^2.1.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
+
+yargs-parser@^20.2.9:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
- Reduce selector specificity to 0,1,0 when not targeting pseudo-classes, and 0,1,1 when targeting a pseudo-class
- Add stylelint to guarantee the above
- Add `rt-` prefix to the keyframe names