### PR TITLE
tabs: Pass color prop

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -170,6 +170,7 @@ import {
   TabsTrigger,
   TabsContent,
   tabsListPropDefs,
+  tabsRootPropDefs,
   //
   TextArea,
   textAreaPropDefs,
@@ -4059,7 +4060,7 @@ export default function Sink() {
                         </Text>
                       </summary>
                       <Grid gap="5" columns="2" align="center">
-                        {tabsListPropDefs.color.values.map((color) => (
+                        {tabsRootPropDefs.color.values.map((color) => (
                           <React.Fragment key={color}>
                             <Text>{color}</Text>
                             <Flex>

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -170,7 +170,6 @@ import {
   TabsTrigger,
   TabsContent,
   tabsListPropDefs,
-  tabsRootPropDefs,
   //
   TextArea,
   textAreaPropDefs,
@@ -4060,16 +4059,12 @@ export default function Sink() {
                         </Text>
                       </summary>
                       <Grid gap="5" columns="2" align="center">
-                        {tabsRootPropDefs.color.values.map((color) => (
+                        {tabsListPropDefs.color.values.map((color) => (
                           <React.Fragment key={color}>
                             <Text>{color}</Text>
                             <Flex>
-                              <TabsRoot
-                                defaultValue="account"
-                                activationMode="manual"
-                                color={color}
-                              >
-                                <TabsList size="1">
+                              <TabsRoot defaultValue="account" activationMode="manual">
+                                <TabsList size="1" color={color}>
                                   <TabsTrigger value="account">Account</TabsTrigger>
                                   <TabsTrigger value="documents">Documents</TabsTrigger>
                                   <TabsTrigger value="settings">Settings</TabsTrigger>

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4049,6 +4049,45 @@ export default function Sink() {
                         ))}
                       </tbody>
                     </table>
+                    <Text as="p" my="5">
+                      <Code>color</Code> can be set per instance:
+                    </Text>
+                    <details>
+                      <summary>
+                        <Text size="2" color="gray">
+                          See color combinations
+                        </Text>
+                      </summary>
+                      <Grid gap="5" columns="2" align="center">
+                        {tabsListPropDefs.color.values.map((color) => (
+                          <React.Fragment key={color}>
+                            <Text>{color}</Text>
+                            <Flex>
+                              <TabsRoot
+                                defaultValue="account"
+                                activationMode="manual"
+                                color={color}
+                              >
+                                <TabsList size="1">
+                                  <TabsTrigger value="account">Account</TabsTrigger>
+                                  <TabsTrigger value="documents">Documents</TabsTrigger>
+                                  <TabsTrigger value="settings">Settings</TabsTrigger>
+                                </TabsList>
+                                <TabsContent value="account">
+                                  <Box py="5">Account</Box>
+                                </TabsContent>
+                                <TabsContent value="documents">
+                                  <Box py="5">Documents</Box>
+                                </TabsContent>
+                                <TabsContent value="settings">
+                                  <Box py="5">Settings</Box>
+                                </TabsContent>
+                              </TabsRoot>
+                            </Flex>
+                          </React.Fragment>
+                        ))}
+                      </Grid>
+                    </details>
                   </DocsSection>
 
                   <DocsSection title="AspectRatio">

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4058,13 +4058,31 @@ export default function Sink() {
                           See color combinations
                         </Text>
                       </summary>
-                      <Grid gap="5" columns="2" align="center">
-                        {tabsListPropDefs.color.values.map((color) => (
+                      <Grid gap="5" columns="3" align="center">
+                        {tabsListPropDefs.color.values.map((color, i) => (
                           <React.Fragment key={color}>
                             <Text>{color}</Text>
                             <Flex>
                               <TabsRoot defaultValue="account" activationMode="manual">
                                 <TabsList size="1" color={color}>
+                                  <TabsTrigger value="account">Account</TabsTrigger>
+                                  <TabsTrigger value="documents">Documents</TabsTrigger>
+                                  <TabsTrigger value="settings">Settings</TabsTrigger>
+                                </TabsList>
+                                <TabsContent value="account">
+                                  <Box py="5">Account</Box>
+                                </TabsContent>
+                                <TabsContent value="documents">
+                                  <Box py="5">Documents</Box>
+                                </TabsContent>
+                                <TabsContent value="settings">
+                                  <Box py="5">Settings</Box>
+                                </TabsContent>
+                              </TabsRoot>
+                            </Flex>
+                            <Flex>
+                              <TabsRoot defaultValue="account" activationMode="manual">
+                                <TabsList size="1" color={color} highContrast>
                                   <TabsTrigger value="account">Account</TabsTrigger>
                                   <TabsTrigger value="documents">Documents</TabsTrigger>
                                   <TabsTrigger value="settings">Settings</TabsTrigger>

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -9,6 +9,8 @@
   - Change the size of the bounding box to match the size of the Slider track
 - `Skeleton`: New component
 - `Spinner`: New component
+- `Tabs`:
+  - Add `color` and `highContrast` props to `TabsList`
 
 ## 2.0.3
 

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -106,7 +106,7 @@
   --tabs-list-active-accent: var(--accent-10);
 
   &.rt-high-contrast {
-    --tabs-list-active-accent: var(--accent-11);
+    --tabs-list-active-accent: var(--accent-12);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -137,7 +137,7 @@
     background-color: var(--accent-10);
   }
 
-  .rt-TabsList.rt-high-contrast & {
+  :where(.rt-TabsList.rt-high-contrast) & {
     &:where([data-state='active'])::before {
       background-color: var(--accent-12);
     }

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -103,6 +103,11 @@
 
 .rt-TabsList {
   box-shadow: inset 0 -1px 0 0 var(--gray-a5);
+  --tabs-list-active-accent: var(--accent-10);
+
+  &.rt-high-contrast {
+    --tabs-list-active-accent: var(--accent-11);
+  }
 }
 
 .rt-TabsTrigger {
@@ -134,7 +139,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: var(--accent-10);
+    background-color: var(--tabs-list-active-accent);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -139,7 +139,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: var(--tabs-list-active-accent);
+    background-color: var(--accent-10);
+    
+    :where(.rt-TabsTrigger.rt-high-contrast) & {
+      background-color: var(--accent-12);
+    }
+  }
   }
 }
 

--- a/packages/radix-ui-themes/src/components/tabs.css
+++ b/packages/radix-ui-themes/src/components/tabs.css
@@ -103,11 +103,6 @@
 
 .rt-TabsList {
   box-shadow: inset 0 -1px 0 0 var(--gray-a5);
-  --tabs-list-active-accent: var(--accent-10);
-
-  &.rt-high-contrast {
-    --tabs-list-active-accent: var(--accent-12);
-  }
 }
 
 .rt-TabsTrigger {
@@ -140,11 +135,12 @@
     left: 0;
     right: 0;
     background-color: var(--accent-10);
-    
-    :where(.rt-TabsTrigger.rt-high-contrast) & {
+  }
+
+  .rt-TabsList.rt-high-contrast & {
+    &:where([data-state='active'])::before {
       background-color: var(--accent-12);
     }
-  }
   }
 }
 

--- a/packages/radix-ui-themes/src/components/tabs.props.ts
+++ b/packages/radix-ui-themes/src/components/tabs.props.ts
@@ -4,10 +4,14 @@ const sizes = ['1', '2'] as const;
 
 const tabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2', responsive: true },
-  color: { ...colorProp, default: undefined },
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
+};
+
+const tabsRootPropDefs = {
+  color: { ...colorProp, default: undefined },
+} satisfies {
   color: typeof colorProp;
 };
 
-export { tabsListPropDefs };
+export { tabsListPropDefs, tabsRootPropDefs };

--- a/packages/radix-ui-themes/src/components/tabs.props.ts
+++ b/packages/radix-ui-themes/src/components/tabs.props.ts
@@ -1,11 +1,13 @@
-import { PropDef } from '../helpers';
+import { PropDef, colorProp } from '../helpers';
 
 const sizes = ['1', '2'] as const;
 
 const tabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2', responsive: true },
+  color: { ...colorProp, default: undefined },
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
+  color: typeof colorProp;
 };
 
 export { tabsListPropDefs };

--- a/packages/radix-ui-themes/src/components/tabs.props.ts
+++ b/packages/radix-ui-themes/src/components/tabs.props.ts
@@ -4,14 +4,10 @@ const sizes = ['1', '2'] as const;
 
 const tabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2', responsive: true },
-} satisfies {
-  size: PropDef<(typeof sizes)[number]>;
-};
-
-const tabsRootPropDefs = {
   color: { ...colorProp, default: undefined },
 } satisfies {
+  size: PropDef<(typeof sizes)[number]>;
   color: typeof colorProp;
 };
 
-export { tabsListPropDefs, tabsRootPropDefs };
+export { tabsListPropDefs };

--- a/packages/radix-ui-themes/src/components/tabs.props.ts
+++ b/packages/radix-ui-themes/src/components/tabs.props.ts
@@ -1,13 +1,15 @@
-import { PropDef, colorProp } from '../helpers';
+import { PropDef, colorProp, highContrastProp } from '../helpers';
 
 const sizes = ['1', '2'] as const;
 
 const tabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2', responsive: true },
   color: { ...colorProp, default: undefined },
+  highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
   color: typeof colorProp;
+  highContrast: typeof highContrastProp;
 };
 
 export { tabsListPropDefs };

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -3,17 +3,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { tabsListPropDefs } from './tabs.props';
+import { tabsListPropDefs, tabsRootPropDefs } from './tabs.props';
 import { extractMarginProps, withMarginProps, withBreakpoints } from '../helpers';
-import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor, colorProp } from '../helpers';
 
 type TabsRootElement = React.ElementRef<typeof TabsPrimitive.Root>;
+type TabsRootOwnProps = GetPropDefTypes<typeof tabsRootPropDefs>;
 interface TabsRootProps
-  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>,
-    MarginProps {}
+  extends PropsWithoutRefOrColor<typeof TabsPrimitive.Root>,
+    MarginProps,
+    TabsRootOwnProps {}
 const TabsRoot = React.forwardRef<TabsRootElement, TabsRootProps>((props, forwardedRef) => {
-  const { rest: marginRest, ...marginProps } = extractMarginProps(props);
-  const { className, color, ...rootProps } = marginRest;
+  const { rest, ...marginProps } = extractMarginProps(props);
+  const { className, color, ...rootProps } = rest;
   return (
     <TabsPrimitive.Root
       data-accent-color={color}

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -5,8 +5,7 @@ import classNames from 'classnames';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import { tabsListPropDefs } from './tabs.props';
 import { extractMarginProps, withMarginProps, withBreakpoints } from '../helpers';
-
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type TabsRootElement = React.ElementRef<typeof TabsPrimitive.Root>;
 interface TabsRootProps
@@ -14,9 +13,10 @@ interface TabsRootProps
     MarginProps {}
 const TabsRoot = React.forwardRef<TabsRootElement, TabsRootProps>((props, forwardedRef) => {
   const { rest: marginRest, ...marginProps } = extractMarginProps(props);
-  const { className, ...rootProps } = marginRest;
+  const { className, color, ...rootProps } = marginRest;
   return (
     <TabsPrimitive.Root
+      data-accent-color={color}
       {...rootProps}
       ref={forwardedRef}
       className={classNames('rt-TabsRoot', className, withMarginProps(marginProps))}
@@ -28,7 +28,7 @@ TabsRoot.displayName = 'TabsRoot';
 type TabsListElement = React.ElementRef<typeof TabsPrimitive.List>;
 type TabsListOwnProps = GetPropDefTypes<typeof tabsListPropDefs>;
 interface TabsListProps
-  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>,
+  extends PropsWithoutRefOrColor<typeof TabsPrimitive.List>,
     TabsListOwnProps {}
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
   const { className, size = tabsListPropDefs.size.default, ...listProps } = props;

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -30,7 +30,7 @@ TabsRoot.displayName = 'TabsRoot';
 type TabsListElement = React.ElementRef<typeof TabsPrimitive.List>;
 type TabsListOwnProps = GetPropDefTypes<typeof tabsListPropDefs>;
 interface TabsListProps
-  extends PropsWithoutRefOrColor<typeof TabsPrimitive.List>,
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>,
     TabsListOwnProps {}
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
   const { className, size = tabsListPropDefs.size.default, ...listProps } = props;

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -3,22 +3,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { tabsListPropDefs, tabsRootPropDefs } from './tabs.props';
+import { tabsListPropDefs } from './tabs.props';
 import { extractMarginProps, withMarginProps, withBreakpoints } from '../helpers';
 import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor, colorProp } from '../helpers';
 
 type TabsRootElement = React.ElementRef<typeof TabsPrimitive.Root>;
-type TabsRootOwnProps = GetPropDefTypes<typeof tabsRootPropDefs>;
 interface TabsRootProps
-  extends PropsWithoutRefOrColor<typeof TabsPrimitive.Root>,
-    MarginProps,
-    TabsRootOwnProps {}
+  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>,
+    MarginProps {}
 const TabsRoot = React.forwardRef<TabsRootElement, TabsRootProps>((props, forwardedRef) => {
-  const { rest, ...marginProps } = extractMarginProps(props);
-  const { className, color, ...rootProps } = rest;
+  const { rest: marginRest, ...marginProps } = extractMarginProps(props);
+  const { className, ...rootProps } = marginRest;
   return (
     <TabsPrimitive.Root
-      data-accent-color={color}
       {...rootProps}
       ref={forwardedRef}
       className={classNames('rt-TabsRoot', className, withMarginProps(marginProps))}
@@ -30,12 +27,13 @@ TabsRoot.displayName = 'TabsRoot';
 type TabsListElement = React.ElementRef<typeof TabsPrimitive.List>;
 type TabsListOwnProps = GetPropDefTypes<typeof tabsListPropDefs>;
 interface TabsListProps
-  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>,
+  extends PropsWithoutRefOrColor<typeof TabsPrimitive.List>,
     TabsListOwnProps {}
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
-  const { className, size = tabsListPropDefs.size.default, ...listProps } = props;
+  const { className, size = tabsListPropDefs.size.default, color, ...listProps } = props;
   return (
     <TabsPrimitive.List
+      data-accent-color={color}
       {...listProps}
       ref={forwardedRef}
       className={classNames('rt-TabsList', className, withBreakpoints(size, 'rt-r-size'))}

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -30,13 +30,21 @@ interface TabsListProps
   extends PropsWithoutRefOrColor<typeof TabsPrimitive.List>,
     TabsListOwnProps {}
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
-  const { className, size = tabsListPropDefs.size.default, color, ...listProps } = props;
+  const {
+    className,
+    size = tabsListPropDefs.size.default,
+    color,
+    highContrast,
+    ...listProps
+  } = props;
   return (
     <TabsPrimitive.List
       data-accent-color={color}
       {...listProps}
       ref={forwardedRef}
-      className={classNames('rt-TabsList', className, withBreakpoints(size, 'rt-r-size'))}
+      className={classNames('rt-TabsList', className, withBreakpoints(size, 'rt-r-size'), {
+        'rt-high-contrast': highContrast,
+      })}
     />
   );
 });


### PR DESCRIPTION
## Description

Support the `color` prop to control the color of the active tab trigger. 

<img width="1048" alt="Screenshot 2024-01-10 at 9 41 50 AM" src="https://github.com/radix-ui/themes/assets/36613477/3d13b5ad-1410-4c55-b246-b19cffd45913">

## Testing steps

Visit the [sink page ](https://themes-playground-git-ksadd-tabs-color-prop-modulz.vercel.app/sink#Tabs)to verify the colors are properly set in the examples and the default is the global accent color.

## Relates issues / PRs

Addresses #205 
