### PR TITLE
Fix CSS rule order

### DIFF
--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -58,7 +58,7 @@
 /* classic */
 
 /* prettier-ignore */
-.radix-themes {
+:where(.radix-themes) {
   --base-button-classic-after-inset: 2px;
   --base-button-classic-box-shadow-top:
     inset 0 0 0 1px var(--gray-a4),
@@ -229,7 +229,7 @@
 
 /* solid */
 
-.radix-themes {
+:where(.radix-themes) {
   --base-button-solid-active-filter: brightness(0.92) saturate(1.1);
   --base-button-solid-high-contrast-hover-filter: contrast(0.88) saturate(1.1) brightness(1.1);
   --base-button-solid-high-contrast-active-filter: contrast(0.82) saturate(1.2) brightness(1.16);

--- a/packages/radix-ui-themes/src/components/card.css
+++ b/packages/radix-ui-themes/src/components/card.css
@@ -155,7 +155,7 @@
 }
 
 /* prettier-ignore */
-.radix-themes {
+:where(.radix-themes) {
   /*
    * Make sure that hovered shadows length matches the shadows length at rest for clean transitions:
    * https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#interpolation

--- a/packages/radix-ui-themes/src/components/kbd.css
+++ b/packages/radix-ui-themes/src/components/kbd.css
@@ -1,4 +1,4 @@
-.radix-themes {
+:where(.radix-themes) {
   /* prettier-ignore */
   --kbd-box-shadow:
     inset 0 -0.05em 0.5em var(--gray-a2),

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -312,7 +312,7 @@
 /* classic */
 
 /* prettier-ignore */
-.radix-themes {
+:where(.radix-themes) {
   --select-trigger-classic-box-shadow:
 		inset 0 0 0 1px var(--gray-a5),
 		inset 0 2px 1px var(--white-a11),

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -217,7 +217,7 @@
 
 /* all high-contrast */
 
-.radix-themes {
+:where(.radix-themes) {
   --slider-range-high-contrast-background-image: linear-gradient(var(--black-a8), var(--black-a8));
 }
 :is(.dark, .dark-theme),
@@ -231,7 +231,7 @@
   }
 }
 
-.radix-themes {
+:where(.radix-themes) {
   --slider-disabled-blend-mode: multiply;
 }
 :is(.dark, .dark-theme),

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -1,4 +1,4 @@
-.radix-themes {
+:where(.radix-themes) {
   --switch-disabled-blend-mode: multiply;
   --switch-button-high-contrast-checked-color-overlay: var(--black-a8);
   --switch-button-high-contrast-checked-active-before-filter: contrast(0.82) saturate(1.2)
@@ -115,7 +115,7 @@
 
 /* surface */
 
-.radix-themes {
+:where(.radix-themes) {
   --switch-button-surface-checked-active-filter: brightness(0.92) saturate(1.1);
 }
 
@@ -186,7 +186,7 @@
 
 /* classic */
 
-.radix-themes {
+:where(.radix-themes) {
   --switch-button-surface-checked-active-filter: brightness(0.92) saturate(1.1);
 }
 :is(.dark, .dark-theme),

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -172,11 +172,12 @@
 
   /* Because Chrome is buggy with box-shadow transitions from "transparent" keyword and/or RGB color into P3 colors */
   --color-transparent: rgb(0 0 0 / 0);
-  @supports (color: color(display-p3 1 1 1)) {
-    @media (color-gamut: p3) {
-      & {
-        --color-transparent: color(display-p3 0 0 0 / 0);
-      }
+}
+
+@supports (color: color(display-p3 1 1 1)) {
+  @media (color-gamut: p3) {
+    .radix-themes {
+      --color-transparent: color(display-p3 0 0 0 / 0);
     }
   }
 }

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -1,4 +1,3 @@
-/* regulars (white foreground) */
 @import '@radix-ui/colors/tomato.css';
 @import '@radix-ui/colors/tomato-dark.css';
 @import '@radix-ui/colors/tomato-alpha.css';
@@ -89,7 +88,6 @@
 @import '@radix-ui/colors/brown-alpha.css';
 @import '@radix-ui/colors/brown-dark-alpha.css';
 
-/* brights (black foreground) */
 @import '@radix-ui/colors/sky.css';
 @import '@radix-ui/colors/sky-dark.css';
 @import '@radix-ui/colors/sky-alpha.css';
@@ -115,7 +113,6 @@
 @import '@radix-ui/colors/amber-alpha.css';
 @import '@radix-ui/colors/amber-dark-alpha.css';
 
-/* metals */
 @import '@radix-ui/colors/gold.css';
 @import '@radix-ui/colors/gold-dark.css';
 @import '@radix-ui/colors/gold-alpha.css';
@@ -126,7 +123,6 @@
 @import '@radix-ui/colors/bronze-alpha.css';
 @import '@radix-ui/colors/bronze-dark-alpha.css';
 
-/* grays */
 @import '@radix-ui/colors/gray.css';
 @import '@radix-ui/colors/gray-dark.css';
 @import '@radix-ui/colors/gray-alpha.css';
@@ -157,30 +153,54 @@
 @import '@radix-ui/colors/sand-alpha.css';
 @import '@radix-ui/colors/sand-dark-alpha.css';
 
-/* overlays */
 @import '@radix-ui/colors/black-alpha.css';
 @import '@radix-ui/colors/white-alpha.css';
 
-.radix-themes {
-  /* text color */
-  color: var(--gray-12);
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*           Semantic colors           */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
 
+:where(.radix-themes) {
+  --color-background: white;
   --color-overlay: var(--gray-a8);
   --color-panel-solid: white;
   --color-panel-translucent: rgba(255, 255, 255, 0.8);
   --color-surface: rgba(255, 255, 255, 0.9);
-
-  /* Because Chrome is buggy with box-shadow transitions from "transparent" keyword and/or RGB color into P3 colors */
-  --color-transparent: rgb(0 0 0 / 0);
+}
+:is(.dark, .dark-theme),
+:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
+  --color-background: var(--gray-1);
+  --color-overlay: rgba(0, 0, 0, 0.75);
+  --color-panel-solid: var(--gray-2);
+  --color-panel-translucent: var(--gray-2-translucent);
+  --color-surface: rgba(0, 0, 0, 0.25);
 }
 
-@supports (color: color(display-p3 1 1 1)) {
-  @media (color-gamut: p3) {
-    .radix-themes {
-      --color-transparent: color(display-p3 0 0 0 / 0);
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*            Transparency             */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
+.radix-themes {
+  /* Because Chrome is buggy with box-shadow transitions from "transparent" keyword and/or RGB color into P3 colors */
+  --color-transparent: rgb(0 0 0 / 0);
+  @supports (color: color(display-p3 1 1 1)) {
+    @media (color-gamut: p3) {
+      & {
+        --color-transparent: color(display-p3 0 0 0 / 0);
+      }
     }
   }
 }
+
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*            Color scheme             */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
 
 /* Make sure that forced light/dark appearance also sets corresponding browser colors, like input autofill color */
 .radix-themes:where(.light, .light-theme) {
@@ -190,16 +210,15 @@
   color-scheme: dark;
 }
 
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
-  --color-overlay: rgba(0, 0, 0, 0.75);
-  --color-panel-solid: var(--gray-2);
-  --color-panel-translucent: var(--gray-2-translucent);
-  --color-surface: rgba(0, 0, 0, 0.25);
-}
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*              Selection              */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
 
 .radix-themes {
   --color-selection-root: var(--accent-a6);
+
   & ::selection {
     background-color: var(--accent-a6);
   }
@@ -210,7 +229,41 @@
   background-color: var(--color-selection-root);
 }
 
-/* additional step-9 contrast colors */
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*         Background and text         */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
+.radix-themes {
+  color: var(--gray-12);
+
+  &:where([data-has-background='true']) {
+    background-color: var(--color-background);
+  }
+}
+
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*          Panel background           */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
+.radix-themes {
+  &:where([data-panel-background='solid']) {
+    --color-panel: var(--color-panel-solid);
+  }
+  &:where([data-panel-background='translucent']) {
+    --color-panel: var(--color-panel-translucent);
+  }
+}
+
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*           Step 9 contrast           */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
 :root {
   --tomato-9-contrast: white;
   --red-9-contrast: white;
@@ -240,7 +293,13 @@
   --gray-9-contrast: white;
 }
 
-/* additional step-2 translucent grays for dark mode panels */
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*          Gray 2 equivalent          */
+/*        for translucent panels       */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
 .dark,
 .dark-theme {
   --gray-2-translucent: #1d1d1db3;
@@ -264,7 +323,12 @@
   }
 }
 
-/* additional surface colors */
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*           Surface colors            */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
 :root,
 .light,
 .light-theme {
@@ -412,7 +476,12 @@
   }
 }
 
-/* accent scales */
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*          Map accent colors          */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
 [data-accent-color='tomato'] {
   --color-surface-accent: var(--tomato-surface);
 
@@ -1219,7 +1288,12 @@
   --accent-a12: var(--gray-a12);
 }
 
-/* gray color overrides */
+/* * * * * * * * * * * * * * * * * * * */
+/*                                     */
+/*           Map gray color            */
+/*                                     */
+/* * * * * * * * * * * * * * * * * * * */
+
 .radix-themes {
   &:where([data-gray-color='mauve']) {
     --gray-surface: var(--mauve-surface);
@@ -1370,29 +1444,5 @@
     --gray-a10: var(--sand-a10);
     --gray-a11: var(--sand-a11);
     --gray-a12: var(--sand-a12);
-  }
-}
-
-/* nested `Theme` background color */
-
-.radix-themes {
-  --color-background: white;
-}
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
-  --color-background: var(--gray-1);
-}
-.radix-themes:where([data-has-background='true']) {
-  background-color: var(--color-background);
-}
-
-/* panel background */
-
-.radix-themes {
-  &:where([data-panel-background='solid']) {
-    --color-panel: var(--color-panel-solid);
-  }
-  &:where([data-panel-background='translucent']) {
-    --color-panel: var(--color-panel-translucent);
   }
 }

--- a/packages/radix-ui-themes/src/styles/tokens/shadow.css
+++ b/packages/radix-ui-themes/src/styles/tokens/shadow.css
@@ -1,5 +1,5 @@
 /* prettier-ignore */
-.radix-themes {
+:where(.radix-themes) {
   --shadow-1:
     inset 0 0 0 1px var(--gray-a5),
     inset 0 1.5px 2px 0 var(--gray-a5);


### PR DESCRIPTION
After merging all the todays PR's, the order of rules in the built CSS got messed up somehow and broke dark mode, although previews on each PR individually looked correct.

Broken dark mode:

<img width="1624" alt="Screenshot 2023-09-26 at 21 22 14" src="https://github.com/radix-ui/themes/assets/8441036/742f38a2-40d2-4d8f-8773-d9aefb3f7d20">
