### PR TITLE
Update shadows and overlays

### DIFF
--- a/packages/radix-ui-themes/src/components/card.css
+++ b/packages/radix-ui-themes/src/components/card.css
@@ -162,9 +162,9 @@
    */
   --card-classic-hover-box-shadow:
     0 0 0 1px var(--gray-a5),
-    0 1px 1px 1px var(--gray-a4),
+    0 1px 1px 1px var(--black-a2),
     0 2px 1px -1px var(--gray-a3),
-    0 2px 3px -2px var(--gray-a3),
+    0 2px 3px -2px var(--black-a1),
     0 3px 12px -4px var(--gray-a3),
     0 4px 16px -8px var(--black-a1);
 }

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -164,7 +164,7 @@
 
 :where(.radix-themes) {
   --color-background: white;
-  --color-overlay: var(--gray-a8);
+  --color-overlay: var(--black-a6);
   --color-panel-solid: white;
   --color-panel-translucent: rgba(255, 255, 255, 0.8);
   --color-surface: rgba(255, 255, 255, 0.9);
@@ -172,7 +172,7 @@
 :is(.dark, .dark-theme),
 :is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --color-background: var(--gray-1);
-  --color-overlay: rgba(0, 0, 0, 0.75);
+  --color-overlay: var(--black-a8);
   --color-panel-solid: var(--gray-2);
   --color-panel-translucent: var(--gray-2-translucent);
   --color-surface: rgba(0, 0, 0, 0.25);
@@ -184,14 +184,15 @@
 /*                                     */
 /* * * * * * * * * * * * * * * * * * * */
 
-.radix-themes {
-  /* Because Chrome is buggy with box-shadow transitions from "transparent" keyword and/or RGB color into P3 colors */
+/* Because Chrome is buggy with box-shadow transitions from "transparent" keyword and/or RGB color into P3 colors. */
+/* Note: using `:where` here to guarantee that the P3 color will take over regardless of the output rule order. */
+:where(.radix-themes) {
   --color-transparent: rgb(0 0 0 / 0);
-  @supports (color: color(display-p3 1 1 1)) {
-    @media (color-gamut: p3) {
-      & {
-        --color-transparent: color(display-p3 0 0 0 / 0);
-      }
+}
+@supports (color: color(display-p3 1 1 1)) {
+  @media (color-gamut: p3) {
+    .radix-themes {
+      --color-transparent: color(display-p3 0 0 0 / 0);
     }
   }
 }

--- a/packages/radix-ui-themes/src/styles/tokens/shadow.css
+++ b/packages/radix-ui-themes/src/styles/tokens/shadow.css
@@ -2,34 +2,36 @@
 :where(.radix-themes) {
   --shadow-1:
     inset 0 0 0 1px var(--gray-a5),
-    inset 0 1.5px 2px 0 var(--gray-a5);
+    inset 0 1.5px 2px 0 var(--gray-a2),
+    inset 0 1.5px 2px 0 var(--black-a2);
 
   --shadow-2:
     0 0 0 1px var(--gray-a3),
-    0 0 0 0.5px var(--gray-a3),
-    0 1px 1px 0 var(--gray-a3),
-    0 2px 1px -1px var(--gray-a3),
+    0 0 0 0.5px var(--black-a1),
+    0 1px 1px 0 var(--gray-a4),
+    0 2px 1px -1px var(--black-a1),
     0 1px 3px 0 var(--black-a1);
 
   --shadow-3:
     0 0 0 1px var(--gray-a3),
     0 2px 3px -2px var(--gray-a3),
-    0 3px 12px -4px var(--gray-a4),
+    0 3px 12px -4px var(--black-a2),
     0 4px 16px -8px var(--black-a2);
 
   --shadow-4:
     0 0 0 1px var(--gray-a3),
-    0 8px 40px var(--gray-a3),
+    0 8px 40px var(--black-a1),
     0 12px 32px -16px var(--gray-a3);
 
   --shadow-5:
     0 0 0 1px var(--gray-a3),
-    0 12px 60px var(--gray-a6),
+    0 12px 60px var(--black-a3),
     0 12px 32px -16px var(--gray-a5);
 
   --shadow-6:
     0 0 0 1px var(--gray-a3),
-    0 16px 64px var(--gray-a7),
+    0 12px 60px var(--black-a3),
+    0 16px 64px var(--gray-a2),
     0 16px 36px -20px var(--gray-a7);
 }
 
@@ -67,7 +69,8 @@
 
   --shadow-6:
     0 0 0 1px var(--gray-a6),
-    0 16px 64px var(--black-a8),
+    0 12px 60px var(--black-a4),
+    0 16px 64px var(--black-a6),
     0 16px 36px -20px var(--black-a11);
 }
 
@@ -106,7 +109,8 @@
 
     --shadow-6:
       0 0 0 1px color-mix(in oklab, var(--gray-a6), var(--gray-6)),
-      0 16px 64px var(--black-a8),
+      0 12px 60px var(--black-a4),
+      0 16px 64px var(--black-a6),
       0 16px 36px -20px var(--black-a11);
   }
 }


### PR DESCRIPTION
- Desaturate light mode shadows and overlays for a more natural look
- Fix `--color-transparent` sRGB variant taking over the P3 variant, which yielded that Chrome's bug with transition through red on box shadows