### PR TITLE
Support `postcss-import`

### DIFF
--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -4,6 +4,7 @@
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",
   "module": "./dist/esm/index.js",
+  "style": "./styles.css",
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
Add `style` so that apps with `postcss-import` can import Radix Themes stylesheet by `@import "@radix-ui/themes";`