### PR TITLE
[b] Add DataList component with `direction`

### DIFF
--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import {
+  DataListRoot,
+  DataListData,
+  DataListItem,
+  DataListLabel,
+  Theme,
+  Container,
+  Text,
+} from '@radix-ui/themes';
+
+export default function DataListPage() {
+  return (
+    <html>
+      <body>
+        <Theme>
+          <Container m="6">
+            <Text weight="medium">Default</Text>
+            <DataListRoot mt="2">
+              <DataListItem>
+                <DataListLabel>Obi wan</DataListLabel>
+                <DataListData>Jedi Master</DataListData>
+              </DataListItem>
+              <DataListItem>
+                <DataListLabel>Anakin</DataListLabel>
+                <DataListData>Padewan</DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+          <Container m="6">
+            <Text weight="medium">Vertical Layout</Text>
+            <DataListRoot layout="vertical" mt="2">
+              <DataListItem>
+                <DataListLabel>Obi wan</DataListLabel>
+                <DataListData>Jedi Master</DataListData>
+              </DataListItem>
+              <DataListItem>
+                <DataListLabel>Anakin</DataListLabel>
+                <DataListData>Padewan</DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+          <Container m="6">
+            <Text weight="medium">Varied data</Text>
+            <DataListRoot mt="2">
+              <DataListItem>
+                <DataListLabel>Name</DataListLabel>
+                <DataListData>Jane Roe</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Email</DataListLabel>
+                <DataListData>janeroe@foo-corp.com</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Organization</DataListLabel>
+                <DataListData>
+                  <Link href="https://foo-corp.com">Foo Corp</Link>
+                </DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+        </Theme>
+      </body>
+    </html>
+  );
+}

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -90,7 +90,7 @@ export default function DataListPage() {
                   <DataListData>janeroe@foo-corpcom</DataListData>
                 </DataListItem>
 
-                <DataListItem align="center">
+                <DataListItem align="end">
                   <DataListLabel>Authentication</DataListLabel>
                   <DataListData>
                     <Flex gap="2" mx="-1">
@@ -106,9 +106,9 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With varied content
               </Heading>
-              <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}>
+              <DataListRoot direction={{ initial: 'column', sm: 'row' }} mt="9">
                 <DataListItem>
-                  <DataListLabel>Status</DataListLabel>
+                  <DataListLabel>Status!!!!!!!</DataListLabel>
                   <DataListData>
                     <Badge color="green" size="1" style={{ marginLeft: -2 }}>
                       Active
@@ -213,7 +213,7 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With long label
               </Heading>
-              <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}>
+              <DataListRoot direction="column">
                 <DataListItem>
                   <DataListLabel>Name</DataListLabel>
                   <DataListData>Vlad Moroz</DataListData>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -1,66 +1,242 @@
 import Link from 'next/link';
 import {
+  Badge,
+  Box,
   DataListRoot,
   DataListData,
   DataListItem,
   DataListLabel,
+  Flex,
   Theme,
   Container,
   Text,
+  Heading,
+  Button,
+  IconButton,
 } from '@radix-ui/themes';
