### PR TITLE
fix: css-loader can't resolve `@radix-ui/themes/styles.css`

### DIFF
--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -18,7 +18,8 @@
     },
     "./styles.css": {
       "import": "./styles.css",
-      "require": "./styles.css"
+      "require": "./styles.css",
+      "default": "./styles.css"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
I attempted to import the @radix-ui/themes/styles.css file into my SCSS module, but I encountered an error regarding export limitations. The error message looked like this:

```plain
error[internal]: Package path @radix-ui/themes/styles.css is not exported in <REPOSITORY>/node_modules/@radix-ui/themes/package.json
```

It appears that the css-loader only recognizes the `default` export and ignores the `import` and `require` fields. To resolve this issue, I added a default export, and it resolved the problem.