### PR TITLE
Rename flex props

### DIFF
--- a/apps/playground/app/explore-components/page.tsx
+++ b/apps/playground/app/explore-components/page.tsx
@@ -1400,7 +1400,7 @@ export default function ExploreComponents() {
                       <Flex direction="column" gap="4">
                         {codePropDefs.size.values.map((size) => (
                           <Flex align="center" key={size}>
-                            <Box shrink="0" style={{ width: 80 }}>
+                            <Box flexShrink="0" style={{ width: 80 }}>
                               <Text color="gray" size="1">
                                 Size {size}
                               </Text>
@@ -2369,7 +2369,7 @@ export default function ExploreComponents() {
                         <Flex direction="column" gap="4" style={{ whiteSpace: 'nowrap' }}>
                           {kbdPropDefs.size.values.map((size) => (
                             <Flex align="center" key={size}>
-                              <Box shrink="0" style={{ width: 80 }}>
+                              <Box flexShrink="0" style={{ width: 80 }}>
                                 <Text color="gray" size="1">
                                   Size {size}
                                 </Text>
@@ -2498,7 +2498,7 @@ export default function ExploreComponents() {
                       <Flex direction="column" gap="4">
                         {linkPropDefs.size.values.map((size) => (
                           <Flex align="center" key={size}>
-                            <Box shrink="0" style={{ width: 80 }}>
+                            <Box flexShrink="0" style={{ width: 80 }}>
                               <Text color="gray" size="1">
                                 Size {size}
                               </Text>
@@ -2552,7 +2552,7 @@ export default function ExploreComponents() {
                           src="https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop"
                           fallback="A"
                         />
-                        <Box grow="1">
+                        <Box flexGrow="1">
                           <TextArea
                             size="1"
                             placeholder="Write a comment…"
@@ -2592,7 +2592,7 @@ export default function ExploreComponents() {
                           src="https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop"
                           fallback="A"
                         />
-                        <Box grow="1">
+                        <Box flexGrow="1">
                           <TextArea placeholder="Write a comment…" style={{ height: 100 }} />
                           <Flex gap="3" mt="3" justify="between">
                             <Flex align="center" gap="2" asChild>
@@ -2627,7 +2627,7 @@ export default function ExploreComponents() {
                           src="https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop"
                           fallback="A"
                         />
-                        <Box grow="1">
+                        <Box flexGrow="1">
                           <TextArea
                             size="3"
                             placeholder="Write a comment…"
@@ -2666,7 +2666,7 @@ export default function ExploreComponents() {
                           src="https://images.unsplash.com/photo-1607346256330-dee7af15f7c5?&w=64&h=64&dpr=2&q=70&crop=focalpoint&fp-x=0.67&fp-y=0.5&fp-z=1.4&fit=crop"
                           fallback="A"
                         />
-                        <Box grow="1">
+                        <Box flexGrow="1">
                           <TextArea
                             size="3"
                             placeholder="Write a comment…"
@@ -3262,7 +3262,7 @@ export default function ExploreComponents() {
                   </Link>
                 </Heading>
                 <Flex my="6" gap="9">
-                  <Box shrink="0">
+                  <Box flexShrink="0">
                     <Card size="4" style={{ width: 400 }}>
                       <Flex direction="column" gap="3">
                         <Grid gap="1">
@@ -3290,7 +3290,7 @@ export default function ExploreComponents() {
                       </Flex>
                     </Card>
                   </Box>
-                  <Box shrink="0">
+                  <Box flexShrink="0">
                     <Card size="4" style={{ width: 400 }}>
                       <Flex direction="column" gap="3">
                         <Grid gap="1">
@@ -4038,7 +4038,7 @@ export default function ExploreComponents() {
                       <Flex direction="column" gap="4" style={{ whiteSpace: 'nowrap' }}>
                         {textPropDefs.size.values.map((size) => (
                           <Flex align="center" key={size}>
-                            <Box shrink="0" style={{ width: 80 }}>
+                            <Box flexShrink="0" style={{ width: 80 }}>
                               <Text color="gray" size="1">
                                 Size {size}
                               </Text>

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4288,9 +4288,9 @@ export default function Sink() {
                         gap="5"
                       >
                         {[...new Array(6)].map((_, i) => (
-                          <Flex grow="1" align="center" justify="center" key={i}>
+                          <Flex flexGrow="1" align="center" justify="center" key={i}>
                             <Box
-                              grow="1"
+                              flexGrow="1"
                               style={{
                                 backgroundColor: 'var(--color-panel-solid)',
                                 boxShadow: `var(--shadow-${i + 1})`,

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -2,6 +2,8 @@
 
 ## 2.1.0
 
+- General
+  - Deprecate `shrink` and `grow` props in favour of `flexShrink` and `flexGrow`. The older `shrink` and `grow` props will be removed in the next major release.
 - `Button`, `IconButton`:
   - Add new `loading` prop
 - `Progress`: New component

--- a/packages/radix-ui-themes/src/helpers/props/layout.props.ts
+++ b/packages/radix-ui-themes/src/helpers/props/layout.props.ts
@@ -71,8 +71,8 @@ const layoutPropDefs = {
   left: { type: 'enum', values: positionEdgeValues, default: undefined, responsive: true },
   width: { type: 'enum', values: widthHeightValues, default: undefined, responsive: true },
   height: { type: 'enum', values: widthHeightValues, default: undefined, responsive: true },
-  shrink: { type: 'enum', values: flexShrinkValues, default: undefined, responsive: true },
-  grow: { type: 'enum', values: flexGrowValues, default: undefined, responsive: true },
+  flexShrink: { type: 'enum', values: flexShrinkValues, default: undefined, responsive: true },
+  flexGrow: { type: 'enum', values: flexGrowValues, default: undefined, responsive: true },
   gridColumn: { type: 'string', default: undefined, responsive: true },
   gridColumnStart: { type: 'string', default: undefined, responsive: true },
   gridColumnEnd: { type: 'string', default: undefined, responsive: true },
@@ -95,8 +95,8 @@ const layoutPropDefs = {
   left: PropDef<(typeof positionEdgeValues)[number]>;
   width: PropDef<(typeof widthHeightValues)[number]>;
   height: PropDef<(typeof widthHeightValues)[number]>;
-  shrink: PropDef<(typeof flexShrinkValues)[number]>;
-  grow: PropDef<(typeof flexGrowValues)[number]>;
+  flexShrink: PropDef<(typeof flexShrinkValues)[number]>;
+  flexGrow: PropDef<(typeof flexGrowValues)[number]>;
   gridColumn: PropDef<string>;
   gridColumnStart: PropDef<string>;
   gridColumnEnd: PropDef<string>;
@@ -105,7 +105,12 @@ const layoutPropDefs = {
   gridRowEnd: PropDef<string>;
 };
 
-type LayoutProps = GetPropDefTypes<typeof layoutPropDefs>;
+type LayoutProps = GetPropDefTypes<typeof layoutPropDefs> & {
+  /** @deprecated Rename this prop to `flexShrink`. The `shrink` prop will be removed in the next major release. */
+  shrink?: GetPropDefTypes<typeof layoutPropDefs>['flexShrink'];
+  /** @deprecated Rename this prop to `flexGrow`. The `grow` prop will be removed in the next major release. */
+  grow?: GetPropDefTypes<typeof layoutPropDefs>['flexGrow'];
+};
 
 function extractLayoutProps<T extends LayoutProps>(props: T) {
   const { rest: paddingRest, ...paddingProps } = extractPaddingProps(props);
@@ -118,8 +123,10 @@ function extractLayoutProps<T extends LayoutProps>(props: T) {
     bottom = layoutPropDefs.bottom.default,
     left = layoutPropDefs.left.default,
     right = layoutPropDefs.right.default,
-    shrink = layoutPropDefs.shrink.default,
-    grow = layoutPropDefs.grow.default,
+    shrink = layoutPropDefs.flexShrink.default,
+    grow = layoutPropDefs.flexGrow.default,
+    flexShrink = layoutPropDefs.flexShrink.default,
+    flexGrow = layoutPropDefs.flexGrow.default,
     gridColumn = layoutPropDefs.gridColumn.default,
     gridColumnStart = layoutPropDefs.gridColumnStart.default,
     gridColumnEnd = layoutPropDefs.gridColumnEnd.default,
@@ -138,8 +145,8 @@ function extractLayoutProps<T extends LayoutProps>(props: T) {
     bottom,
     left,
     right,
-    shrink,
-    grow,
+    flexShrink,
+    flexGrow,
     gridColumn,
     gridColumnStart,
     gridColumnEnd,
@@ -151,11 +158,11 @@ function extractLayoutProps<T extends LayoutProps>(props: T) {
 }
 
 function getLayoutStyles(props: LayoutProps) {
-  const baseLayoutClassNamess = classNames(
+  const baseLayoutClassNames = classNames(
     withPaddingProps(props),
     withBreakpoints(props.position, 'rt-r-position'),
-    withBreakpoints(props.shrink, 'rt-r-fs'),
-    withBreakpoints(props.grow, 'rt-r-fg'),
+    withBreakpoints(props.flexShrink ?? props.shrink, 'rt-r-fs'),
+    withBreakpoints(props.flexGrow ?? props.grow, 'rt-r-fg'),
     withBreakpoints(props.width, 'rt-r-w'),
     withBreakpoints(props.height, 'rt-r-h'),
     withBreakpoints(props.inset, 'rt-r-inset'),
@@ -203,7 +210,7 @@ function getLayoutStyles(props: LayoutProps) {
 
   return [
     classNames(
-      baseLayoutClassNamess,
+      baseLayoutClassNames,
       gridColumnClassNames,
       gridColumnStartClassNames,
       gridColumnEndClassNames,

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -203,7 +203,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
           }}
         >
           <ScrollArea>
-            <Box grow="1" p="5" position="relative">
+            <Box flexGrow="1" p="5" position="relative">
               <Box position="absolute" top="0" right="0" m="2">
                 <Tooltip
                   content="Press ⌘&thinsp;C to show/hide the Theme Panel"


### PR DESCRIPTION
Deprecate `shrink` and `grow` props in favour of `flexShrink` and `flexGrow`. The older `shrink` and `grow` props will be removed in the next major release.