+import { StarIcon, MagicWandIcon, StarFilledIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 
 export default function DataListPage() {
   return (
     <html>
       <body>
         <Theme>
-          <Container m="6">
-            <Text weight="medium">Default</Text>
-            <DataListRoot mt="2">
-              <DataListItem>
-                <DataListLabel>Obi wan</DataListLabel>
-                <DataListData>Jedi Master</DataListData>
-              </DataListItem>
-              <DataListItem>
-                <DataListLabel>Anakin</DataListLabel>
-                <DataListData>Padewan</DataListData>
-              </DataListItem>
-            </DataListRoot>
-          </Container>
-          <Container m="6">
-            <Text weight="medium">Vertical Layout</Text>
-            <DataListRoot layout="vertical" mt="2">
-              <DataListItem>
-                <DataListLabel>Obi wan</DataListLabel>
-                <DataListData>Jedi Master</DataListData>
-              </DataListItem>
-              <DataListItem>
-                <DataListLabel>Anakin</DataListLabel>
-                <DataListData>Padewan</DataListData>
-              </DataListItem>
-            </DataListRoot>
-          </Container>
-          <Container m="6">
-            <Text weight="medium">Varied data</Text>
-            <DataListRoot mt="2">
-              <DataListItem>
-                <DataListLabel>Name</DataListLabel>
-                <DataListData>Jane Roe</DataListData>
-              </DataListItem>
+          <Box ml="5" style={{ maxWidth: '688px;', margin: 'auto' }}>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium" mb="2">
+                Default
+              </Text>
+              <DataListRoot mt="2">
+                <DataListItem>
+                  <DataListLabel>Obi wan</DataListLabel>
+                  <DataListData>Jedi Master</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Anakin</DataListLabel>
+                  <DataListData>Padewan</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Vertical Layout</Text>
+              <DataListRoot direction="column" mt="2">
+                <DataListItem>
+                  <DataListLabel>Obi wan</DataListLabel>
+                  <DataListData>Jedi Master</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Anakin</DataListLabel>
+                  <DataListData>Padewan</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Varied data</Text>
+              <DataListRoot mt="2" direction="column">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Jane Roe</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>janeroe@foo-corp.com</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Organization</DataListLabel>
+                  <DataListData>
+                    <Link href="https://foo-corp.com">Foo Corp</Link>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Varied data 2</Text>
+              <DataListRoot direction="row">
+                <DataListItem>
+                  <DataListLabel>Status</DataListLabel>
+                  <DataListData>
+                    <Badge color="green" size="1" style={{ marginLeft: -2 }}>
+                      Active
+                    </Badge>
+                  </DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Jane Roe</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Email</DataListLabel>
-                <DataListData>janeroe@foo-corp.com</DataListData>
-              </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>janeroe@foo-corpcom</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Organization</DataListLabel>
-                <DataListData>
-                  <Link href="https://foo-corp.com">Foo Corp</Link>
-                </DataListData>
-              </DataListItem>
-            </DataListRoot>
-          </Container>
+                <DataListItem align="center">
+                  <DataListLabel>Authentication</DataListLabel>
+                  <DataListData>
+                    <Flex gap="2" mx="-1">
+                      <StarIcon />
+                      <MagicWandIcon />
+                      <StarFilledIcon />
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With varied content
+              </Heading>
+              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
+              <DataListRoot direction="row">
+                <DataListItem>
+                  <DataListLabel>Status</DataListLabel>
+                  <DataListData>
+                    <Badge color="green" size="1" style={{ marginLeft: -2 }}>
+                      Active
+                    </Badge>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem align="center">
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>
+                    <Button size="1">Add</Button>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Organization</DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Long value</DataListLabel>
+                  <DataListData>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ac nisl et libero
+                    ultricies viverra quis vitae quam. Proin a feugiat metus.
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem align="center">
+                  <DataListLabel>Authentication methods</DataListLabel>
+                  <DataListData>
+                    <Flex gap="2">
+                      <StarFilledIcon />
+                      <StarFilledIcon />
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Long value</DataListLabel>
+                  <DataListData>
+                    Sed luctus, est id feugiat blandit, sapien nisl lobortis arcu, eu malesuada
+                    nulla ex ut lorem. In odio nisl, consectetur id commodo vel, posuere eu risus.
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With nested flex
+              </Heading>
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={80}>Appearance</DataListLabel>
+                  <DataListData>
+                    <Flex align="center" gap="1">
+                      <IconButton size="1">
+                        <InfoCircledIcon />
+                      </IconButton>
+                      <Text>System</Text>
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                One after another
+              </Heading>
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={130}>Appearance</DataListLabel>
+                  <DataListData>System</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel width={130}>Radius</DataListLabel>
+                  <DataListData>Medium</DataListData>
+                </DataListItem>
+              </DataListRoot>
+
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={130}>Page background</DataListLabel>
+                  <DataListData>White</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel width={130}>Link color</DataListLabel>
+                  <DataListData>Blue</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With long label
+              </Heading>
+              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
+              <DataListRoot direction="row">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Vlad Moroz</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>
+                    Lorem ipsum dolor sit amet consectetur adipscing elit
+                  </DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+          </Box>
         </Theme>
       </body>
     </html>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -106,8 +106,7 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With varied content
               </Heading>
-              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
-              <DataListRoot direction="row">
+              <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}>
                 <DataListItem>
                   <DataListLabel>Status</DataListLabel>
                   <DataListData>
@@ -214,8 +213,7 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With long label
               </Heading>
-              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
-              <DataListRoot direction="row">
+              <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}>
                 <DataListItem>
                   <DataListLabel>Name</DataListLabel>
                   <DataListData>Vlad Moroz</DataListData>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -21,7 +21,7 @@ export default function DataListPage() {
     <html>
       <body>
         <Theme>
-          <Box ml="5" style={{ maxWidth: '688px;', margin: 'auto' }}>
+          <Box ml="5" style={{ maxWidth: '688px', margin: 'auto' }}>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium" mb="2">
                 Default

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,0 +1,216 @@
+:where(.DataListRoot) {
+  margin: 0;
+}
+
+@breakpoints {
+  .DataListRoot.gap-0 {
+    --data-list-gap-x: 0px;
+    --data-list-gap-y: 0px;
+  }
+  .DataListRoot.gap-1 {
+    --data-list-gap-x: var(--space-1);
+    --data-list-gap-y: var(--space-1);
+  }
+  .DataListRoot.gap-2 {
+    --data-list-gap-x: var(--space-2);
+    --data-list-gap-y: var(--space-2);
+  }
+  .DataListRoot.gap-3 {
+    --data-list-gap-x: var(--space-3);
+    --data-list-gap-y: var(--space-3);
+  }
+  .DataListRoot.gap-4 {
+    --data-list-gap-x: var(--space-4);
+    --data-list-gap-y: var(--space-4);
+  }
+  .DataListRoot.gap-5 {
+    --data-list-gap-x: var(--space-5);
+    --data-list-gap-y: var(--space-5);
+  }
+  .DataListRoot.gap-6 {
+    --data-list-gap-x: var(--space-6);
+    --data-list-gap-y: var(--space-6);
+  }
+  .DataListRoot.gap-7 {
+    --data-list-gap-x: var(--space-7);
+    --data-list-gap-y: var(--space-7);
+  }
+  .DataListRoot.gap-8 {
+    --data-list-gap-x: var(--space-8);
+    --data-list-gap-y: var(--space-8);
+  }
+  .DataListRoot.gap-9 {
+    --data-list-gap-x: var(--space-9);
+    --data-list-gap-y: var(--space-9);
+  }
+
+  .DataListRoot.gap-x-0 {
+    --data-list-gap-x: 0px;
+  }
+  .DataListRoot.gap-x-1 {
+    --data-list-gap-x: var(--space-1);
+  }
+  .DataListRoot.gap-x-2 {
+    --data-list-gap-x: var(--space-2);
+  }
+  .DataListRoot.gap-x-3 {
+    --data-list-gap-x: var(--space-3);
+  }
+  .DataListRoot.gap-x-4 {
+    --data-list-gap-x: var(--space-4);
+  }
+  .DataListRoot.gap-x-5 {
+    --data-list-gap-x: var(--space-5);
+  }
+  .DataListRoot.gap-x-6 {
+    --data-list-gap-x: var(--space-6);
+  }
+  .DataListRoot.gap-x-7 {
+    --data-list-gap-x: var(--space-7);
+  }
+  .DataListRoot.gap-x-8 {
+    --data-list-gap-x: var(--space-8);
+  }
+  .DataListRoot.gap-x-9 {
+    --data-list-gap-x: var(--space-9);
+  }
+
+  .DataListRoot.gap-y-0 {
+    --data-list-gap-y: 0px;
+  }
+  .DataListRoot.gap-y-1 {
+    --data-list-gap-y: var(--space-1);
+  }
+  .DataListRoot.gap-y-2 {
+    --data-list-gap-y: var(--space-2);
+  }
+  .DataListRoot.gap-y-3 {
+    --data-list-gap-y: var(--space-3);
+  }
+  .DataListRoot.gap-y-4 {
+    --data-list-gap-y: var(--space-4);
+  }
+  .DataListRoot.gap-y-5 {
+    --data-list-gap-y: var(--space-5);
+  }
+  .DataListRoot.gap-y-6 {
+    --data-list-gap-y: var(--space-6);
+  }
+  .DataListRoot.gap-y-7 {
+    --data-list-gap-y: var(--space-7);
+  }
+  .DataListRoot.gap-y-8 {
+    --data-list-gap-y: var(--space-8);
+  }
+  .DataListRoot.gap-y-9 {
+    --data-list-gap-y: var(--space-9);
+  }
+}
+
+/* prettier-ignore */
+.DataListRoot::before,
+  .DataListRoot::after {
+    /* Remove top and bottom item padding */
+    --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
+    /* Include padding trim when leading trim is used */
+    --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
+    --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
+    display: table;
+    content: '';
+  }
+:where(.DataListRoot)::before {
+  margin-bottom: var(--data-list-padding-trim);
+}
+:where(.DataListRoot)::after {
+  margin-top: var(--data-list-padding-trim);
+}
+
+/* Make sure that consecutive data lists are spaced, regardless of leading trim */
+.DataListRoot:has(+ .DataListRoot)::after,
+.DataListRoot + .DataListRoot::before {
+  display: none;
+}
+
+.DataListItem {
+  position: relative;
+  box-sizing: border-box;
+}
+
+@breakpoints {
+  .layout-vertical .DataListItem {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
+  }
+  .layout-horizontal .DataListItem {
+    display: table-row;
+    padding: 0;
+  }
+}
+
+.DataListLabel {
+  --data-list-label-width: 200px;
+  color: var(--gray-a11);
+  box-sizing: border-box;
+  vertical-align: inherit;
+}
+
+@breakpoints {
+  .layout-vertical .DataListLabel {
+    display: block;
+    white-space: normal;
+    padding: 0;
+    width: auto;
+  }
+  .layout-horizontal .DataListLabel {
+    display: table-cell;
+    white-space: nowrap;
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
+    padding-right: var(--data-list-gap-x);
+    width: var(--data-list-label-width);
+  }
+}
+
+.DataListData {
+  vertical-align: inherit;
+  box-sizing: border-box;
+  margin: 0;
+}
+
+@breakpoints {
+  .layout-vertical .DataListData {
+    display: block;
+    padding: 0;
+  }
+  .layout-horizontal .DataListData {
+    display: table-cell;
+
+    /*
+       * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
+       * content to be a bit larger in height without increasing the height of each item, in case
+       * there is a badge or a small button inside.
+       */
+    padding-top: calc(var(--data-list-gap-y) * 0.375);
+    padding-bottom: calc(var(--data-list-gap-y) * 0.375);
+  }
+}
+
+.DataListDataInner {
+  display: flex;
+}
+
+/*
+   * Improve alignment when nesting flex elements with Text. Prepending contents with a text character
+   * enforces default baseline alignment when child elements contain text within. The character used is
+   * a zero-width joiner, which is invisible, and pseudo-elements aren't copyable.
+   */
+.DataListDataInner::before {
+  content: '\200D';
+}
+
+.DataListDataInnerContents {
+  display: block;
+}

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -137,14 +137,14 @@
 }
 
 @breakpoints {
-  .layout-vertical .DataListItem {
+  .direction-column .DataListItem {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
     padding-top: calc(var(--data-list-gap-y) / 2);
     padding-bottom: calc(var(--data-list-gap-y) / 2);
   }
-  .layout-horizontal .DataListItem {
+  .direction-row .DataListItem {
     display: table-row;
     padding: 0;
   }
@@ -158,13 +158,13 @@
 }
 
 @breakpoints {
-  .layout-vertical .DataListLabel {
+  .direction-column .DataListLabel {
     display: block;
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .layout-horizontal .DataListLabel {
+  .direction-row .DataListLabel {
     display: table-cell;
     white-space: nowrap;
     padding-top: calc(var(--data-list-gap-y) / 2);
@@ -181,11 +181,11 @@
 }
 
 @breakpoints {
-  .layout-vertical .DataListData {
+  .direction-column .DataListData {
     display: block;
     padding: 0;
   }
-  .layout-horizontal .DataListData {
+  .direction-row .DataListData {
     display: table-cell;
 
     /*

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -3,106 +3,106 @@
 }
 
 @breakpoints {
-  .rt-DataListRoot.gap-0 {
+  .rt-DataListRoot.rt-r-gap-0 {
     --data-list-gap-x: 0px;
     --data-list-gap-y: 0px;
   }
-  .rt-DataListRoot.gap-1 {
+  .rt-DataListRoot.rt-r-gap-1 {
     --data-list-gap-x: var(--space-1);
     --data-list-gap-y: var(--space-1);
   }
-  .rt-DataListRoot.gap-2 {
+  .rt-DataListRoot.rt-r-gap-2 {
     --data-list-gap-x: var(--space-2);
     --data-list-gap-y: var(--space-2);
   }
-  .rt-DataListRoot.gap-3 {
+  .rt-DataListRoot.rt-r-gap-3 {
     --data-list-gap-x: var(--space-3);
     --data-list-gap-y: var(--space-3);
   }
-  .rt-DataListRoot.gap-4 {
+  .rt-DataListRoot.rt-r-gap-4 {
     --data-list-gap-x: var(--space-4);
     --data-list-gap-y: var(--space-4);
   }
-  .rt-DataListRoot.gap-5 {
+  .rt-DataListRoot.rt-r-gap-5 {
     --data-list-gap-x: var(--space-5);
     --data-list-gap-y: var(--space-5);
   }
-  .rt-DataListRoot.gap-6 {
+  .rt-DataListRoot.rt-r-gap-6 {
     --data-list-gap-x: var(--space-6);
     --data-list-gap-y: var(--space-6);
   }
-  .rt-DataListRoot.gap-7 {
+  .rt-DataListRoot.rt-r-gap-7 {
     --data-list-gap-x: var(--space-7);
     --data-list-gap-y: var(--space-7);
   }
-  .rt-DataListRoot.gap-8 {
+  .rt-DataListRoot.rt-r-gap-8 {
     --data-list-gap-x: var(--space-8);
     --data-list-gap-y: var(--space-8);
   }
-  .rt-DataListRoot.gap-9 {
+  .rt-DataListRoot.rt-r-gap-9 {
     --data-list-gap-x: var(--space-9);
     --data-list-gap-y: var(--space-9);
   }
 
-  .rt-DataListRoot.gap-x-0 {
+  .rt-DataListRoot.rt-r-gap-x-0 {
     --data-list-gap-x: 0px;
   }
-  .rt-DataListRoot.gap-x-1 {
+  .rt-DataListRoot.rt-r-gap-x-1 {
     --data-list-gap-x: var(--space-1);
   }
-  .rt-DataListRoot.gap-x-2 {
+  .rt-DataListRoot.rt-r-gap-x-2 {
     --data-list-gap-x: var(--space-2);
   }
-  .rt-DataListRoot.gap-x-3 {
+  .rt-DataListRoot.rt-r-gap-x-3 {
     --data-list-gap-x: var(--space-3);
   }
-  .rt-DataListRoot.gap-x-4 {
+  .rt-DataListRoot.rt-r-gap-x-4 {
     --data-list-gap-x: var(--space-4);
   }
-  .rt-DataListRoot.gap-x-5 {
+  .rt-DataListRoot.rt-r-gap-x-5 {
     --data-list-gap-x: var(--space-5);
   }
-  .rt-DataListRoot.gap-x-6 {
+  .rt-DataListRoot.rt-r-gap-x-6 {
     --data-list-gap-x: var(--space-6);
   }
-  .rt-DataListRoot.gap-x-7 {
+  .rt-DataListRoot.rt-r-gap-x-7 {
     --data-list-gap-x: var(--space-7);
   }
-  .rt-DataListRoot.gap-x-8 {
+  .rt-DataListRoot.rt-r-gap-x-8 {
     --data-list-gap-x: var(--space-8);
   }
-  .rt-DataListRoot.gap-x-9 {
+  .rt-DataListRoot.rt-r-gap-x-9 {
     --data-list-gap-x: var(--space-9);
   }
 
-  .rt-DataListRoot.gap-y-0 {
+  .rt-DataListRoot.rt-r-gap-y-0 {
     --data-list-gap-y: 0px;
   }
-  .rt-DataListRoot.gap-y-1 {
+  .rt-DataListRoot.rt-r-gap-y-1 {
     --data-list-gap-y: var(--space-1);
   }
-  .rt-DataListRoot.gap-y-2 {
+  .rt-DataListRoot.rt-r-gap-y-2 {
     --data-list-gap-y: var(--space-2);
   }
-  .rt-DataListRoot.gap-y-3 {
+  .rt-DataListRoot.rt-r-gap-y-3 {
     --data-list-gap-y: var(--space-3);
   }
-  .rt-DataListRoot.gap-y-4 {
+  .rt-DataListRoot.rt-r-gap-y-4 {
     --data-list-gap-y: var(--space-4);
   }
-  .rt-DataListRoot.gap-y-5 {
+  .rt-DataListRoot.rt-r-gap-y-5 {
     --data-list-gap-y: var(--space-5);
   }
-  .rt-DataListRoot.gap-y-6 {
+  .rt-DataListRoot.rt-r-gap-y-6 {
     --data-list-gap-y: var(--space-6);
   }
-  .rt-DataListRoot.gap-y-7 {
+  .rt-DataListRoot.rt-r-gap-y-7 {
     --data-list-gap-y: var(--space-7);
   }
-  .rt-DataListRoot.gap-y-8 {
+  .rt-DataListRoot.rt-r-gap-y-8 {
     --data-list-gap-y: var(--space-8);
   }
-  .rt-DataListRoot.gap-y-9 {
+  .rt-DataListRoot.rt-r-gap-y-9 {
     --data-list-gap-y: var(--space-9);
   }
 }
@@ -181,11 +181,11 @@
 }
 
 @breakpoints {
-  .direction-column .rt-DataListData {
+  .rt-r-direction-column .rt-DataListData {
     display: block;
     padding: 0;
   }
-  .direction-row .rt-DataListData {
+  .rt-r-direction-row .rt-DataListData {
     display: table-cell;
 
     /*

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,151 +1,50 @@
-:where(.DataListRoot) {
-  margin: 0;
-}
-
 @breakpoints {
   .DataListRoot.gap-0 {
-    --data-list-gap-x: 0px;
-    --data-list-gap-y: 0px;
+    --data-list-gap: 0px;
   }
   .DataListRoot.gap-1 {
-    --data-list-gap-x: var(--space-1);
-    --data-list-gap-y: var(--space-1);
+    --data-list-gap: var(--space-1);
   }
   .DataListRoot.gap-2 {
-    --data-list-gap-x: var(--space-2);
-    --data-list-gap-y: var(--space-2);
+    --data-list-gap: var(--space-2);
   }
   .DataListRoot.gap-3 {
-    --data-list-gap-x: var(--space-3);
-    --data-list-gap-y: var(--space-3);
+    --data-list-gap: var(--space-3);
   }
   .DataListRoot.gap-4 {
-    --data-list-gap-x: var(--space-4);
-    --data-list-gap-y: var(--space-4);
+    --data-list-gap: var(--space-4);
   }
   .DataListRoot.gap-5 {
-    --data-list-gap-x: var(--space-5);
-    --data-list-gap-y: var(--space-5);
+    --data-list-gap: var(--space-5);
   }
   .DataListRoot.gap-6 {
-    --data-list-gap-x: var(--space-6);
-    --data-list-gap-y: var(--space-6);
+    --data-list-gap: var(--space-6);
   }
   .DataListRoot.gap-7 {
-    --data-list-gap-x: var(--space-7);
-    --data-list-gap-y: var(--space-7);
+    --data-list-gap: var(--space-7);
   }
   .DataListRoot.gap-8 {
-    --data-list-gap-x: var(--space-8);
-    --data-list-gap-y: var(--space-8);
+    --data-list-gap: var(--space-8);
   }
   .DataListRoot.gap-9 {
-    --data-list-gap-x: var(--space-9);
-    --data-list-gap-y: var(--space-9);
+    --data-list-gap: var(--space-9);
   }
-
-  .DataListRoot.gap-x-0 {
-    --data-list-gap-x: 0px;
-  }
-  .DataListRoot.gap-x-1 {
-    --data-list-gap-x: var(--space-1);
-  }
-  .DataListRoot.gap-x-2 {
-    --data-list-gap-x: var(--space-2);
-  }
-  .DataListRoot.gap-x-3 {
-    --data-list-gap-x: var(--space-3);
-  }
-  .DataListRoot.gap-x-4 {
-    --data-list-gap-x: var(--space-4);
-  }
-  .DataListRoot.gap-x-5 {
-    --data-list-gap-x: var(--space-5);
-  }
-  .DataListRoot.gap-x-6 {
-    --data-list-gap-x: var(--space-6);
-  }
-  .DataListRoot.gap-x-7 {
-    --data-list-gap-x: var(--space-7);
-  }
-  .DataListRoot.gap-x-8 {
-    --data-list-gap-x: var(--space-8);
-  }
-  .DataListRoot.gap-x-9 {
-    --data-list-gap-x: var(--space-9);
-  }
-
-  .DataListRoot.gap-y-0 {
-    --data-list-gap-y: 0px;
-  }
-  .DataListRoot.gap-y-1 {
-    --data-list-gap-y: var(--space-1);
-  }
-  .DataListRoot.gap-y-2 {
-    --data-list-gap-y: var(--space-2);
-  }
-  .DataListRoot.gap-y-3 {
-    --data-list-gap-y: var(--space-3);
-  }
-  .DataListRoot.gap-y-4 {
-    --data-list-gap-y: var(--space-4);
-  }
-  .DataListRoot.gap-y-5 {
-    --data-list-gap-y: var(--space-5);
-  }
-  .DataListRoot.gap-y-6 {
-    --data-list-gap-y: var(--space-6);
-  }
-  .DataListRoot.gap-y-7 {
-    --data-list-gap-y: var(--space-7);
-  }
-  .DataListRoot.gap-y-8 {
-    --data-list-gap-y: var(--space-8);
-  }
-  .DataListRoot.gap-y-9 {
-    --data-list-gap-y: var(--space-9);
-  }
-}
-
-/* prettier-ignore */
-.DataListRoot::before,
-  .DataListRoot::after {
-    /* Remove top and bottom item padding */
-    --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
-    /* Include padding trim when leading trim is used */
-    --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
-    --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
-    display: table;
-    content: '';
-  }
-:where(.DataListRoot)::before {
-  margin-bottom: var(--data-list-padding-trim);
-}
-:where(.DataListRoot)::after {
-  margin-top: var(--data-list-padding-trim);
-}
-
-/* Make sure that consecutive data lists are spaced, regardless of leading trim */
-.DataListRoot:has(+ .DataListRoot)::after,
-.DataListRoot + .DataListRoot::before {
-  display: none;
 }
 
 .DataListItem {
   position: relative;
   box-sizing: border-box;
+  display: flex;
 }
 
 @breakpoints {
-  .layout-vertical .DataListItem {
-    display: flex;
+  .direction-column .DataListItem {
     flex-direction: column;
     gap: var(--space-1);
-    padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2);
   }
-  .layout-horizontal .DataListItem {
-    display: table-row;
+  .direction-row .DataListItem {
+    flex-direction: row;
+    gap: var(--data-list-gap);
     padding: 0;
   }
 }
@@ -154,47 +53,31 @@
   --data-list-label-width: 200px;
   color: var(--gray-a11);
   box-sizing: border-box;
-  vertical-align: inherit;
+  display: block;
 }
 
 @breakpoints {
-  .layout-vertical .DataListLabel {
-    display: block;
+  .direction-column .DataListLabel {
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .layout-horizontal .DataListLabel {
-    display: table-cell;
+  .direction-row .DataListLabel {
     white-space: nowrap;
-    padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2);
-    padding-right: var(--data-list-gap-x);
     width: var(--data-list-label-width);
   }
 }
 
 .DataListData {
-  vertical-align: inherit;
   box-sizing: border-box;
   margin: 0;
+  display: block;
 }
 
 @breakpoints {
-  .layout-vertical .DataListData {
-    display: block;
+  .direction-column .DataListData,
+  .direction-column-reverse .DataListData {
     padding: 0;
-  }
-  .layout-horizontal .DataListData {
-    display: table-cell;
-
-    /*
-       * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
-       * content to be a bit larger in height without increasing the height of each item, in case
-       * there is a badge or a small button inside.
-       */
-    padding-top: calc(var(--data-list-gap-y) * 0.375);
-    padding-bottom: calc(var(--data-list-gap-y) * 0.375);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,50 +1,151 @@
+:where(.DataListRoot) {
+  margin: 0;
+}
+
 @breakpoints {
   .DataListRoot.gap-0 {
-    --data-list-gap: 0px;
+    --data-list-gap-x: 0px;
+    --data-list-gap-y: 0px;
   }
   .DataListRoot.gap-1 {
-    --data-list-gap: var(--space-1);
+    --data-list-gap-x: var(--space-1);
+    --data-list-gap-y: var(--space-1);
   }
   .DataListRoot.gap-2 {
-    --data-list-gap: var(--space-2);
+    --data-list-gap-x: var(--space-2);
+    --data-list-gap-y: var(--space-2);
   }
   .DataListRoot.gap-3 {
-    --data-list-gap: var(--space-3);
+    --data-list-gap-x: var(--space-3);
+    --data-list-gap-y: var(--space-3);
   }
   .DataListRoot.gap-4 {
-    --data-list-gap: var(--space-4);
+    --data-list-gap-x: var(--space-4);
+    --data-list-gap-y: var(--space-4);
   }
   .DataListRoot.gap-5 {
-    --data-list-gap: var(--space-5);
+    --data-list-gap-x: var(--space-5);
+    --data-list-gap-y: var(--space-5);
   }
   .DataListRoot.gap-6 {
-    --data-list-gap: var(--space-6);
+    --data-list-gap-x: var(--space-6);
+    --data-list-gap-y: var(--space-6);
   }
   .DataListRoot.gap-7 {
-    --data-list-gap: var(--space-7);
+    --data-list-gap-x: var(--space-7);
+    --data-list-gap-y: var(--space-7);
   }
   .DataListRoot.gap-8 {
-    --data-list-gap: var(--space-8);
+    --data-list-gap-x: var(--space-8);
+    --data-list-gap-y: var(--space-8);
   }
   .DataListRoot.gap-9 {
-    --data-list-gap: var(--space-9);
+    --data-list-gap-x: var(--space-9);
+    --data-list-gap-y: var(--space-9);
   }
+
+  .DataListRoot.gap-x-0 {
+    --data-list-gap-x: 0px;
+  }
+  .DataListRoot.gap-x-1 {
+    --data-list-gap-x: var(--space-1);
+  }
+  .DataListRoot.gap-x-2 {
+    --data-list-gap-x: var(--space-2);
+  }
+  .DataListRoot.gap-x-3 {
+    --data-list-gap-x: var(--space-3);
+  }
+  .DataListRoot.gap-x-4 {
+    --data-list-gap-x: var(--space-4);
+  }
+  .DataListRoot.gap-x-5 {
+    --data-list-gap-x: var(--space-5);
+  }
+  .DataListRoot.gap-x-6 {
+    --data-list-gap-x: var(--space-6);
+  }
+  .DataListRoot.gap-x-7 {
+    --data-list-gap-x: var(--space-7);
+  }
+  .DataListRoot.gap-x-8 {
+    --data-list-gap-x: var(--space-8);
+  }
+  .DataListRoot.gap-x-9 {
+    --data-list-gap-x: var(--space-9);
+  }
+
+  .DataListRoot.gap-y-0 {
+    --data-list-gap-y: 0px;
+  }
+  .DataListRoot.gap-y-1 {
+    --data-list-gap-y: var(--space-1);
+  }
+  .DataListRoot.gap-y-2 {
+    --data-list-gap-y: var(--space-2);
+  }
+  .DataListRoot.gap-y-3 {
+    --data-list-gap-y: var(--space-3);
+  }
+  .DataListRoot.gap-y-4 {
+    --data-list-gap-y: var(--space-4);
+  }
+  .DataListRoot.gap-y-5 {
+    --data-list-gap-y: var(--space-5);
+  }
+  .DataListRoot.gap-y-6 {
+    --data-list-gap-y: var(--space-6);
+  }
+  .DataListRoot.gap-y-7 {
+    --data-list-gap-y: var(--space-7);
+  }
+  .DataListRoot.gap-y-8 {
+    --data-list-gap-y: var(--space-8);
+  }
+  .DataListRoot.gap-y-9 {
+    --data-list-gap-y: var(--space-9);
+  }
+}
+
+/* prettier-ignore */
+.DataListRoot::before,
+  .DataListRoot::after {
+    /* Remove top and bottom item padding */
+    --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
+    /* Include padding trim when leading trim is used */
+    --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
+    --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
+    display: table;
+    content: '';
+  }
+:where(.DataListRoot)::before {
+  margin-bottom: var(--data-list-padding-trim);
+}
+:where(.DataListRoot)::after {
+  margin-top: var(--data-list-padding-trim);
+}
+
+/* Make sure that consecutive data lists are spaced, regardless of leading trim */
+.DataListRoot:has(+ .DataListRoot)::after,
+.DataListRoot + .DataListRoot::before {
+  display: none;
 }
 
 .DataListItem {
   position: relative;
   box-sizing: border-box;
-  display: flex;
 }
 
 @breakpoints {
-  .direction-column .DataListItem {
+  .layout-vertical .DataListItem {
+    display: flex;
     flex-direction: column;
     gap: var(--space-1);
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
   }
-  .direction-row .DataListItem {
-    flex-direction: row;
-    gap: var(--data-list-gap);
+  .layout-horizontal .DataListItem {
+    display: table-row;
     padding: 0;
   }
 }
@@ -53,31 +154,47 @@
   --data-list-label-width: 200px;
   color: var(--gray-a11);
   box-sizing: border-box;
-  display: block;
+  vertical-align: inherit;
 }
 
 @breakpoints {
-  .direction-column .DataListLabel {
+  .layout-vertical .DataListLabel {
+    display: block;
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .direction-row .DataListLabel {
+  .layout-horizontal .DataListLabel {
+    display: table-cell;
     white-space: nowrap;
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
+    padding-right: var(--data-list-gap-x);
     width: var(--data-list-label-width);
   }
 }
 
 .DataListData {
+  vertical-align: inherit;
   box-sizing: border-box;
   margin: 0;
-  display: block;
 }
 
 @breakpoints {
-  .direction-column .DataListData,
-  .direction-column-reverse .DataListData {
+  .layout-vertical .DataListData {
+    display: block;
     padding: 0;
+  }
+  .layout-horizontal .DataListData {
+    display: table-cell;
+
+    /*
+       * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
+       * content to be a bit larger in height without increasing the height of each item, in case
+       * there is a badge or a small button inside.
+       */
+    padding-top: calc(var(--data-list-gap-y) * 0.375);
+    padding-bottom: calc(var(--data-list-gap-y) * 0.375);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,115 +1,115 @@
-:where(.DataListRoot) {
+:where(.rt-DataListRoot) {
   margin: 0;
 }
 
 @breakpoints {
-  .DataListRoot.gap-0 {
+  .rt-DataListRoot.gap-0 {
     --data-list-gap-x: 0px;
     --data-list-gap-y: 0px;
   }
-  .DataListRoot.gap-1 {
+  .rt-DataListRoot.gap-1 {
     --data-list-gap-x: var(--space-1);
     --data-list-gap-y: var(--space-1);
   }
-  .DataListRoot.gap-2 {
+  .rt-DataListRoot.gap-2 {
     --data-list-gap-x: var(--space-2);
     --data-list-gap-y: var(--space-2);
   }
-  .DataListRoot.gap-3 {
+  .rt-DataListRoot.gap-3 {
     --data-list-gap-x: var(--space-3);
     --data-list-gap-y: var(--space-3);
   }
-  .DataListRoot.gap-4 {
+  .rt-DataListRoot.gap-4 {
     --data-list-gap-x: var(--space-4);
     --data-list-gap-y: var(--space-4);
   }
-  .DataListRoot.gap-5 {
+  .rt-DataListRoot.gap-5 {
     --data-list-gap-x: var(--space-5);
     --data-list-gap-y: var(--space-5);
   }
-  .DataListRoot.gap-6 {
+  .rt-DataListRoot.gap-6 {
     --data-list-gap-x: var(--space-6);
     --data-list-gap-y: var(--space-6);
   }
-  .DataListRoot.gap-7 {
+  .rt-DataListRoot.gap-7 {
     --data-list-gap-x: var(--space-7);
     --data-list-gap-y: var(--space-7);
   }
-  .DataListRoot.gap-8 {
+  .rt-DataListRoot.gap-8 {
     --data-list-gap-x: var(--space-8);
     --data-list-gap-y: var(--space-8);
   }
-  .DataListRoot.gap-9 {
+  .rt-DataListRoot.gap-9 {
     --data-list-gap-x: var(--space-9);
     --data-list-gap-y: var(--space-9);
   }
 
-  .DataListRoot.gap-x-0 {
+  .rt-DataListRoot.gap-x-0 {
     --data-list-gap-x: 0px;
   }
-  .DataListRoot.gap-x-1 {
+  .rt-DataListRoot.gap-x-1 {
     --data-list-gap-x: var(--space-1);
   }
-  .DataListRoot.gap-x-2 {
+  .rt-DataListRoot.gap-x-2 {
     --data-list-gap-x: var(--space-2);
   }
-  .DataListRoot.gap-x-3 {
+  .rt-DataListRoot.gap-x-3 {
     --data-list-gap-x: var(--space-3);
   }
-  .DataListRoot.gap-x-4 {
+  .rt-DataListRoot.gap-x-4 {
     --data-list-gap-x: var(--space-4);
   }
-  .DataListRoot.gap-x-5 {
+  .rt-DataListRoot.gap-x-5 {
     --data-list-gap-x: var(--space-5);
   }
-  .DataListRoot.gap-x-6 {
+  .rt-DataListRoot.gap-x-6 {
     --data-list-gap-x: var(--space-6);
   }
-  .DataListRoot.gap-x-7 {
+  .rt-DataListRoot.gap-x-7 {
     --data-list-gap-x: var(--space-7);
   }
-  .DataListRoot.gap-x-8 {
+  .rt-DataListRoot.gap-x-8 {
     --data-list-gap-x: var(--space-8);
   }
-  .DataListRoot.gap-x-9 {
+  .rt-DataListRoot.gap-x-9 {
     --data-list-gap-x: var(--space-9);
   }
 
-  .DataListRoot.gap-y-0 {
+  .rt-DataListRoot.gap-y-0 {
     --data-list-gap-y: 0px;
   }
-  .DataListRoot.gap-y-1 {
+  .rt-DataListRoot.gap-y-1 {
     --data-list-gap-y: var(--space-1);
   }
-  .DataListRoot.gap-y-2 {
+  .rt-DataListRoot.gap-y-2 {
     --data-list-gap-y: var(--space-2);
   }
-  .DataListRoot.gap-y-3 {
+  .rt-DataListRoot.gap-y-3 {
     --data-list-gap-y: var(--space-3);
   }
-  .DataListRoot.gap-y-4 {
+  .rt-DataListRoot.gap-y-4 {
     --data-list-gap-y: var(--space-4);
   }
-  .DataListRoot.gap-y-5 {
+  .rt-DataListRoot.gap-y-5 {
     --data-list-gap-y: var(--space-5);
   }
-  .DataListRoot.gap-y-6 {
+  .rt-DataListRoot.gap-y-6 {
     --data-list-gap-y: var(--space-6);
   }
-  .DataListRoot.gap-y-7 {
+  .rt-DataListRoot.gap-y-7 {
     --data-list-gap-y: var(--space-7);
   }
-  .DataListRoot.gap-y-8 {
+  .rt-DataListRoot.gap-y-8 {
     --data-list-gap-y: var(--space-8);
   }
-  .DataListRoot.gap-y-9 {
+  .rt-DataListRoot.gap-y-9 {
     --data-list-gap-y: var(--space-9);
   }
 }
 
 /* prettier-ignore */
-.DataListRoot::before,
-  .DataListRoot::after {
+.rt-DataListRoot::before,
+  .rt-DataListRoot::after {
     /* Remove top and bottom item padding */
     --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
     /* Include padding trim when leading trim is used */
@@ -118,39 +118,39 @@
     display: table;
     content: '';
   }
-:where(.DataListRoot)::before {
+:where(.rt-DataListRoot)::before {
   margin-bottom: var(--data-list-padding-trim);
 }
-:where(.DataListRoot)::after {
+:where(.rt-DataListRoot)::after {
   margin-top: var(--data-list-padding-trim);
 }
 
 /* Make sure that consecutive data lists are spaced, regardless of leading trim */
-.DataListRoot:has(+ .DataListRoot)::after,
-.DataListRoot + .DataListRoot::before {
+.rt-DataListRoot:has(+ .rt-DataListRoot)::after,
+.rt-DataListRoot + .rt-DataListRoot::before {
   display: none;
 }
 
-.DataListItem {
+.rt-DataListItem {
   position: relative;
   box-sizing: border-box;
 }
 
 @breakpoints {
-  .direction-column .DataListItem {
+  .rt-r-direction-column .rt-DataListItem {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
     padding-top: calc(var(--data-list-gap-y) / 2);
     padding-bottom: calc(var(--data-list-gap-y) / 2);
   }
-  .direction-row .DataListItem {
+  .rt-r-direction-row .rt-DataListItem {
     display: table-row;
     padding: 0;
   }
 }
 
-.DataListLabel {
+.rt-DataListLabel {
   --data-list-label-width: 200px;
   color: var(--gray-a11);
   box-sizing: border-box;
@@ -158,13 +158,13 @@
 }
 
 @breakpoints {
-  .direction-column .DataListLabel {
+  .rt-r-direction-column .rt-DataListLabel {
     display: block;
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .direction-row .DataListLabel {
+  .rt-r-direction-row .rt-DataListLabel {
     display: table-cell;
     white-space: nowrap;
     padding-top: calc(var(--data-list-gap-y) / 2);
@@ -174,18 +174,18 @@
   }
 }
 
-.DataListData {
+.rt-DataListData {
   vertical-align: inherit;
   box-sizing: border-box;
   margin: 0;
 }
 
 @breakpoints {
-  .direction-column .DataListData {
+  .direction-column .rt-DataListData {
     display: block;
     padding: 0;
   }
-  .direction-row .DataListData {
+  .direction-row .rt-DataListData {
     display: table-cell;
 
     /*
@@ -198,7 +198,7 @@
   }
 }
 
-.DataListDataInner {
+.rt-DataListDataInner {
   display: flex;
 }
 
@@ -207,10 +207,10 @@
    * enforces default baseline alignment when child elements contain text within. The character used is
    * a zero-width joiner, which is invisible, and pseudo-elements aren't copyable.
    */
-.DataListDataInner::before {
+.rt-DataListDataInner::before {
   content: '\200D';
 }
 
-.DataListDataInnerContents {
+.rt-DataListDataInnerContents {
   display: block;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,0 +1,11 @@
+import type { Text } from './text';
+import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
+
+export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
+  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
+  layout?: Responsive<'horizontal' | 'vertical'>;
+}

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,10 +1,15 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
+import { Grid } from './grid';
+import { Flex } from './flex';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
+  direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  rows?: React.ComponentPropsWithoutRef<typeof Grid>['rows'];
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
   trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
   layout?: Responsive<'horizontal' | 'vertical'>;

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -12,5 +12,4 @@ export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginP
   gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
   trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
-  layout?: Responsive<'horizontal' | 'vertical'>;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -3,7 +3,10 @@ import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
 import { Flex } from './flex';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
+  direction?: Omit<
+    React.ComponentPropsWithoutRef<typeof Flex>['direction'],
+    'column-reverse' | 'row-reverse'
+  >;
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,15 +1,22 @@
 import type { Text } from './text';
-import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
-import { Flex } from './flex';
+import { PropDef, trimProp, textSize } from '../helpers';
+import { textPropDefs } from './text.props';
 
-export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  direction?: Omit<
-    React.ComponentPropsWithoutRef<typeof Flex>['direction'],
-    'column-reverse' | 'row-reverse'
-  >;
-  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
-}
+const directionValues = ['row', 'column'] as const;
+const gapValues = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+
+export const dataListPropDefs = {
+  direction: { type: 'enum', values: directionValues, default: undefined, responsive: true },
+  gap: { type: 'enum', values: gapValues, default: '4', responsive: true },
+  gapX: { type: 'enum', values: gapValues, default: undefined, responsive: true },
+  gapY: { type: 'enum', values: gapValues, default: undefined, responsive: true },
+  size: textPropDefs.size,
+  trim: trimProp,
+} satisfies {
+  direction?: PropDef<(typeof directionValues)[number]>;
+  gap?: PropDef<(typeof gapValues)[number]>;
+  gapX?: PropDef<(typeof gapValues)[number]>;
+  gapY?: PropDef<(typeof gapValues)[number]>;
+  size?: typeof textSize;
+  trim?: typeof trimProp;
+};

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,15 +1,12 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
-import { Grid } from './grid';
 import { Flex } from './flex';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
   direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  rows?: React.ComponentPropsWithoutRef<typeof Grid>['rows'];
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
   trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
   layout?: Responsive<'horizontal' | 'vertical'>;

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,16 +1,8 @@
-import { Text } from '@radix-ui/themes';
+import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
-import { MarginProps, PropsWithoutRefOrColor, Responsive, withBreakpoints } from '../helpers';
-
-interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
-  layout?: Responsive<'horizontal' | 'vertical'>;
-}
+import { Responsive, withBreakpoints } from '../helpers';
+import { DataListRootProps } from './data-list.props';
 
 /*
  * decide what to do with layout prop
@@ -100,9 +92,4 @@ const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'
 
 DataListData.displayName = 'DataListData';
 
-export const DataList = {
-  Root: DataListRoot,
-  Item: DataListItem,
-  Label: DataListLabel,
-  Data: DataListData,
-};
+export { DataListRoot, DataListItem, DataListLabel, DataListData };

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,0 +1,108 @@
+import { Text } from '@radix-ui/themes';
+import classNames from 'classnames';
+import * as React from 'react';
+import { MarginProps, PropsWithoutRefOrColor, Responsive, withBreakpoints } from '../helpers';
+
+interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
+  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
+  layout?: Responsive<'horizontal' | 'vertical'>;
+}
+
+/*
+ * decide what to do with layout prop
+ * - gap prop?
+ * - label width
+ */
+
+const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
+  (
+    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
+    forwardedRef
+  ) => (
+    <Text asChild size={size} {...props}>
+      <dl
+        ref={forwardedRef}
+        className={classNames(
+          'DataListRoot',
+          withBreakpoints(gap, 'gap'),
+          withBreakpoints(gapX, 'gap-x'),
+          withBreakpoints(gapY, 'gap-y'),
+          withBreakpoints(layout, 'layout')
+        )}
+      >
+        {children}
+      </dl>
+    </Text>
+  )
+);
+
+DataListRoot.displayName = 'DataListRoot';
+
+interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
+  align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;
+}
+
+const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
+  ({ align, className, ...props }, forwardedRef) => (
+    <div
+      ref={forwardedRef}
+      className={classNames(
+        className,
+        'DataListItem',
+        withBreakpoints(align, 'va', {
+          start: 'top',
+          center: 'middle',
+          end: 'bottom',
+        })
+      )}
+      {...props}
+    />
+  )
+);
+
+DataListItem.displayName = 'DataListItem';
+
+interface DataListLabelProps extends React.ComponentPropsWithRef<'dt'> {
+  width?: number | string;
+}
+
+const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
+  ({ className, style, width, ...props }, forwardedRef) => (
+    <dt
+      ref={forwardedRef}
+      className={classNames(className, 'DataListLabel')}
+      style={
+        {
+          '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
+          ...style,
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+);
+
+DataListLabel.displayName = 'DataListLabel';
+
+const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'dd'>>(
+  ({ children, className, ...props }, forwardedRef) => (
+    <dd ref={forwardedRef} className={classNames(className, 'DataListData')} {...props}>
+      <span className="DataListDataInner">
+        <span className="DataListDataInnerContents">{children}</span>
+      </span>
+    </dd>
+  )
+);
+
+DataListData.displayName = 'DataListData';
+
+export const DataList = {
+  Root: DataListRoot,
+  Item: DataListItem,
+  Label: DataListLabel,
+  Data: DataListData,
+};

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -10,6 +10,7 @@ import { DataListRootProps } from './data-list.props';
  * - support the breakpoints, related to `withBreakpoints`?
  * - fix alignment
  * - test margin
+ * - label width issue
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
@@ -49,7 +50,7 @@ const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
       className={classNames(
         className,
         'DataListItem',
-        withBreakpoints(align, 'va', {
+        withBreakpoints(align, 'rt-r-va', {
           start: 'top',
           center: 'middle',
           end: 'bottom',

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,38 +1,36 @@
-import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
+import { Flex } from './flex';
+import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
+import { Grid } from './grid';
 
 /*
  * decide what to do with layout prop
- * - gap prop?
  * - label width
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  (
-    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
-    forwardedRef
-  ) => (
-    <Text asChild size={size} {...props}>
-      <dl
-        ref={forwardedRef}
-        className={classNames(
-          'DataListRoot',
-          withBreakpoints(gap, 'gap'),
-          withBreakpoints(gapX, 'gap-x'),
-          withBreakpoints(gapY, 'gap-y'),
-          withBreakpoints(layout, 'layout')
-        )}
-      >
-        {children}
-      </dl>
-    </Text>
+  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
+    <Flex asChild gap={gap} direction="column">
+      <Text asChild size={size}>
+        <dl
+          ref={forwardedRef}
+          className={classNames(
+            'DataListRoot',
+            withBreakpoints(gap, 'gap'),
+            withBreakpoints(direction, 'direction')
+          )}
+        >
+          {children}
+        </dl>
+      </Text>
+    </Flex>
   )
 );
 
-DataListRoot.displayName = 'DataListRoot';
+DataListRoot.displayName = 'DataListRootGrid';
 
 interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
   align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -20,9 +20,9 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
           ref={forwardedRef}
           className={classNames(
             'rt-DataListRoot',
-            withBreakpoints(gap, 'gap'),
-            withBreakpoints(gapX, 'gap-x'),
-            withBreakpoints(gapY, 'gap-y'),
+            withBreakpoints(gap, 'rt-r-gap'),
+            withBreakpoints(gapX, 'rt-r-gap-x'),
+            withBreakpoints(gapY, 'rt-r-gap-y'),
             withBreakpoints(direction, 'rt-r-direction'),
             withMarginProps(marginProps)
           )}

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,29 +1,39 @@
-import { Text } from '@radix-ui/themes';
+import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
 import { DataListRootProps } from './data-list.props';
 
+/**
+ * - fix layout direction
+ *  - columns? still need direction
+ * - support the breakpoints, related to `withBreakpoints`?
+ * - fix alignment
+ * - test margin
+ */
+
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
   (
-    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
+    { children, direction = 'row', gap = '4', gapX, gapY, size = '2', trim, ...props },
     forwardedRef
-  ) => (
-    <Text asChild size={size} {...props}>
-      <dl
-        ref={forwardedRef}
-        className={classNames(
-          'DataListRoot',
-          withBreakpoints(gap, 'gap'),
-          withBreakpoints(gapX, 'gap-x'),
-          withBreakpoints(gapY, 'gap-y'),
-          withBreakpoints(layout, 'layout')
-        )}
-      >
-        {children}
-      </dl>
-    </Text>
-  )
+  ) => {
+    return (
+      <Text asChild size={size} trim={trim} {...props}>
+        <dl
+          ref={forwardedRef}
+          className={classNames(
+            'DataListRoot',
+            withBreakpoints(gap, 'gap'),
+            withBreakpoints(gapX, 'gap-x'),
+            withBreakpoints(gapY, 'gap-y'),
+            withBreakpoints(direction, 'direction')
+          )}
+        >
+          {children}
+        </dl>
+      </Text>
+    );
+  }
 );
 
 DataListRoot.displayName = 'DataListRoot';

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,36 +1,32 @@
+import { Text } from '@radix-ui/themes';
 import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
-import { Flex } from './flex';
-import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
-import { Grid } from './grid';
-
-/*
- * decide what to do with layout prop
- * - label width
- */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
-    <Flex asChild gap={gap} direction="column">
-      <Text asChild size={size}>
-        <dl
-          ref={forwardedRef}
-          className={classNames(
-            'DataListRoot',
-            withBreakpoints(gap, 'gap'),
-            withBreakpoints(direction, 'direction')
-          )}
-        >
-          {children}
-        </dl>
-      </Text>
-    </Flex>
+  (
+    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
+    forwardedRef
+  ) => (
+    <Text asChild size={size} {...props}>
+      <dl
+        ref={forwardedRef}
+        className={classNames(
+          'DataListRoot',
+          withBreakpoints(gap, 'gap'),
+          withBreakpoints(gapX, 'gap-x'),
+          withBreakpoints(gapY, 'gap-y'),
+          withBreakpoints(layout, 'layout')
+        )}
+      >
+        {children}
+      </dl>
+    </Text>
   )
 );
 
-DataListRoot.displayName = 'DataListRootGrid';
+DataListRoot.displayName = 'DataListRoot';
 
 interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
   align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,21 +1,19 @@
 import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
-import { Responsive, withBreakpoints } from '../helpers';
+import { Responsive, withBreakpoints, extractMarginProps, withMarginProps } from '../helpers';
 import { DataListRootProps } from './data-list.props';
 
 /**
- *  - columns instaed of direction?
+ * - columns instaed of direction?
  * - support the breakpoints, related to `withBreakpoints`?
- * - test margin
  * - label width issue
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  (
-    { children, direction = 'row', gap = '4', gapX, gapY, size = '2', trim, ...props },
-    forwardedRef
-  ) => {
+  (props, forwardedRef) => {
+    const { rest: marginRest, ...marginProps } = extractMarginProps(props);
+    const { children, direction = 'row', gap = '4', gapX, gapY, size = '2', trim } = marginRest;
     return (
       <Text asChild size={size} trim={trim} {...props}>
         <dl
@@ -25,7 +23,8 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
             withBreakpoints(gap, 'gap'),
             withBreakpoints(gapX, 'gap-x'),
             withBreakpoints(gapY, 'gap-y'),
-            withBreakpoints(direction, 'direction')
+            withBreakpoints(direction, 'direction'),
+            withMarginProps(marginProps)
           )}
         >
           {children}

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,21 +1,31 @@
 import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
-import { Responsive, withBreakpoints, extractMarginProps, withMarginProps } from '../helpers';
-import { DataListRootProps } from './data-list.props';
+import {
+  Responsive,
+  withBreakpoints,
+  extractMarginProps,
+  withMarginProps,
+  MarginProps,
+  GetPropDefTypes,
+} from '../helpers';
+import { dataListPropDefs } from './data-list.props';
 
 /**
- * - columns instaed of direction?
- * - support the breakpoints, related to `withBreakpoints`?
+ * - columns instead of direction?
  * - label width issue
  */
-
+type DataListRootOwnProps = GetPropDefTypes<typeof dataListPropDefs>;
+interface DataListRootProps
+  extends React.ComponentPropsWithoutRef<'dl'>,
+    MarginProps,
+    DataListRootOwnProps {}
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
   (props, forwardedRef) => {
     const { rest: marginRest, ...marginProps } = extractMarginProps(props);
     const { children, direction = 'row', gap = '4', gapX, gapY, size = '2', trim } = marginRest;
     return (
-      <Text asChild size={size} trim={trim} {...props}>
+      <Text asChild size={size} trim={trim}>
         <dl
           ref={forwardedRef}
           className={classNames(
@@ -36,6 +46,7 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
 
 DataListRoot.displayName = 'DataListRoot';
 
+// the align prop is different than text align
 interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
   align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;
 }

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -5,10 +5,8 @@ import { Responsive, withBreakpoints } from '../helpers';
 import { DataListRootProps } from './data-list.props';
 
 /**
- * - fix layout direction
- *  - columns? still need direction
+ *  - columns instaed of direction?
  * - support the breakpoints, related to `withBreakpoints`?
- * - fix alignment
  * - test margin
  * - label width issue
  */

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -19,11 +19,11 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
         <dl
           ref={forwardedRef}
           className={classNames(
-            'DataListRoot',
+            'rt-DataListRoot',
             withBreakpoints(gap, 'gap'),
             withBreakpoints(gapX, 'gap-x'),
             withBreakpoints(gapY, 'gap-y'),
-            withBreakpoints(direction, 'direction'),
+            withBreakpoints(direction, 'rt-r-direction'),
             withMarginProps(marginProps)
           )}
         >
@@ -46,7 +46,7 @@ const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
       ref={forwardedRef}
       className={classNames(
         className,
-        'DataListItem',
+        'rt-DataListItem',
         withBreakpoints(align, 'rt-r-va', {
           start: 'top',
           center: 'middle',
@@ -68,7 +68,7 @@ const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
   ({ className, style, width, ...props }, forwardedRef) => (
     <dt
       ref={forwardedRef}
-      className={classNames(className, 'DataListLabel')}
+      className={classNames(className, 'rt-DataListLabel')}
       style={
         {
           '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
@@ -84,9 +84,9 @@ DataListLabel.displayName = 'DataListLabel';
 
 const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'dd'>>(
   ({ children, className, ...props }, forwardedRef) => (
-    <dd ref={forwardedRef} className={classNames(className, 'DataListData')} {...props}>
-      <span className="DataListDataInner">
-        <span className="DataListDataInnerContents">{children}</span>
+    <dd ref={forwardedRef} className={classNames(className, 'rt-DataListData')} {...props}>
+      <span className="rt-DataListDataInner">
+        <span className="rt-DataListDataInnerContents">{children}</span>
       </span>
     </dd>
   )

--- a/packages/radix-ui-themes/src/components/index.ts
+++ b/packages/radix-ui-themes/src/components/index.ts
@@ -143,6 +143,8 @@ export { Callout, CalloutRoot, CalloutIcon, CalloutText } from './callout';
 export * from './callout.props';
 export { Card } from './card';
 export * from './card.props';
+export { DataListRoot, DataListData, DataListItem, DataListLabel } from './data-list';
+export * from './data-list.props';
 // export * from './collapsible';
 // export * from './definition-list';
 export { IconButton } from './icon-button';

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -1,17 +1,15 @@
 import { weightProp, alignProp, trimProp, colorProp, highContrastProp } from '../helpers';
-import type { PropDef } from '../helpers';
-
-const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+import { textSize } from '../helpers/props/text-size.prop';
 
 const textPropDefs = {
-  size: { type: 'enum', values: sizes, default: undefined, responsive: true },
+  size: textSize,
   weight: weightProp,
   align: alignProp,
   trim: trimProp,
   color: colorProp,
   highContrast: highContrastProp,
 } satisfies {
-  size: PropDef<(typeof sizes)[number]>;
+  size: typeof textSize;
   weight: typeof weightProp;
   align: typeof alignProp;
   trim: typeof trimProp;

--- a/packages/radix-ui-themes/src/helpers/props/index.ts
+++ b/packages/radix-ui-themes/src/helpers/props/index.ts
@@ -7,4 +7,5 @@ export * from './margin.props';
 export * from './prop-def';
 export * from './radius.prop';
 export * from './text-align.prop';
+export * from './text-size.prop';
 export * from './weight.prop';

--- a/packages/radix-ui-themes/src/helpers/props/text-size.prop.ts
+++ b/packages/radix-ui-themes/src/helpers/props/text-size.prop.ts
@@ -1,0 +1,12 @@
+import type { PropDef } from '..';
+
+const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+
+const textSize = {
+  type: 'enum',
+  values: sizes,
+  default: undefined,
+  responsive: true,
+} satisfies PropDef<(typeof sizes)[number]>;
+
+export { textSize };

--- a/packages/radix-ui-themes/src/styles/index.css
+++ b/packages/radix-ui-themes/src/styles/index.css
@@ -22,6 +22,7 @@
 @import '../components/code.css';
 @import '../components/container.css';
 @import '../components/context-menu.css';
+@import '../components/data-list.css';
 @import '../components/dialog.css';
 @import '../components/dropdown-menu.css';
 @import '../components/em.css';


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

🚧 WIP

## Description

[See testing page](https://themes-playground-git-ksadds-data-list-with-direction-modulz.vercel.app/test-data-list)

Another option related to #230 that uses `direction` to set the layout and retains `width` being handled by the labels. One option here would be to take a `width` property at the root component and set it for the labels. I do prefer to composability of this interface over the column approach even if it requires slightly more repetition. 


```jsx
// Use the flex properties `column` or `row` to denote the kv pair layout
<DataListRoot mt="2" direction="column">
  <DataListItem>
    <DataListLabel>Name</DataListLabel>
    <DataListData>Jane Roe</DataListData>
  </DataListItem>
  <DataListItem>
    <DataListLabel>Email</DataListLabel>
    <DataListData>janeroe@foo-corp.com</DataListData>
  </DataListItem>
  <DataListItem>
    <DataListLabel>Organization</DataListLabel>
    <DataListData>
      <Link href="https://foo-corp.com">Foo Corp</Link>
    </DataListData>
  </DataListItem>
</DataListRoot>
```

<!-- Describe the change you are introducing -->

## Testing steps

<!-- Describe step by step how to test the change being introduced -->

## Relates issues / PRs

<!-- List out related issues and PR links -->
