### PR TITLE
Add contributor docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,7 +92,7 @@ git push -u origin HEAD
 
 ## Working locally
 
-The repo is managed with Yarn Workspaces.
+The repo is managed with [Yarn Workspaces](https://yarnpkg.com/features/workspaces) and [Turborepo](https://turbo.build/repo).
 
 ### Development
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to Radix Themes
+
+## Code of Conduct
+
+Radix has adopted the [Contributor Covenant](https://www.contributor-covenant.org/) as its Code of Conduct, and we expect project participants to adhere to it.
+
+Please read [the full text](/CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+
+## Heuristics
+
+[heuristic](<https://en.wikipedia.org/wiki/Heuristic_(computer_science)>)
+/ˌhjʊ(ə)ˈrɪstɪk/
+
+> A technique designed for solving a problem more quickly when classic methods are too slow, or for finding an approximate solution when classic methods fail to find any exact solution
+
+- Priority is the best User Experience
+- Complexity should be introduced when it’s inevitable
+- Code should be easy to reason about
+- Code should be easy to delete
+- Avoid abstracting too early
+- Avoid thinking too far in the future
+
+## Questions
+
+If you have questions about Radix Themes, be sure to check out the docs where we have several examples and detailed API references that may help you solve your problem. You can also share your questions on [GitHub Discussions](https://github.com/radix-ui/themes/discussions).
+
+## How to contribute
+
+There are many ways to contribute to the project. Code is just one possible means of contribution.
+
+- **Feedback.** Tell us what we're doing well or where we can improve.
+- **Support.** You can answer questions on StackOverflow or [GitHub Discussions](https://github.com/radix-ui/themes/discussions), or provide solutions for others in [open issues](https://github.com/radix-ui/themes/issues).
+- **Write.** If you come up with an interesting example, write about it. Post it to your blog and share it with us. We'd love to see what folks in the community build with Radix Themes!
+- **Report.** Create issues with bug reports so we can make Radix Themes even better.
+
+## Working on your first Pull Request?
+
+There are a lot of great resources on creating a good pull request. We've included a few below, but don't be shy—we appreciate all contributions and are happy to help those who are willing to help us!
+
+- [How to Contribute to a Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
+## Preparing a Pull Request
+
+[Pull Requests](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) are always welcome, but before working on a large change, it is best to open an issue first to discuss it with maintainers.
+
+A good PR is small, focuses on a single feature or improvement, and clearly communicates the problem it solves. Try not to include more than one issue in a single PR. It's much easier for us to review multiple small pull requests than one that is large and unwieldy.
+
+1. [Fork the repository](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).
+
+2. Clone the fork to your local machine and add upstream remote:
+
+```sh
+git clone https://github.com/<your username>/themes.git
+cd themes
+git remote add upstream https://github.com/radix-ui/themes.git
+```
+
+1. Synchronize your local `main` branch with the upstream remote:
+
+```sh
+git checkout main
+git pull upstream main
+```
+
+1. Make sure your Node version matches the [.nvmrc](../.nvmrc).
+
+```
+node -v
+```
+
+1. Install dependencies with [yarn](https://yarnpkg.com):
+
+```sh
+yarn install
+```
+
+1. Create a new branch related to your PR:
+
+```sh
+git checkout -b my-bug-fix
+```
+
+6. Make changes, then commit and push to your forked repository:
+
+```sh
+git push -u origin HEAD
+```
+
+7. Go to [the repository](https://github.com/radix-ui/themes/pulls) and [make a Pull Request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+8. We will review your Pull Request and either merge it, request changes to it, or close it with an explanation.
+
+## Working locally
+
+The repo is managed with Yarn Workspaces.
+
+### Development
+
+```bash
+# install dependencies
+yarn install
+
+# start Storybook and see examples in the browser
+yarn dev
+```
+
+After staring the development server, navigate to `http://localhost:3000/sink` to view the playground. Visit other demos by navigating to pages in the app directory (./app/\*), such as `/demo`, `/explore-components`, `/home-os`.
+
+Make your changes and check that they resolve the problem with an example in `/sink` or another demo page. If there are no examples in the playground to support your change, we suggest adding one and then running local development to make sure nothing is broken.
+
+Lastly, run `yarn build` to ensure that the build runs successfully before submitting the pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+
+Thank you for contributing! Please follow the steps below to help us process your PR quickly.
+
+- 📝 Use a meaningful title for the pull request and include the name of the package modified.
+- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
+- 🙏 Please review your own PR to check for anything you may have missed.
+
+-->
+
+## Description
+
+<!-- Describe the change you are introducing -->
+
+## Testing steps
+
+<!-- Describe step by step how to test the change being introduced -->
+
+## Relates issues / PRs
+
+<!-- List out related issues and PR links -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at colm@workos.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ For changelog, visit [radix-ui.com/themes/docs/overview/releases](https://radix-
 - [Discord](https://discord.com/invite/7Xb99uG) - To get involved with the Radix community, ask questions and share tips.
 - [Twitter](https://twitter.com/radix_ui) - To receive updates, announcements, blog posts, and general Radix tips.
 
+## Local Development
+
+Fork the repository and clone it down to your machine. Then run `yarn && yarn dev` to start the development server, navigate to `http://localhost:3000/sink` to view the playground. Visit other demos by navigating to pages in the app directory (./app/\*), such as `/demo`, `/explore-components`, `/home-os`.
+
 ## License
 
 Licensed under the MIT License, Copyright © 2023-present [WorkOS](https://workos.com).

--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ For changelog, visit [radix-ui.com/themes/docs/overview/releases](https://radix-
 
 ## Community
 
+See our [contribution guidelines](./.github/CONTRIBUTING.md) for information on local development and creating a pull request.
+
+- [Github Discussions](https://github.com/radix-ui/themes/discussions) - Ask questions and get answers from other community members.
 - [Discord](https://discord.com/invite/7Xb99uG) - To get involved with the Radix community, ask questions and share tips.
 - [Twitter](https://twitter.com/radix_ui) - To receive updates, announcements, blog posts, and general Radix tips.
-
-## Local Development
-
-Fork the repository and clone it down to your machine. Then run `yarn && yarn dev` to start the development server, navigate to `http://localhost:3000/sink` to view the playground. Visit other demos by navigating to pages in the app directory (./app/\*), such as `/demo`, `/explore-components`, `/home-os`.
 
 ## License
 


### PR DESCRIPTION
This PR adds contributor docs using the primitives docs as a starting point. Also adds code of conduct and PR template. 