### PR TITLE
Fix bugged Text Area selector (2.0.2)

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- Fix an issue when Chrome would sometimes crash while using CSS inspector on a Radix Themes stylesheet
+
 ## 2.0.1
 
 - `Card`

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radix-ui/themes",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",
   "module": "./dist/esm/index.js",

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -144,11 +144,10 @@
       /* Firefox */
       opacity: 1;
     }
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-      & + :where(.rt-TextAreaChrome) {
-        background-color: var(--color-autofill-root);
-        box-shadow: inset 0 0 0 1px var(--color-autofill-root), inset 0 0 0 1px var(--gray-a6);
-      }
+    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
+      + :where(.rt-TextAreaChrome) {
+      background-color: var(--color-autofill-root);
+      box-shadow: inset 0 0 0 1px var(--color-autofill-root), inset 0 0 0 1px var(--gray-a6);
     }
     &:where(:disabled, :read-only) {
       & + :where(.rt-TextAreaChrome) {
@@ -178,11 +177,10 @@
       /* Firefox */
       opacity: 1;
     }
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-      & + :where(.rt-TextAreaChrome) {
-        background-color: var(--color-autofill-root);
-        box-shadow: inset 0 0 0 1px var(--color-autofill-root), var(--shadow-1);
-      }
+    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
+      + :where(.rt-TextAreaChrome) {
+      background-color: var(--color-autofill-root);
+      box-shadow: inset 0 0 0 1px var(--color-autofill-root), var(--shadow-1);
     }
     &:where(:disabled, :read-only) {
       & + :where(.rt-TextAreaChrome) {
@@ -210,11 +208,10 @@
       color: var(--accent-12);
       opacity: 0.65;
     }
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-      & + :where(.rt-TextAreaChrome) {
-        /* Use gray autofill color when component color is gray */
-        background-color: var(--accent-a4);
-      }
+    /* Use gray autofill color when component color is gray */
+    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
+      + :where(.rt-TextAreaChrome) {
+      background-color: var(--accent-a4);
     }
     &:where(:focus) {
       /* Use gray outline when component color is gray */


### PR DESCRIPTION
Fixes a bugged CSS selector that caused Chrome crashes when interacting with CSS inspector.