### PR TITLE
[c] Add DataList component with `flex` layout

### DIFF
--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -10,15 +10,18 @@ import {
   Theme,
   Container,
   Text,
+  Heading,
+  Button,
+  IconButton,
 } from '@radix-ui/themes';
-import { StarIcon, MagicWandIcon, StarFilledIcon } from '@radix-ui/react-icons';
+import { StarIcon, MagicWandIcon, StarFilledIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 
 export default function DataListPage() {
   return (
     <html>
       <body>
         <Theme>
-          <Box ml="5">
+          <Box ml="5" style={{ maxWidth: '688px;', margin: 'auto' }}>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium" mb="2">
                 Default
@@ -99,6 +102,140 @@ export default function DataListPage() {
                 </DataListItem>
               </DataListRoot>
             </Flex>
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With varied content
+              </Heading>
+              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
+              <DataListRoot direction="row">
+                <DataListItem>
+                  <DataListLabel>Status</DataListLabel>
+                  <DataListData>
+                    <Badge color="green" size="1" style={{ marginLeft: -2 }}>
+                      Active
+                    </Badge>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem align="center">
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>
+                    <Button size="1">Add</Button>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Organization</DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Long value</DataListLabel>
+                  <DataListData>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ac nisl et libero
+                    ultricies viverra quis vitae quam. Proin a feugiat metus.
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem align="center">
+                  <DataListLabel>Authentication methods</DataListLabel>
+                  <DataListData>
+                    <Flex gap="2">
+                      <StarFilledIcon />
+                      <StarFilledIcon />
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Long value</DataListLabel>
+                  <DataListData>
+                    Sed luctus, est id feugiat blandit, sapien nisl lobortis arcu, eu malesuada
+                    nulla ex ut lorem. In odio nisl, consectetur id commodo vel, posuere eu risus.
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With nested flex
+              </Heading>
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={80}>Appearance</DataListLabel>
+                  <DataListData>
+                    <Flex align="center" gap="1">
+                      <IconButton size="1">
+                        <InfoCircledIcon />
+                      </IconButton>
+                      <Text>System</Text>
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                One after another
+              </Heading>
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={130}>Appearance</DataListLabel>
+                  <DataListData>System</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel width={130}>Radius</DataListLabel>
+                  <DataListData>Medium</DataListData>
+                </DataListItem>
+              </DataListRoot>
+
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel width={130}>Page background</DataListLabel>
+                  <DataListData>White</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel width={130}>Link color</DataListLabel>
+                  <DataListData>Blue</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With long label
+              </Heading>
+              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
+              <DataListRoot direction="row">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Vlad Moroz</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+
+                <DataListItem>
+                  <DataListLabel>
+                    Lorem ipsum dolor sit amet consectetur adipscing elit
+                  </DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
           </Box>
         </Theme>
       </body>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -207,17 +207,17 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With long label
               </Heading>
-              <DataListRoot direction={{ initial: 'column', sm: 'row' }} labelWidth="350px">
+              <DataListRoot direction={{ initial: 'column', sm: 'row' }}>
                 <DataListItem>
-                  <DataListLabel>Name</DataListLabel>
+                  <DataListLabel width="350px">Name</DataListLabel>
                   <DataListData>Vlad Moroz</DataListData>
                 </DataListItem>
                 <DataListItem>
-                  <DataListLabel>Email</DataListLabel>
+                  <DataListLabel width="350px">Email</DataListLabel>
                   <DataListData>vlad@workos.com</DataListData>
                 </DataListItem>
                 <DataListItem>
-                  <DataListLabel>
+                  <DataListLabel width="350px">
                     Lorem ipsum dolor sit amet consectetur adipscing elit
                   </DataListLabel>
                   <DataListData>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -188,25 +188,17 @@ export default function DataListPage() {
                 One after another
               </Heading>
               <DataListRoot>
-                <DataListItem>
-                  <DataListLabel width={130}>Appearance</DataListLabel>
-                  <DataListData>System</DataListData>
-                </DataListItem>
-                <DataListItem>
-                  <DataListLabel width={130}>Radius</DataListLabel>
-                  <DataListData>Medium</DataListData>
-                </DataListItem>
+                <DataListLabel>Appearance</DataListLabel>
+                <DataListData>System</DataListData>
+                <DataListLabel>Radius</DataListLabel>
+                <DataListData>Medium</DataListData>
               </DataListRoot>
 
               <DataListRoot>
-                <DataListItem>
-                  <DataListLabel width={130}>Page background</DataListLabel>
-                  <DataListData>White</DataListData>
-                </DataListItem>
-                <DataListItem>
-                  <DataListLabel width={130}>Link color</DataListLabel>
-                  <DataListData>Blue</DataListData>
-                </DataListItem>
+                <DataListLabel>Page background</DataListLabel>
+                <DataListData>White</DataListData>
+                <DataListLabel>Link color</DataListLabel>
+                <DataListData>Blue</DataListData>
               </DataListRoot>
             </Box>
 
@@ -216,24 +208,14 @@ export default function DataListPage() {
               </Heading>
               {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
               <DataListRoot direction="row">
-                <DataListItem>
-                  <DataListLabel>Name</DataListLabel>
-                  <DataListData>Vlad Moroz</DataListData>
-                </DataListItem>
-
-                <DataListItem>
-                  <DataListLabel>Email</DataListLabel>
-                  <DataListData>vlad@workos.com</DataListData>
-                </DataListItem>
-
-                <DataListItem>
-                  <DataListLabel>
-                    Lorem ipsum dolor sit amet consectetur adipscing elit
-                  </DataListLabel>
-                  <DataListData>
-                    <Link href="https://workos.com">WorkOS</Link>
-                  </DataListData>
-                </DataListItem>
+                <DataListLabel>Name</DataListLabel>
+                <DataListData>Vlad Moroz</DataListData>
+                <DataListLabel>Email</DataListLabel>
+                <DataListData>vlad@workos.com</DataListData>
+                <DataListLabel>Lorem ipsum dolor sit amet consectetur adipscing elit</DataListLabel>
+                <DataListData>
+                  <Link href="https://workos.com">WorkOS</Link>
+                </DataListData>
               </DataListRoot>
             </Box>
           </Box>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -20,7 +20,7 @@ export default function DataListPage() {
     <html>
       <body>
         <Theme>
-          <Box ml="5" style={{ maxWidth: '688px;', margin: 'auto' }}>
+          <Box ml="5" style={{ maxWidth: '688px', margin: 'auto' }}>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium" mb="2">
                 Default

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -22,86 +22,37 @@ export default function DataListPage() {
         <Theme>
           <Box ml="5" style={{ maxWidth: '688px', margin: 'auto' }}>
             <Flex gap="2" mt="4" direction="column">
-              <Text weight="medium" mb="2">
+              <Heading mb="5" size="3">
                 Default
-              </Text>
+              </Heading>
               <DataListRoot mt="2">
                 <DataListItem>
-                  <DataListLabel>Obi wan</DataListLabel>
-                  <DataListData>Jedi Master</DataListData>
+                  <DataListLabel>Jedi Master</DataListLabel>
+                  <DataListData>Obi wan</DataListData>
                 </DataListItem>
                 <DataListItem>
-                  <DataListLabel>Anakin</DataListLabel>
-                  <DataListData>Padewan</DataListData>
+                  <DataListLabel>Padewan</DataListLabel>
+                  <DataListData>Anakin Skywalker</DataListData>
                 </DataListItem>
               </DataListRoot>
             </Flex>
             <Flex gap="2" mt="4" direction="column">
-              <Text weight="medium">Vertical Layout</Text>
+              <Heading mb="5" size="3">
+                Vertical Layout
+              </Heading>
               <DataListRoot direction="column" mt="2">
                 <DataListItem>
-                  <DataListLabel>Obi wan</DataListLabel>
-                  <DataListData>Jedi Master</DataListData>
+                  <DataListLabel>Jedi Master</DataListLabel>
+                  <DataListData>Obi wan</DataListData>
                 </DataListItem>
                 <DataListItem>
-                  <DataListLabel>Anakin</DataListLabel>
-                  <DataListData>Padewan</DataListData>
+                  <DataListLabel>Padewan</DataListLabel>
+                  <DataListData>Anakin Skywalker</DataListData>
                 </DataListItem>
               </DataListRoot>
             </Flex>
-            <Flex gap="2" mt="4" direction="column">
-              <Text weight="medium">Varied data</Text>
-              <DataListRoot mt="2" direction="column">
-                <DataListItem>
-                  <DataListLabel>Name</DataListLabel>
-                  <DataListData>Jane Roe</DataListData>
-                </DataListItem>
-                <DataListItem>
-                  <DataListLabel>Email</DataListLabel>
-                  <DataListData>janeroe@foo-corp.com</DataListData>
-                </DataListItem>
-                <DataListItem>
-                  <DataListLabel>Organization</DataListLabel>
-                  <DataListData>
-                    <Link href="https://foo-corp.com">Foo Corp</Link>
-                  </DataListData>
-                </DataListItem>
-              </DataListRoot>
-            </Flex>
-            <Flex gap="2" mt="4" direction="column">
-              <Text weight="medium">Varied data 2</Text>
-              <DataListRoot direction="row">
-                <DataListItem>
-                  <DataListLabel>Status</DataListLabel>
-                  <DataListData>
-                    <Badge color="green" size="1" style={{ marginLeft: -2 }}>
-                      Active
-                    </Badge>
-                  </DataListData>
-                </DataListItem>
-                <DataListItem>
-                  <DataListLabel>Name</DataListLabel>
-                  <DataListData>Jane Roe</DataListData>
-                </DataListItem>
 
-                <DataListItem>
-                  <DataListLabel>Email</DataListLabel>
-                  <DataListData>janeroe@foo-corpcom</DataListData>
-                </DataListItem>
-
-                <DataListItem align="center">
-                  <DataListLabel>Authentication</DataListLabel>
-                  <DataListData>
-                    <Flex gap="2" mx="-1">
-                      <StarIcon />
-                      <MagicWandIcon />
-                      <StarFilledIcon />
-                    </Flex>
-                  </DataListData>
-                </DataListItem>
-              </DataListRoot>
-            </Flex>
-            <Box mb="6">
+            <Box mb="6" mt="6">
               <Heading mb="5" size="3">
                 With varied content
               </Heading>
@@ -146,7 +97,8 @@ export default function DataListPage() {
                   <DataListLabel>Authentication methods</DataListLabel>
                   <DataListData>
                     <Flex gap="2">
-                      <StarFilledIcon />
+                      <StarIcon />
+                      <MagicWandIcon />
                       <StarFilledIcon />
                     </Flex>
                   </DataListData>
@@ -190,16 +142,20 @@ export default function DataListPage() {
                   <DataListLabel>Appearance</DataListLabel>
                   <DataListData>System</DataListData>
                 </DataListItem>
-
-                <DataListLabel>Radius</DataListLabel>
-                <DataListData>Medium</DataListData>
+                <DataListItem>
+                  <DataListLabel>Radius</DataListLabel>
+                  <DataListData>Medium</DataListData>
+                </DataListItem>
               </DataListRoot>
-
-              <DataListRoot>
-                <DataListLabel>Page background</DataListLabel>
-                <DataListData>White</DataListData>
-                <DataListLabel>Link color</DataListLabel>
-                <DataListData>Blue</DataListData>
+              <DataListRoot mt="4">
+                <DataListItem>
+                  <DataListLabel>Page background</DataListLabel>
+                  <DataListData>White</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Link color</DataListLabel>
+                  <DataListData>Blue</DataListData>
+                </DataListItem>
               </DataListRoot>
             </Box>
 
@@ -220,6 +176,28 @@ export default function DataListPage() {
                   <DataListLabel width="350px">
                     Lorem ipsum dolor sit amet consectetur adipscing elit
                   </DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Box>
+
+            <Box mb="6">
+              <Heading mb="5" size="3">
+                With varied X & Y gaps
+              </Heading>
+              <DataListRoot direction={{ initial: 'column', sm: 'row' }} gapX="7" gapY="2">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Vlad Moroz</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Lorem ipsum dolor</DataListLabel>
                   <DataListData>
                     <Link href="https://workos.com">WorkOS</Link>
                   </DataListData>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -11,6 +11,7 @@ import {
   Container,
   Text,
 } from '@radix-ui/themes';
+import { StarIcon, MagicWandIcon, StarFilledIcon } from '@radix-ui/react-icons';
 
 export default function DataListPage() {
   return (
@@ -48,17 +49,15 @@ export default function DataListPage() {
             </Flex>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium">Varied data</Text>
-              <DataListRoot mt="2" direction="column" trim="both">
+              <DataListRoot mt="2" direction="column">
                 <DataListItem>
                   <DataListLabel>Name</DataListLabel>
                   <DataListData>Jane Roe</DataListData>
                 </DataListItem>
-
                 <DataListItem>
                   <DataListLabel>Email</DataListLabel>
                   <DataListData>janeroe@foo-corp.com</DataListData>
                 </DataListItem>
-
                 <DataListItem>
                   <DataListLabel>Organization</DataListLabel>
                   <DataListData>
@@ -69,7 +68,7 @@ export default function DataListPage() {
             </Flex>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium">Varied data 2</Text>
-              <DataListRoot direction="row" trim="both">
+              <DataListRoot direction="row">
                 <DataListItem>
                   <DataListLabel>Status</DataListLabel>
                   <DataListData>
@@ -92,8 +91,9 @@ export default function DataListPage() {
                   <DataListLabel>Authentication</DataListLabel>
                   <DataListData>
                     <Flex gap="2" mx="-1">
-                      {/* <ProviderIcon provider="google" size="2" />
-                    <ProviderIcon provider="microsoft" size="2" /> */}
+                      <StarIcon />
+                      <MagicWandIcon />
+                      <StarFilledIcon />
                     </Flex>
                   </DataListData>
                 </DataListItem>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -1,9 +1,12 @@
 import Link from 'next/link';
 import {
+  Badge,
   DataListRoot,
+  DataListRootGrid,
   DataListData,
   DataListItem,
   DataListLabel,
+  Flex,
   Theme,
   Container,
   Text,
@@ -16,7 +19,7 @@ export default function DataListPage() {
         <Theme>
           <Container m="6">
             <Text weight="medium">Default</Text>
-            <DataListRoot mt="2">
+            <DataListRootGrid mt="2">
               <DataListItem>
                 <DataListLabel>Obi wan</DataListLabel>
                 <DataListData>Jedi Master</DataListData>
@@ -25,11 +28,11 @@ export default function DataListPage() {
                 <DataListLabel>Anakin</DataListLabel>
                 <DataListData>Padewan</DataListData>
               </DataListItem>
-            </DataListRoot>
+            </DataListRootGrid>
           </Container>
           <Container m="6">
             <Text weight="medium">Vertical Layout</Text>
-            <DataListRoot layout="vertical" mt="2">
+            <DataListRootGrid direction="column" mt="2">
               <DataListItem>
                 <DataListLabel>Obi wan</DataListLabel>
                 <DataListData>Jedi Master</DataListData>
@@ -38,11 +41,11 @@ export default function DataListPage() {
                 <DataListLabel>Anakin</DataListLabel>
                 <DataListData>Padewan</DataListData>
               </DataListItem>
-            </DataListRoot>
+            </DataListRootGrid>
           </Container>
           <Container m="6">
             <Text weight="medium">Varied data</Text>
-            <DataListRoot mt="2">
+            <DataListRootGrid mt="2">
               <DataListItem>
                 <DataListLabel>Name</DataListLabel>
                 <DataListData>Jane Roe</DataListData>
@@ -59,7 +62,59 @@ export default function DataListPage() {
                   <Link href="https://foo-corp.com">Foo Corp</Link>
                 </DataListData>
               </DataListItem>
-            </DataListRoot>
+            </DataListRootGrid>
+          </Container>
+          <Container m="6">
+            <DataListRootGrid mt="2">
+              <DataListItem>
+                <DataListLabel>Name</DataListLabel>
+                <DataListData>Jane Roe</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Email</DataListLabel>
+                <DataListData>janeroe@foo-corp.com</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Organization</DataListLabel>
+                <DataListData>
+                  <Link href="https://foo-corp.com">Foo Corp</Link>
+                </DataListData>
+              </DataListItem>
+            </DataListRootGrid>
+          </Container>
+          <Container m="6">
+            <DataListRootGrid>
+              <DataListItem>
+                <DataListLabel>Status</DataListLabel>
+                <DataListData>
+                  <Badge color="green" size="1" style={{ marginLeft: -2 }}>
+                    Active
+                  </Badge>
+                </DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Name</DataListLabel>
+                <DataListData>Jane Roe</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Email</DataListLabel>
+                <DataListData>janeroe@foo-corpcom</DataListData>
+              </DataListItem>
+
+              <DataListItem align="center">
+                <DataListLabel>Authentication</DataListLabel>
+                <DataListData>
+                  <Flex gap="2" mx="-1">
+                    {/* <ProviderIcon provider="google" size="2" />
+                    <ProviderIcon provider="microsoft" size="2" /> */}
+                  </Flex>
+                </DataListData>
+              </DataListItem>
+            </DataListRootGrid>
           </Container>
         </Theme>
       </body>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -48,7 +48,7 @@ export default function DataListPage() {
             </Flex>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium">Varied data</Text>
-              <DataListRoot mt="2" direction="column">
+              <DataListRoot mt="2" direction="column" trim="both">
                 <DataListItem>
                   <DataListLabel>Name</DataListLabel>
                   <DataListData>Jane Roe</DataListData>
@@ -69,7 +69,7 @@ export default function DataListPage() {
             </Flex>
             <Flex gap="2" mt="4" direction="column">
               <Text weight="medium">Varied data 2</Text>
-              <DataListRoot>
+              <DataListRoot direction="row" trim="both">
                 <DataListItem>
                   <DataListLabel>Status</DataListLabel>
                   <DataListData>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import {
+  DataListRoot,
+  DataListData,
+  DataListItem,
+  DataListLabel,
+  Theme,
+  Container,
+  Text,
+} from '@radix-ui/themes';
+
+export default function DataListPage() {
+  return (
+    <html>
+      <body>
+        <Theme>
+          <Container m="6">
+            <Text weight="medium">Default</Text>
+            <DataListRoot mt="2">
+              <DataListItem>
+                <DataListLabel>Obi wan</DataListLabel>
+                <DataListData>Jedi Master</DataListData>
+              </DataListItem>
+              <DataListItem>
+                <DataListLabel>Anakin</DataListLabel>
+                <DataListData>Padewan</DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+          <Container m="6">
+            <Text weight="medium">Vertical Layout</Text>
+            <DataListRoot layout="vertical" mt="2">
+              <DataListItem>
+                <DataListLabel>Obi wan</DataListLabel>
+                <DataListData>Jedi Master</DataListData>
+              </DataListItem>
+              <DataListItem>
+                <DataListLabel>Anakin</DataListLabel>
+                <DataListData>Padewan</DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+          <Container m="6">
+            <Text weight="medium">Varied data</Text>
+            <DataListRoot mt="2">
+              <DataListItem>
+                <DataListLabel>Name</DataListLabel>
+                <DataListData>Jane Roe</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Email</DataListLabel>
+                <DataListData>janeroe@foo-corp.com</DataListData>
+              </DataListItem>
+
+              <DataListItem>
+                <DataListLabel>Organization</DataListLabel>
+                <DataListData>
+                  <Link href="https://foo-corp.com">Foo Corp</Link>
+                </DataListData>
+              </DataListItem>
+            </DataListRoot>
+          </Container>
+        </Theme>
+      </body>
+    </html>
+  );
+}

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import {
   Badge,
+  Box,
   DataListRoot,
-  DataListRootGrid,
   DataListData,
   DataListItem,
   DataListLabel,
@@ -17,105 +17,89 @@ export default function DataListPage() {
     <html>
       <body>
         <Theme>
-          <Container m="6">
-            <Text weight="medium">Default</Text>
-            <DataListRootGrid mt="2">
-              <DataListItem>
-                <DataListLabel>Obi wan</DataListLabel>
-                <DataListData>Jedi Master</DataListData>
-              </DataListItem>
-              <DataListItem>
-                <DataListLabel>Anakin</DataListLabel>
-                <DataListData>Padewan</DataListData>
-              </DataListItem>
-            </DataListRootGrid>
-          </Container>
-          <Container m="6">
-            <Text weight="medium">Vertical Layout</Text>
-            <DataListRootGrid direction="column" mt="2">
-              <DataListItem>
-                <DataListLabel>Obi wan</DataListLabel>
-                <DataListData>Jedi Master</DataListData>
-              </DataListItem>
-              <DataListItem>
-                <DataListLabel>Anakin</DataListLabel>
-                <DataListData>Padewan</DataListData>
-              </DataListItem>
-            </DataListRootGrid>
-          </Container>
-          <Container m="6">
-            <Text weight="medium">Varied data</Text>
-            <DataListRootGrid mt="2">
-              <DataListItem>
-                <DataListLabel>Name</DataListLabel>
-                <DataListData>Jane Roe</DataListData>
-              </DataListItem>
+          <Box ml="5">
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium" mb="2">
+                Default
+              </Text>
+              <DataListRoot mt="2">
+                <DataListItem>
+                  <DataListLabel>Obi wan</DataListLabel>
+                  <DataListData>Jedi Master</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Anakin</DataListLabel>
+                  <DataListData>Padewan</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Vertical Layout</Text>
+              <DataListRoot direction="column" mt="2">
+                <DataListItem>
+                  <DataListLabel>Obi wan</DataListLabel>
+                  <DataListData>Jedi Master</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Anakin</DataListLabel>
+                  <DataListData>Padewan</DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Varied data</Text>
+              <DataListRoot mt="2" direction="column">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Jane Roe</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Email</DataListLabel>
-                <DataListData>janeroe@foo-corp.com</DataListData>
-              </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>janeroe@foo-corp.com</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Organization</DataListLabel>
-                <DataListData>
-                  <Link href="https://foo-corp.com">Foo Corp</Link>
-                </DataListData>
-              </DataListItem>
-            </DataListRootGrid>
-          </Container>
-          <Container m="6">
-            <DataListRootGrid mt="2">
-              <DataListItem>
-                <DataListLabel>Name</DataListLabel>
-                <DataListData>Jane Roe</DataListData>
-              </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Organization</DataListLabel>
+                  <DataListData>
+                    <Link href="https://foo-corp.com">Foo Corp</Link>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+            <Flex gap="2" mt="4" direction="column">
+              <Text weight="medium">Varied data 2</Text>
+              <DataListRoot>
+                <DataListItem>
+                  <DataListLabel>Status</DataListLabel>
+                  <DataListData>
+                    <Badge color="green" size="1" style={{ marginLeft: -2 }}>
+                      Active
+                    </Badge>
+                  </DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Jane Roe</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Email</DataListLabel>
-                <DataListData>janeroe@foo-corp.com</DataListData>
-              </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>janeroe@foo-corpcom</DataListData>
+                </DataListItem>
 
-              <DataListItem>
-                <DataListLabel>Organization</DataListLabel>
-                <DataListData>
-                  <Link href="https://foo-corp.com">Foo Corp</Link>
-                </DataListData>
-              </DataListItem>
-            </DataListRootGrid>
-          </Container>
-          <Container m="6">
-            <DataListRootGrid>
-              <DataListItem>
-                <DataListLabel>Status</DataListLabel>
-                <DataListData>
-                  <Badge color="green" size="1" style={{ marginLeft: -2 }}>
-                    Active
-                  </Badge>
-                </DataListData>
-              </DataListItem>
-
-              <DataListItem>
-                <DataListLabel>Name</DataListLabel>
-                <DataListData>Jane Roe</DataListData>
-              </DataListItem>
-
-              <DataListItem>
-                <DataListLabel>Email</DataListLabel>
-                <DataListData>janeroe@foo-corpcom</DataListData>
-              </DataListItem>
-
-              <DataListItem align="center">
-                <DataListLabel>Authentication</DataListLabel>
-                <DataListData>
-                  <Flex gap="2" mx="-1">
-                    {/* <ProviderIcon provider="google" size="2" />
+                <DataListItem align="center">
+                  <DataListLabel>Authentication</DataListLabel>
+                  <DataListData>
+                    <Flex gap="2" mx="-1">
+                      {/* <ProviderIcon provider="google" size="2" />
                     <ProviderIcon provider="microsoft" size="2" /> */}
-                  </Flex>
-                </DataListData>
-              </DataListItem>
-            </DataListRootGrid>
-          </Container>
+                    </Flex>
+                  </DataListData>
+                </DataListItem>
+              </DataListRoot>
+            </Flex>
+          </Box>
         </Theme>
       </body>
     </html>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -188,8 +188,11 @@ export default function DataListPage() {
                 One after another
               </Heading>
               <DataListRoot>
-                <DataListLabel>Appearance</DataListLabel>
-                <DataListData>System</DataListData>
+                <DataListItem>
+                  <DataListLabel>Appearance</DataListLabel>
+                  <DataListData>System</DataListData>
+                </DataListItem>
+
                 <DataListLabel>Radius</DataListLabel>
                 <DataListData>Medium</DataListData>
               </DataListRoot>
@@ -207,15 +210,23 @@ export default function DataListPage() {
                 With long label
               </Heading>
               {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
-              <DataListRoot direction="row">
-                <DataListLabel>Name</DataListLabel>
-                <DataListData>Vlad Moroz</DataListData>
-                <DataListLabel>Email</DataListLabel>
-                <DataListData>vlad@workos.com</DataListData>
-                <DataListLabel>Lorem ipsum dolor sit amet consectetur adipscing elit</DataListLabel>
-                <DataListData>
-                  <Link href="https://workos.com">WorkOS</Link>
-                </DataListData>
+              <DataListRoot direction="row" labelWidth="350px">
+                <DataListItem>
+                  <DataListLabel>Name</DataListLabel>
+                  <DataListData>Vlad Moroz</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>Email</DataListLabel>
+                  <DataListData>vlad@workos.com</DataListData>
+                </DataListItem>
+                <DataListItem>
+                  <DataListLabel>
+                    Lorem ipsum dolor sit amet consectetur adipscing elit
+                  </DataListLabel>
+                  <DataListData>
+                    <Link href="https://workos.com">WorkOS</Link>
+                  </DataListData>
+                </DataListItem>
               </DataListRoot>
             </Box>
           </Box>

--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -8,7 +8,6 @@ import {
   DataListLabel,
   Flex,
   Theme,
-  Container,
   Text,
   Heading,
   Button,
@@ -106,8 +105,7 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With varied content
               </Heading>
-              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
-              <DataListRoot direction="row">
+              <DataListRoot direction={{ initial: 'column', sm: 'row' }}>
                 <DataListItem>
                   <DataListLabel>Status</DataListLabel>
                   <DataListData>
@@ -209,8 +207,7 @@ export default function DataListPage() {
               <Heading mb="5" size="3">
                 With long label
               </Heading>
-              {/* <DataListRoot layout={{ initial: 'vertical', sm: 'horizontal' }}> */}
-              <DataListRoot direction="row" labelWidth="350px">
+              <DataListRoot direction={{ initial: 'column', sm: 'row' }} labelWidth="350px">
                 <DataListItem>
                   <DataListLabel>Name</DataListLabel>
                   <DataListData>Vlad Moroz</DataListData>

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -31,6 +31,12 @@
   }
 }
 
+.rt-DataListRoot {
+  display: flex;
+  flex-direction: column;
+  gap: var(--data-list-gap);
+}
+
 .rt-DataListItem {
   position: relative;
   box-sizing: border-box;

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -115,8 +115,9 @@
     /* Include padding trim when leading trim is used */
     --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
     --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
-    display: table;
-    content: '';
+    /* display: table;
+    content: ''; */
+    display: none;
   }
 :where(.DataListRoot)::before {
   margin-bottom: var(--data-list-padding-trim);
@@ -134,18 +135,18 @@
 .DataListItem {
   position: relative;
   box-sizing: border-box;
+  display: flex;
 }
 
 @breakpoints {
-  .layout-vertical .DataListItem {
-    display: flex;
+  .direction-column .DataListItem {
     flex-direction: column;
     gap: var(--space-1);
-    padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2);
+    /* padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2); */
   }
-  .layout-horizontal .DataListItem {
-    display: table-row;
+  .direction-row .DataListItem {
+    flex-direction: row;
     padding: 0;
   }
 }
@@ -154,47 +155,44 @@
   --data-list-label-width: 200px;
   color: var(--gray-a11);
   box-sizing: border-box;
-  vertical-align: inherit;
+  display: block;
 }
 
 @breakpoints {
-  .layout-vertical .DataListLabel {
-    display: block;
+  .direction-column .DataListLabel {
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .layout-horizontal .DataListLabel {
-    display: table-cell;
+  .direction-row .DataListLabel {
     white-space: nowrap;
-    padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2);
+    /* padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2); */
     padding-right: var(--data-list-gap-x);
     width: var(--data-list-label-width);
   }
 }
 
 .DataListData {
-  vertical-align: inherit;
   box-sizing: border-box;
   margin: 0;
+  display: block;
 }
 
 @breakpoints {
-  .layout-vertical .DataListData {
-    display: block;
+  .direction-column .DataListData,
+  .direction-column-reverse .DataListData {
     padding: 0;
   }
-  .layout-horizontal .DataListData {
-    display: table-cell;
-
+  .direction-row .DataListData,
+  .direction-row-reverse .DataListData {
     /*
        * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
        * content to be a bit larger in height without increasing the height of each item, in case
        * there is a badge or a small button inside.
        */
-    padding-top: calc(var(--data-list-gap-y) * 0.375);
-    padding-bottom: calc(var(--data-list-gap-y) * 0.375);
+    /* padding-top: calc(var(--data-list-gap-y) * 0.375);
+    padding-bottom: calc(var(--data-list-gap-y) * 0.375); */
   }
 }
 

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -65,6 +65,7 @@
   .direction-row .DataListLabel {
     white-space: nowrap;
     width: var(--data-list-label-width);
+    flex-shrink: 0;
   }
 }
 

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,105 +1,33 @@
 @breakpoints {
   .DataListRoot.gap-0 {
-    --data-list-gap-x: 0px;
-    --data-list-gap-y: 0px;
+    --data-list-gap: 0px;
   }
   .DataListRoot.gap-1 {
-    --data-list-gap-x: var(--space-1);
-    --data-list-gap-y: var(--space-1);
+    --data-list-gap: var(--space-1);
   }
   .DataListRoot.gap-2 {
-    --data-list-gap-x: var(--space-2);
-    --data-list-gap-y: var(--space-2);
+    --data-list-gap: var(--space-2);
   }
   .DataListRoot.gap-3 {
-    --data-list-gap-x: var(--space-3);
-    --data-list-gap-y: var(--space-3);
+    --data-list-gap: var(--space-3);
   }
   .DataListRoot.gap-4 {
-    --data-list-gap-x: var(--space-4);
-    --data-list-gap-y: var(--space-4);
+    --data-list-gap: var(--space-4);
   }
   .DataListRoot.gap-5 {
-    --data-list-gap-x: var(--space-5);
-    --data-list-gap-y: var(--space-5);
+    --data-list-gap: var(--space-5);
   }
   .DataListRoot.gap-6 {
-    --data-list-gap-x: var(--space-6);
-    --data-list-gap-y: var(--space-6);
+    --data-list-gap: var(--space-6);
   }
   .DataListRoot.gap-7 {
-    --data-list-gap-x: var(--space-7);
-    --data-list-gap-y: var(--space-7);
+    --data-list-gap: var(--space-7);
   }
   .DataListRoot.gap-8 {
-    --data-list-gap-x: var(--space-8);
-    --data-list-gap-y: var(--space-8);
+    --data-list-gap: var(--space-8);
   }
   .DataListRoot.gap-9 {
-    --data-list-gap-x: var(--space-9);
-    --data-list-gap-y: var(--space-9);
-  }
-
-  .DataListRoot.gap-x-0 {
-    --data-list-gap-x: 0px;
-  }
-  .DataListRoot.gap-x-1 {
-    --data-list-gap-x: var(--space-1);
-  }
-  .DataListRoot.gap-x-2 {
-    --data-list-gap-x: var(--space-2);
-  }
-  .DataListRoot.gap-x-3 {
-    --data-list-gap-x: var(--space-3);
-  }
-  .DataListRoot.gap-x-4 {
-    --data-list-gap-x: var(--space-4);
-  }
-  .DataListRoot.gap-x-5 {
-    --data-list-gap-x: var(--space-5);
-  }
-  .DataListRoot.gap-x-6 {
-    --data-list-gap-x: var(--space-6);
-  }
-  .DataListRoot.gap-x-7 {
-    --data-list-gap-x: var(--space-7);
-  }
-  .DataListRoot.gap-x-8 {
-    --data-list-gap-x: var(--space-8);
-  }
-  .DataListRoot.gap-x-9 {
-    --data-list-gap-x: var(--space-9);
-  }
-
-  .DataListRoot.gap-y-0 {
-    --data-list-gap-y: 0px;
-  }
-  .DataListRoot.gap-y-1 {
-    --data-list-gap-y: var(--space-1);
-  }
-  .DataListRoot.gap-y-2 {
-    --data-list-gap-y: var(--space-2);
-  }
-  .DataListRoot.gap-y-3 {
-    --data-list-gap-y: var(--space-3);
-  }
-  .DataListRoot.gap-y-4 {
-    --data-list-gap-y: var(--space-4);
-  }
-  .DataListRoot.gap-y-5 {
-    --data-list-gap-y: var(--space-5);
-  }
-  .DataListRoot.gap-y-6 {
-    --data-list-gap-y: var(--space-6);
-  }
-  .DataListRoot.gap-y-7 {
-    --data-list-gap-y: var(--space-7);
-  }
-  .DataListRoot.gap-y-8 {
-    --data-list-gap-y: var(--space-8);
-  }
-  .DataListRoot.gap-y-9 {
-    --data-list-gap-y: var(--space-9);
+    --data-list-gap: var(--space-9);
   }
 }
 
@@ -116,6 +44,7 @@
   }
   .direction-row .DataListItem {
     flex-direction: row;
+    gap: var(--data-list-gap);
     padding: 0;
   }
 }
@@ -135,7 +64,6 @@
   }
   .direction-row .DataListLabel {
     white-space: nowrap;
-    padding-right: var(--data-list-gap-x);
     width: var(--data-list-label-width);
   }
 }
@@ -150,16 +78,6 @@
   .direction-column .DataListData,
   .direction-column-reverse .DataListData {
     padding: 0;
-  }
-  .direction-row .DataListData,
-  .direction-row-reverse .DataListData {
-    /*
-       * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
-       * content to be a bit larger in height without increasing the height of each item, in case
-       * there is a badge or a small button inside.
-       */
-    /* padding-top: calc(var(--data-list-gap-y) * 0.375);
-    padding-bottom: calc(var(--data-list-gap-y) * 0.375); */
   }
 }
 

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,7 +1,3 @@
-:where(.DataListRoot) {
-  margin: 0;
-}
-
 @breakpoints {
   .DataListRoot.gap-0 {
     --data-list-gap-x: 0px;
@@ -117,8 +113,6 @@
   .direction-column .DataListItem {
     flex-direction: column;
     gap: var(--space-1);
-    /* padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2); */
   }
   .direction-row .DataListItem {
     flex-direction: row;
@@ -141,8 +135,6 @@
   }
   .direction-row .DataListLabel {
     white-space: nowrap;
-    /* padding-top: calc(var(--data-list-gap-y) / 2);
-    padding-bottom: calc(var(--data-list-gap-y) / 2); */
     padding-right: var(--data-list-gap-x);
     width: var(--data-list-label-width);
   }

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -143,6 +143,8 @@
   .rt-r-direction-row .rt-DataListLabel {
     white-space: nowrap;
     width: var(--data-list-label-width);
+    min-width: var(--data-list-label-min-width);
+    max-width: var(--data-list-label-max-width);
     flex-shrink: 0;
   }
 }

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,40 +1,113 @@
 @breakpoints {
   .rt-DataListRoot.rt-r-gap-0 {
-    --data-list-gap: 0px;
+    --data-list-gap-x: 0px;
+    --data-list-gap-y: 0px;
   }
   .rt-DataListRoot.rt-r-gap-1 {
-    --data-list-gap: var(--space-1);
+    --data-list-gap-x: var(--space-1);
+    --data-list-gap-y: var(--space-1);
   }
   .rt-DataListRoot.rt-r-gap-2 {
-    --data-list-gap: var(--space-2);
+    --data-list-gap-x: var(--space-2);
+    --data-list-gap-y: var(--space-2);
   }
   .rt-DataListRoot.rt-r-gap-3 {
-    --data-list-gap: var(--space-3);
+    --data-list-gap-x: var(--space-3);
+    --data-list-gap-y: var(--space-3);
   }
   .rt-DataListRoot.rt-r-gap-4 {
-    --data-list-gap: var(--space-4);
+    --data-list-gap-x: var(--space-4);
+    --data-list-gap-y: var(--space-4);
   }
   .rt-DataListRoot.rt-r-gap-5 {
-    --data-list-gap: var(--space-5);
+    --data-list-gap-x: var(--space-5);
+    --data-list-gap-y: var(--space-5);
   }
   .rt-DataListRoot.rt-r-gap-6 {
-    --data-list-gap: var(--space-6);
+    --data-list-gap-x: var(--space-6);
+    --data-list-gap-y: var(--space-6);
   }
   .rt-DataListRoot.rt-r-gap-7 {
-    --data-list-gap: var(--space-7);
+    --data-list-gap-x: var(--space-7);
+    --data-list-gap-y: var(--space-7);
   }
   .rt-DataListRoot.rt-r-gap-8 {
-    --data-list-gap: var(--space-8);
+    --data-list-gap-x: var(--space-8);
+    --data-list-gap-y: var(--space-8);
   }
   .rt-DataListRoot.rt-r-gap-9 {
-    --data-list-gap: var(--space-9);
+    --data-list-gap-x: var(--space-9);
+    --data-list-gap-y: var(--space-9);
+  }
+
+  .rt-DataListRoot.rt-r-gap-x-0 {
+    --data-list-gap-x: 0px;
+  }
+  .rt-DataListRoot.rt-r-gap-x-1 {
+    --data-list-gap-x: var(--space-1);
+  }
+  .rt-DataListRoot.rt-r-gap-x-2 {
+    --data-list-gap-x: var(--space-2);
+  }
+  .rt-DataListRoot.rt-r-gap-x-3 {
+    --data-list-gap-x: var(--space-3);
+  }
+  .rt-DataListRoot.rt-r-gap-x-4 {
+    --data-list-gap-x: var(--space-4);
+  }
+  .rt-DataListRoot.rt-r-gap-x-5 {
+    --data-list-gap-x: var(--space-5);
+  }
+  .rt-DataListRoot.rt-r-gap-x-6 {
+    --data-list-gap-x: var(--space-6);
+  }
+  .rt-DataListRoot.rt-r-gap-x-7 {
+    --data-list-gap-x: var(--space-7);
+  }
+  .rt-DataListRoot.rt-r-gap-x-8 {
+    --data-list-gap-x: var(--space-8);
+  }
+  .rt-DataListRoot.rt-r-gap-x-9 {
+    --data-list-gap-x: var(--space-9);
+  }
+
+  .rt-DataListRoot.rt-r-gap-y-0 {
+    --data-list-gap-y: 0px;
+  }
+  .rt-DataListRoot.rt-r-gap-y-1 {
+    --data-list-gap-y: var(--space-1);
+  }
+  .rt-DataListRoot.rt-r-gap-y-2 {
+    --data-list-gap-y: var(--space-2);
+  }
+  .rt-DataListRoot.rt-r-gap-y-3 {
+    --data-list-gap-y: var(--space-3);
+  }
+  .rt-DataListRoot.rt-r-gap-y-4 {
+    --data-list-gap-y: var(--space-4);
+  }
+  .rt-DataListRoot.rt-r-gap-y-5 {
+    --data-list-gap-y: var(--space-5);
+  }
+  .rt-DataListRoot.rt-r-gap-y-6 {
+    --data-list-gap-y: var(--space-6);
+  }
+  .rt-DataListRoot.rt-r-gap-y-7 {
+    --data-list-gap-y: var(--space-7);
+  }
+  .rt-DataListRoot.rt-r-gap-y-8 {
+    --data-list-gap-y: var(--space-8);
+  }
+  .rt-DataListRoot.rt-r-gap-y-9 {
+    --data-list-gap-y: var(--space-9);
   }
 }
 
-.rt-DataListRoot {
+:where(.rt-DataListRoot) {
+  margin: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--data-list-gap);
+  row-gap: var(--data-list-gap-x);
 }
 
 .rt-DataListItem {
@@ -50,7 +123,7 @@
   }
   .rt-r-direction-row .rt-DataListItem {
     flex-direction: row;
-    gap: var(--data-list-gap);
+    gap: var(--data-list-gap-y);
     padding: 0;
   }
 }

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,32 +1,32 @@
 @breakpoints {
-  .rt-DataListRoot.gap-0 {
+  .rt-DataListRoot.rt-r-gap-0 {
     --data-list-gap: 0px;
   }
-  .rt-DataListRoot.gap-1 {
+  .rt-DataListRoot.rt-r-gap-1 {
     --data-list-gap: var(--space-1);
   }
-  .rt-DataListRoot.gap-2 {
+  .rt-DataListRoot.rt-r-gap-2 {
     --data-list-gap: var(--space-2);
   }
-  .rt-DataListRoot.gap-3 {
+  .rt-DataListRoot.rt-r-gap-3 {
     --data-list-gap: var(--space-3);
   }
-  .rt-DataListRoot.gap-4 {
+  .rt-DataListRoot.rt-r-gap-4 {
     --data-list-gap: var(--space-4);
   }
-  .rt-DataListRoot.gap-5 {
+  .rt-DataListRoot.rt-r-gap-5 {
     --data-list-gap: var(--space-5);
   }
-  .rt-DataListRoot.gap-6 {
+  .rt-DataListRoot.rt-r-gap-6 {
     --data-list-gap: var(--space-6);
   }
-  .rt-DataListRoot.gap-7 {
+  .rt-DataListRoot.rt-r-gap-7 {
     --data-list-gap: var(--space-7);
   }
-  .rt-DataListRoot.gap-8 {
+  .rt-DataListRoot.rt-r-gap-8 {
     --data-list-gap: var(--space-8);
   }
-  .rt-DataListRoot.gap-9 {
+  .rt-DataListRoot.rt-r-gap-9 {
     --data-list-gap: var(--space-9);
   }
 }

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -107,31 +107,6 @@
   }
 }
 
-/* prettier-ignore */
-.DataListRoot::before,
-  .DataListRoot::after {
-    /* Remove top and bottom item padding */
-    --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
-    /* Include padding trim when leading trim is used */
-    --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
-    --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
-    /* display: table;
-    content: ''; */
-    display: none;
-  }
-:where(.DataListRoot)::before {
-  margin-bottom: var(--data-list-padding-trim);
-}
-:where(.DataListRoot)::after {
-  margin-top: var(--data-list-padding-trim);
-}
-
-/* Make sure that consecutive data lists are spaced, regardless of leading trim */
-.DataListRoot:has(+ .DataListRoot)::after,
-.DataListRoot + .DataListRoot::before {
-  display: none;
-}
-
 .DataListItem {
   position: relative;
   box-sizing: border-box;

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,0 +1,216 @@
+:where(.DataListRoot) {
+  margin: 0;
+}
+
+@breakpoints {
+  .DataListRoot.gap-0 {
+    --data-list-gap-x: 0px;
+    --data-list-gap-y: 0px;
+  }
+  .DataListRoot.gap-1 {
+    --data-list-gap-x: var(--space-1);
+    --data-list-gap-y: var(--space-1);
+  }
+  .DataListRoot.gap-2 {
+    --data-list-gap-x: var(--space-2);
+    --data-list-gap-y: var(--space-2);
+  }
+  .DataListRoot.gap-3 {
+    --data-list-gap-x: var(--space-3);
+    --data-list-gap-y: var(--space-3);
+  }
+  .DataListRoot.gap-4 {
+    --data-list-gap-x: var(--space-4);
+    --data-list-gap-y: var(--space-4);
+  }
+  .DataListRoot.gap-5 {
+    --data-list-gap-x: var(--space-5);
+    --data-list-gap-y: var(--space-5);
+  }
+  .DataListRoot.gap-6 {
+    --data-list-gap-x: var(--space-6);
+    --data-list-gap-y: var(--space-6);
+  }
+  .DataListRoot.gap-7 {
+    --data-list-gap-x: var(--space-7);
+    --data-list-gap-y: var(--space-7);
+  }
+  .DataListRoot.gap-8 {
+    --data-list-gap-x: var(--space-8);
+    --data-list-gap-y: var(--space-8);
+  }
+  .DataListRoot.gap-9 {
+    --data-list-gap-x: var(--space-9);
+    --data-list-gap-y: var(--space-9);
+  }
+
+  .DataListRoot.gap-x-0 {
+    --data-list-gap-x: 0px;
+  }
+  .DataListRoot.gap-x-1 {
+    --data-list-gap-x: var(--space-1);
+  }
+  .DataListRoot.gap-x-2 {
+    --data-list-gap-x: var(--space-2);
+  }
+  .DataListRoot.gap-x-3 {
+    --data-list-gap-x: var(--space-3);
+  }
+  .DataListRoot.gap-x-4 {
+    --data-list-gap-x: var(--space-4);
+  }
+  .DataListRoot.gap-x-5 {
+    --data-list-gap-x: var(--space-5);
+  }
+  .DataListRoot.gap-x-6 {
+    --data-list-gap-x: var(--space-6);
+  }
+  .DataListRoot.gap-x-7 {
+    --data-list-gap-x: var(--space-7);
+  }
+  .DataListRoot.gap-x-8 {
+    --data-list-gap-x: var(--space-8);
+  }
+  .DataListRoot.gap-x-9 {
+    --data-list-gap-x: var(--space-9);
+  }
+
+  .DataListRoot.gap-y-0 {
+    --data-list-gap-y: 0px;
+  }
+  .DataListRoot.gap-y-1 {
+    --data-list-gap-y: var(--space-1);
+  }
+  .DataListRoot.gap-y-2 {
+    --data-list-gap-y: var(--space-2);
+  }
+  .DataListRoot.gap-y-3 {
+    --data-list-gap-y: var(--space-3);
+  }
+  .DataListRoot.gap-y-4 {
+    --data-list-gap-y: var(--space-4);
+  }
+  .DataListRoot.gap-y-5 {
+    --data-list-gap-y: var(--space-5);
+  }
+  .DataListRoot.gap-y-6 {
+    --data-list-gap-y: var(--space-6);
+  }
+  .DataListRoot.gap-y-7 {
+    --data-list-gap-y: var(--space-7);
+  }
+  .DataListRoot.gap-y-8 {
+    --data-list-gap-y: var(--space-8);
+  }
+  .DataListRoot.gap-y-9 {
+    --data-list-gap-y: var(--space-9);
+  }
+}
+
+/* prettier-ignore */
+.DataListRoot::before,
+  .DataListRoot::after {
+    /* Remove top and bottom item padding */
+    --data-list-padding-trim: calc(var(--data-list-gap-y) / -2);
+    /* Include padding trim when leading trim is used */
+    --leading-trim-start: calc(var(--data-list-padding-trim) + var(--default-leading-trim-start));
+    --leading-trim-end: calc(var(--data-list-padding-trim) + var(--default-leading-trim-end));
+    display: table;
+    content: '';
+  }
+:where(.DataListRoot)::before {
+  margin-bottom: var(--data-list-padding-trim);
+}
+:where(.DataListRoot)::after {
+  margin-top: var(--data-list-padding-trim);
+}
+
+/* Make sure that consecutive data lists are spaced, regardless of leading trim */
+.DataListRoot:has(+ .DataListRoot)::after,
+.DataListRoot + .DataListRoot::before {
+  display: none;
+}
+
+.DataListItem {
+  position: relative;
+  box-sizing: border-box;
+}
+
+@breakpoints {
+  .layout-vertical .DataListItem {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
+  }
+  .layout-horizontal .DataListItem {
+    display: table-row;
+    padding: 0;
+  }
+}
+
+.DataListLabel {
+  --data-list-label-width: 200px;
+  color: var(--gray-a11);
+  box-sizing: border-box;
+  vertical-align: inherit;
+}
+
+@breakpoints {
+  .layout-vertical .DataListLabel {
+    display: block;
+    white-space: normal;
+    padding: 0;
+    width: auto;
+  }
+  .layout-horizontal .DataListLabel {
+    display: table-cell;
+    white-space: nowrap;
+    padding-top: calc(var(--data-list-gap-y) / 2);
+    padding-bottom: calc(var(--data-list-gap-y) / 2);
+    padding-right: var(--data-list-gap-x);
+    width: var(--data-list-label-width);
+  }
+}
+
+.DataListData {
+  vertical-align: inherit;
+  box-sizing: border-box;
+  margin: 0;
+}
+
+@breakpoints {
+  .layout-vertical .DataListData {
+    display: block;
+    padding: 0;
+  }
+  .layout-horizontal .DataListData {
+    display: table-cell;
+
+    /*
+       * At default size, `DataListLabel` content is 20px high. We want to allow the `DataListData`
+       * content to be a bit larger in height without increasing the height of each item, in case
+       * there is a badge or a small button inside.
+       */
+    padding-top: calc(var(--data-list-gap-y) * 0.375);
+    padding-bottom: calc(var(--data-list-gap-y) * 0.375);
+  }
+}
+
+.DataListDataInner {
+  display: flex;
+}
+
+/*
+   * Improve alignment when nesting flex elements with Text. Prepending contents with a text character
+   * enforces default baseline alignment when child elements contain text within. The character used is
+   * a zero-width joiner, which is invisible, and pseudo-elements aren't copyable.
+   */
+.DataListDataInner::before {
+  content: '\200D';
+}
+
+.DataListDataInnerContents {
+  display: block;
+}

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -50,7 +50,6 @@
 }
 
 .DataListLabel {
-  --data-list-label-width: 200px;
   color: var(--gray-a11);
   box-sizing: border-box;
   display: block;

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,87 +1,87 @@
 @breakpoints {
-  .DataListRoot.gap-0 {
+  .rt-DataListRoot.gap-0 {
     --data-list-gap: 0px;
   }
-  .DataListRoot.gap-1 {
+  .rt-DataListRoot.gap-1 {
     --data-list-gap: var(--space-1);
   }
-  .DataListRoot.gap-2 {
+  .rt-DataListRoot.gap-2 {
     --data-list-gap: var(--space-2);
   }
-  .DataListRoot.gap-3 {
+  .rt-DataListRoot.gap-3 {
     --data-list-gap: var(--space-3);
   }
-  .DataListRoot.gap-4 {
+  .rt-DataListRoot.gap-4 {
     --data-list-gap: var(--space-4);
   }
-  .DataListRoot.gap-5 {
+  .rt-DataListRoot.gap-5 {
     --data-list-gap: var(--space-5);
   }
-  .DataListRoot.gap-6 {
+  .rt-DataListRoot.gap-6 {
     --data-list-gap: var(--space-6);
   }
-  .DataListRoot.gap-7 {
+  .rt-DataListRoot.gap-7 {
     --data-list-gap: var(--space-7);
   }
-  .DataListRoot.gap-8 {
+  .rt-DataListRoot.gap-8 {
     --data-list-gap: var(--space-8);
   }
-  .DataListRoot.gap-9 {
+  .rt-DataListRoot.gap-9 {
     --data-list-gap: var(--space-9);
   }
 }
 
-.DataListItem {
+.rt-DataListItem {
   position: relative;
   box-sizing: border-box;
   display: flex;
 }
 
 @breakpoints {
-  .direction-column .DataListItem {
+  .rt-r-direction-column .rt-DataListItem {
     flex-direction: column;
     gap: var(--space-1);
   }
-  .direction-row .DataListItem {
+  .rt-r-direction-row .rt-DataListItem {
     flex-direction: row;
     gap: var(--data-list-gap);
     padding: 0;
   }
 }
 
-.DataListLabel {
+.rt-DataListLabel {
   color: var(--gray-a11);
   box-sizing: border-box;
   display: block;
 }
 
 @breakpoints {
-  .direction-column .DataListLabel {
+  .rt-r-direction-column .rt-DataListLabel {
     white-space: normal;
     padding: 0;
     width: auto;
   }
-  .direction-row .DataListLabel {
+  .rt-r-direction-row .rt-DataListLabel {
     white-space: nowrap;
     width: var(--data-list-label-width);
     flex-shrink: 0;
   }
 }
 
-.DataListData {
+.rt-DataListData {
   box-sizing: border-box;
   margin: 0;
   display: block;
 }
 
 @breakpoints {
-  .direction-column .DataListData,
-  .direction-column-reverse .DataListData {
+  .rt-r-direction-column .rt-DataListData,
+  .rt-r-direction-column-reverse .rt-DataListData {
     padding: 0;
   }
 }
 
-.DataListDataInner {
+.rt-DataListDataInner {
   display: flex;
 }
 
@@ -90,10 +90,10 @@
    * enforces default baseline alignment when child elements contain text within. The character used is
    * a zero-width joiner, which is invisible, and pseudo-elements aren't copyable.
    */
-.DataListDataInner::before {
+.rt-DataListDataInner::before {
   content: '\200D';
 }
 
-.DataListDataInnerContents {
+.rt-DataListDataInnerContents {
   display: block;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -4,8 +4,8 @@ import { Flex } from './flex';
 import { Grid } from './grid';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
   direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
+  labelWidth?: number | string;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,0 +1,11 @@
+import type { Text } from './text';
+import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
+
+export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
+  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
+  layout?: Responsive<'horizontal' | 'vertical'>;
+}

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,8 +1,10 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
 import { Flex } from './flex';
+import { Grid } from './grid';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
   direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,11 +1,9 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
 import { Flex } from './flex';
-import { Grid } from './grid';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
   direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-  labelWidth?: number | string;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,9 +1,20 @@
 import type { Text } from './text';
-import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
-import { Flex } from './flex';
+import { PropDef, trimProp, textSize } from '../helpers';
+import { textPropDefs } from './text.props';
 
-export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
-  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-}
+const directionValues = ['row', 'column'] as const;
+const gapValues = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+
+export const dataListPropDefs = {
+  direction: { type: 'enum', values: directionValues, default: undefined, responsive: true },
+  gap: { type: 'enum', values: gapValues, default: '4', responsive: true },
+  gapX: { type: 'enum', values: gapValues, default: undefined, responsive: true },
+  gapY: { type: 'enum', values: gapValues, default: undefined, responsive: true },
+  size: textPropDefs.size,
+} satisfies {
+  direction?: PropDef<(typeof directionValues)[number]>;
+  gap?: PropDef<(typeof gapValues)[number]>;
+  gapX?: PropDef<(typeof gapValues)[number]>;
+  gapY?: PropDef<(typeof gapValues)[number]>;
+  size?: typeof textSize;
+};

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,16 +1,9 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
-import { Grid } from './grid';
 import { Flex } from './flex';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
   direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  rows?: React.ComponentPropsWithoutRef<typeof Grid>['rows'];
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
-  layout?: Responsive<'horizontal' | 'vertical'>;
 }

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,10 +1,15 @@
 import type { Text } from './text';
 import { MarginProps, PropsWithoutRefOrColor, Responsive } from '../helpers';
+import { Grid } from './grid';
+import { Flex } from './flex';
 
 export interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  columns?: React.ComponentPropsWithoutRef<typeof Grid>['columns'];
+  direction?: React.ComponentPropsWithoutRef<typeof Flex>['direction'];
   gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
   gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  rows?: React.ComponentPropsWithoutRef<typeof Grid>['rows'];
   size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
   trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
   layout?: Responsive<'horizontal' | 'vertical'>;

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -4,11 +4,13 @@ import { Responsive, withBreakpoints } from '../helpers';
 import { Flex } from './flex';
 import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
-import { Grid } from './grid';
 
 /*
  * decide what to do with layout prop
  * - label width
+ * - setup margin props
+ * - handle 'initial etc'
+ * - align isn't doing anything?
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,32 +1,47 @@
 import classNames from 'classnames';
 import * as React from 'react';
-import { Responsive, withBreakpoints } from '../helpers';
+import {
+  Responsive,
+  withBreakpoints,
+  MarginProps,
+  GetPropDefTypes,
+  extractMarginProps,
+  withMarginProps,
+} from '../helpers';
 import { Text } from './text';
-import { DataListRootProps } from './data-list.props';
+import { dataListPropDefs } from './data-list.props';
 
 /*
  * TODO
- * - setup margin props
- * - fixup types / enum
  * - add support for minWidth maxWidth for label
- * - support for gapX & gapY as row-gap and column-gap
  */
-
+type DataListRootOwnProps = GetPropDefTypes<typeof dataListPropDefs>;
+interface DataListRootProps
+  extends React.ComponentPropsWithoutRef<'dl'>,
+    MarginProps,
+    DataListRootOwnProps {}
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
-    <Text asChild size={size}>
-      <dl
-        ref={forwardedRef}
-        className={classNames(
-          'rt-DataListRoot',
-          withBreakpoints(gap, 'rt-r-gap'),
-          withBreakpoints(direction, 'rt-r-direction')
-        )}
-      >
-        {children}
-      </dl>
-    </Text>
-  )
+  (props, forwardedRef) => {
+    const { rest: marginRest, ...marginProps } = extractMarginProps(props);
+    const { children, direction = 'row', gap = '4', gapX, gapY, size = '2' } = marginRest;
+    return (
+      <Text asChild size={size}>
+        <dl
+          ref={forwardedRef}
+          className={classNames(
+            'rt-DataListRoot',
+            withBreakpoints(gap, 'rt-r-gap'),
+            withBreakpoints(gapX, 'rt-r-gap-x'),
+            withBreakpoints(gapY, 'rt-r-gap-y'),
+            withBreakpoints(direction, 'rt-r-direction'),
+            withMarginProps(marginProps)
+          )}
+        >
+          {children}
+        </dl>
+      </Text>
+    );
+  }
 );
 
 DataListRoot.displayName = 'DataListRootGrid';

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
 import { Flex } from './flex';
+import { Grid } from './grid';
 import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
 
@@ -14,8 +15,11 @@ import { DataListRootProps } from './data-list.props';
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
-    <Flex asChild gap={gap} direction="column">
+  (
+    { children, gap = '4', direction = 'row', columns = 'minmax(200px, 1fr) 1fr', size = '2' },
+    forwardedRef
+  ) => (
+    <Grid asChild gap={gap} columns={columns}>
       <Text asChild size={size}>
         <dl
           ref={forwardedRef}
@@ -28,7 +32,7 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
           {children}
         </dl>
       </Text>
-    </Flex>
+    </Grid>
   )
 );
 

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -72,16 +72,20 @@ DataListItem.displayName = 'DataListItem';
 
 interface DataListLabelProps extends React.ComponentPropsWithRef<'dt'> {
   width?: number | string;
+  minWidth?: number | string;
+  maxWidth?: number | string;
 }
 
 const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
-  ({ className, style, width = '200px', ...props }, forwardedRef) => (
+  ({ className, style, width, minWidth = '200px', maxWidth, ...props }, forwardedRef) => (
     <dt
       ref={forwardedRef}
       className={classNames(className, 'rt-DataListLabel')}
       style={
         {
           '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
+          '--data-list-label-min-width': typeof width === 'number' ? `${width}px` : minWidth,
+          '--data-list-label-max-width': typeof width === 'number' ? `${width}px` : maxWidth,
           ...style,
         } as React.CSSProperties
       }

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,8 +1,6 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
-import { Flex } from './flex';
-import { Grid } from './grid';
 import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
 
@@ -11,24 +9,23 @@ import { DataListRootProps } from './data-list.props';
  * - setup margin props
  * - fixup types / enum
  * - add support for minWidth maxWidth for label
+ * - support for gapX & gapY as row-gap and column-gap
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
   ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
-    <Grid asChild gap={gap}>
-      <Text asChild size={size}>
-        <dl
-          ref={forwardedRef}
-          className={classNames(
-            'rt-DataListRoot',
-            withBreakpoints(gap, 'rt-r-gap'),
-            withBreakpoints(direction, 'rt-r-direction')
-          )}
-        >
-          {children}
-        </dl>
-      </Text>
-    </Grid>
+    <Text asChild size={size}>
+      <dl
+        ref={forwardedRef}
+        className={classNames(
+          'rt-DataListRoot',
+          withBreakpoints(gap, 'rt-r-gap'),
+          withBreakpoints(direction, 'rt-r-direction')
+        )}
+      >
+        {children}
+      </dl>
+    </Text>
   )
 );
 

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -4,6 +4,7 @@ import { Responsive, withBreakpoints } from '../helpers';
 import { Flex } from './flex';
 import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
+import { Grid } from './grid';
 
 /*
  * decide what to do with layout prop
@@ -11,7 +12,7 @@ import { DataListRootProps } from './data-list.props';
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', gapX, gapY, direction = 'row', size = '2' }, forwardedRef) => (
+  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
     <Flex asChild gap={gap} direction="column">
       <Text asChild size={size}>
         <dl
@@ -19,8 +20,6 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
           className={classNames(
             'DataListRoot',
             withBreakpoints(gap, 'gap'),
-            withBreakpoints(gapX, 'gap-x'),
-            withBreakpoints(gapY, 'gap-y'),
             withBreakpoints(direction, 'direction')
           )}
         >

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,16 +1,8 @@
-import { Text } from '@radix-ui/themes';
+import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
-import { MarginProps, PropsWithoutRefOrColor, Responsive, withBreakpoints } from '../helpers';
-
-interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
-  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
-  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
-  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
-  layout?: Responsive<'horizontal' | 'vertical'>;
-}
+import { Responsive, withBreakpoints } from '../helpers';
+import { DataListRootProps } from './data-list.props';
 
 /*
  * decide what to do with layout prop
@@ -100,9 +92,4 @@ const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'
 
 DataListData.displayName = 'DataListData';
 
-export const DataList = {
-  Root: DataListRoot,
-  Item: DataListItem,
-  Label: DataListLabel,
-  Data: DataListData,
-};
+export { DataListRoot, DataListItem, DataListLabel, DataListData };

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -11,30 +11,10 @@ import { DataListRootProps } from './data-list.props';
  * - gap prop?
  * - label width
  * - trim?
+ * - add margin??
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', trim }, forwardedRef) => (
-    <Text asChild size={size} trim={trim}>
-      <dl
-        ref={forwardedRef}
-        className={classNames(
-          'DataListRoot',
-          withBreakpoints(gap, 'gap'),
-          withBreakpoints(gapX, 'gap-x'),
-          withBreakpoints(gapY, 'gap-y'),
-          withBreakpoints(layout, 'layout')
-        )}
-      >
-        {children}
-      </dl>
-    </Text>
-  )
-);
-
-DataListRoot.displayName = 'DataListRoot';
-
-const DataListRootGrid = React.forwardRef<HTMLDListElement, DataListRootProps>(
   (
     { children, gap = '4', gapX, gapY, columns, rows, direction = 'row', size = '2', trim },
     forwardedRef
@@ -58,7 +38,7 @@ const DataListRootGrid = React.forwardRef<HTMLDListElement, DataListRootProps>(
   )
 );
 
-DataListRootGrid.displayName = 'DataListRootGrid';
+DataListRoot.displayName = 'DataListRootGrid';
 
 interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
   align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;
@@ -118,4 +98,4 @@ const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'
 
 DataListData.displayName = 'DataListData';
 
-export { DataListRoot, DataListRootGrid, DataListItem, DataListLabel, DataListData };
+export { DataListRoot, DataListItem, DataListLabel, DataListData };

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,21 +1,21 @@
-import { Text } from './text';
 import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
+import { Flex } from './flex';
+import { Grid } from './grid';
+import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
 
 /*
  * decide what to do with layout prop
  * - gap prop?
  * - label width
+ * - trim?
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  (
-    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
-    forwardedRef
-  ) => (
-    <Text asChild size={size} {...props}>
+  ({ children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', trim }, forwardedRef) => (
+    <Text asChild size={size} trim={trim}>
       <dl
         ref={forwardedRef}
         className={classNames(
@@ -33,6 +33,32 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
 );
 
 DataListRoot.displayName = 'DataListRoot';
+
+const DataListRootGrid = React.forwardRef<HTMLDListElement, DataListRootProps>(
+  (
+    { children, gap = '4', gapX, gapY, columns, rows, direction = 'row', size = '2', trim },
+    forwardedRef
+  ) => (
+    <Grid asChild gap={gap} gapX={gapX} gapY={gapY} columns={columns} rows={rows}>
+      <Text asChild size={size} trim={trim}>
+        <dl
+          ref={forwardedRef}
+          className={classNames(
+            'DataListRoot',
+            withBreakpoints(gap, 'gap'),
+            withBreakpoints(gapX, 'gap-x'),
+            withBreakpoints(gapY, 'gap-y'),
+            withBreakpoints(direction, 'direction')
+          )}
+        >
+          {children}
+        </dl>
+      </Text>
+    </Grid>
+  )
+);
+
+DataListRootGrid.displayName = 'DataListRootGrid';
 
 interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
   align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;
@@ -92,4 +118,4 @@ const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'
 
 DataListData.displayName = 'DataListData';
 
-export { DataListRoot, DataListItem, DataListLabel, DataListData };
+export { DataListRoot, DataListRootGrid, DataListItem, DataListLabel, DataListData };

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -11,10 +11,6 @@ import {
 import { Text } from './text';
 import { dataListPropDefs } from './data-list.props';
 
-/*
- * TODO
- * - add support for minWidth maxWidth for label
- */
 type DataListRootOwnProps = GetPropDefTypes<typeof dataListPropDefs>;
 interface DataListRootProps
   extends React.ComponentPropsWithoutRef<'dl'>,

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -2,25 +2,18 @@ import classNames from 'classnames';
 import * as React from 'react';
 import { Responsive, withBreakpoints } from '../helpers';
 import { Flex } from './flex';
-import { Grid } from './grid';
 import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
 
 /*
  * decide what to do with layout prop
- * - gap prop?
  * - label width
- * - trim?
- * - add margin??
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  (
-    { children, gap = '4', gapX, gapY, columns, rows, direction = 'row', size = '2', trim },
-    forwardedRef
-  ) => (
-    <Grid asChild gap={gap} gapX={gapX} gapY={gapY} columns={columns} rows={rows}>
-      <Text asChild size={size} trim={trim}>
+  ({ children, gap = '4', gapX, gapY, direction = 'row', size = '2' }, forwardedRef) => (
+    <Flex asChild gap={gap} direction="column">
+      <Text asChild size={size}>
         <dl
           ref={forwardedRef}
           className={classNames(
@@ -34,7 +27,7 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
           {children}
         </dl>
       </Text>
-    </Grid>
+    </Flex>
   )
 );
 

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,0 +1,108 @@
+import { Text } from '@radix-ui/themes';
+import classNames from 'classnames';
+import * as React from 'react';
+import { MarginProps, PropsWithoutRefOrColor, Responsive, withBreakpoints } from '../helpers';
+
+interface DataListRootProps extends PropsWithoutRefOrColor<'dl'>, MarginProps {
+  gap?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapX?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  gapY?: Responsive<'0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'>;
+  size?: React.ComponentPropsWithoutRef<typeof Text>['size'];
+  trim?: React.ComponentPropsWithoutRef<typeof Text>['trim'];
+  layout?: Responsive<'horizontal' | 'vertical'>;
+}
+
+/*
+ * decide what to do with layout prop
+ * - gap prop?
+ * - label width
+ */
+
+const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
+  (
+    { children, gap = '4', gapX, gapY, layout = 'horizontal', size = '2', ...props },
+    forwardedRef
+  ) => (
+    <Text asChild size={size} {...props}>
+      <dl
+        ref={forwardedRef}
+        className={classNames(
+          'DataListRoot',
+          withBreakpoints(gap, 'gap'),
+          withBreakpoints(gapX, 'gap-x'),
+          withBreakpoints(gapY, 'gap-y'),
+          withBreakpoints(layout, 'layout')
+        )}
+      >
+        {children}
+      </dl>
+    </Text>
+  )
+);
+
+DataListRoot.displayName = 'DataListRoot';
+
+interface DataListItemProps extends React.ComponentPropsWithRef<'div'> {
+  align?: Responsive<'start' | 'center' | 'end' | 'baseline'>;
+}
+
+const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
+  ({ align, className, ...props }, forwardedRef) => (
+    <div
+      ref={forwardedRef}
+      className={classNames(
+        className,
+        'DataListItem',
+        withBreakpoints(align, 'va', {
+          start: 'top',
+          center: 'middle',
+          end: 'bottom',
+        })
+      )}
+      {...props}
+    />
+  )
+);
+
+DataListItem.displayName = 'DataListItem';
+
+interface DataListLabelProps extends React.ComponentPropsWithRef<'dt'> {
+  width?: number | string;
+}
+
+const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
+  ({ className, style, width, ...props }, forwardedRef) => (
+    <dt
+      ref={forwardedRef}
+      className={classNames(className, 'DataListLabel')}
+      style={
+        {
+          '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
+          ...style,
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+);
+
+DataListLabel.displayName = 'DataListLabel';
+
+const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'dd'>>(
+  ({ children, className, ...props }, forwardedRef) => (
+    <dd ref={forwardedRef} className={classNames(className, 'DataListData')} {...props}>
+      <span className="DataListDataInner">
+        <span className="DataListDataInnerContents">{children}</span>
+      </span>
+    </dd>
+  )
+);
+
+DataListData.displayName = 'DataListData';
+
+export const DataList = {
+  Root: DataListRoot,
+  Item: DataListItem,
+  Label: DataListLabel,
+  Data: DataListData,
+};

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -15,11 +15,8 @@ import { DataListRootProps } from './data-list.props';
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  (
-    { children, gap = '4', direction = 'row', columns = 'minmax(200px, 1fr) 1fr', size = '2' },
-    forwardedRef
-  ) => (
-    <Grid asChild gap={gap} columns={columns}>
+  ({ children, gap = '4', direction = 'row', labelWidth = '200px', size = '2' }, forwardedRef) => (
+    <Grid asChild gap={gap}>
       <Text asChild size={size}>
         <dl
           ref={forwardedRef}
@@ -28,6 +25,12 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
             withBreakpoints(gap, 'gap'),
             withBreakpoints(direction, 'direction')
           )}
+          style={
+            {
+              '--data-list-label-width':
+                typeof labelWidth === 'number' ? `${labelWidth}px` : labelWidth,
+            } as React.CSSProperties
+          }
         >
           {children}
         </dl>
@@ -73,7 +76,6 @@ const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
       className={classNames(className, 'DataListLabel')}
       style={
         {
-          '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
           ...style,
         } as React.CSSProperties
       }

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -21,9 +21,9 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
         <dl
           ref={forwardedRef}
           className={classNames(
-            'DataListRoot',
-            withBreakpoints(gap, 'gap'),
-            withBreakpoints(direction, 'direction')
+            'rt-DataListRoot',
+            withBreakpoints(gap, 'rt-r-gap'),
+            withBreakpoints(direction, 'rt-r-direction')
           )}
           style={
             {
@@ -51,8 +51,8 @@ const DataListItem = React.forwardRef<HTMLDivElement, DataListItemProps>(
       ref={forwardedRef}
       className={classNames(
         className,
-        'DataListItem',
-        withBreakpoints(align, 'va', {
+        'rt-DataListItem',
+        withBreakpoints(align, 'rt-r-va', {
           start: 'top',
           center: 'middle',
           end: 'bottom',
@@ -73,7 +73,7 @@ const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
   ({ className, style, width, ...props }, forwardedRef) => (
     <dt
       ref={forwardedRef}
-      className={classNames(className, 'DataListLabel')}
+      className={classNames(className, 'rt-DataListLabel')}
       style={
         {
           ...style,
@@ -88,9 +88,9 @@ DataListLabel.displayName = 'DataListLabel';
 
 const DataListData = React.forwardRef<HTMLElement, React.ComponentPropsWithRef<'dd'>>(
   ({ children, className, ...props }, forwardedRef) => (
-    <dd ref={forwardedRef} className={classNames(className, 'DataListData')} {...props}>
-      <span className="DataListDataInner">
-        <span className="DataListDataInnerContents">{children}</span>
+    <dd ref={forwardedRef} className={classNames(className, 'rt-DataListData')} {...props}>
+      <span className="rt-DataListDataInner">
+        <span className="rt-DataListDataInnerContents">{children}</span>
       </span>
     </dd>
   )

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -10,6 +10,7 @@ import { DataListRootProps } from './data-list.props';
  * TODO
  * - setup margin props
  * - fixup types / enum
+ * - add support for minWidth maxWidth for label
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -7,15 +7,13 @@ import { Text } from './text';
 import { DataListRootProps } from './data-list.props';
 
 /*
- * decide what to do with layout prop
- * - label width
+ * TODO
  * - setup margin props
- * - handle 'initial etc'
- * - align isn't doing anything?
+ * - fixup types / enum
  */
 
 const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
-  ({ children, gap = '4', direction = 'row', labelWidth = '200px', size = '2' }, forwardedRef) => (
+  ({ children, gap = '4', direction = 'row', size = '2' }, forwardedRef) => (
     <Grid asChild gap={gap}>
       <Text asChild size={size}>
         <dl
@@ -25,12 +23,6 @@ const DataListRoot = React.forwardRef<HTMLDListElement, DataListRootProps>(
             withBreakpoints(gap, 'rt-r-gap'),
             withBreakpoints(direction, 'rt-r-direction')
           )}
-          style={
-            {
-              '--data-list-label-width':
-                typeof labelWidth === 'number' ? `${labelWidth}px` : labelWidth,
-            } as React.CSSProperties
-          }
         >
           {children}
         </dl>
@@ -70,12 +62,13 @@ interface DataListLabelProps extends React.ComponentPropsWithRef<'dt'> {
 }
 
 const DataListLabel = React.forwardRef<HTMLElement, DataListLabelProps>(
-  ({ className, style, width, ...props }, forwardedRef) => (
+  ({ className, style, width = '200px', ...props }, forwardedRef) => (
     <dt
       ref={forwardedRef}
       className={classNames(className, 'rt-DataListLabel')}
       style={
         {
+          '--data-list-label-width': typeof width === 'number' ? `${width}px` : width,
           ...style,
         } as React.CSSProperties
       }

--- a/packages/radix-ui-themes/src/components/index.ts
+++ b/packages/radix-ui-themes/src/components/index.ts
@@ -143,6 +143,8 @@ export { Callout, CalloutRoot, CalloutIcon, CalloutText } from './callout';
 export * from './callout.props';
 export { Card } from './card';
 export * from './card.props';
+export { DataListRoot, DataListData, DataListItem, DataListLabel } from './data-list';
+export * from './data-list.props';
 // export * from './collapsible';
 // export * from './definition-list';
 export { IconButton } from './icon-button';

--- a/packages/radix-ui-themes/src/components/index.ts
+++ b/packages/radix-ui-themes/src/components/index.ts
@@ -143,7 +143,13 @@ export { Callout, CalloutRoot, CalloutIcon, CalloutText } from './callout';
 export * from './callout.props';
 export { Card } from './card';
 export * from './card.props';
-export { DataListRoot, DataListData, DataListItem, DataListLabel } from './data-list';
+export {
+  DataListRoot,
+  DataListRootGrid,
+  DataListData,
+  DataListItem,
+  DataListLabel,
+} from './data-list';
 export * from './data-list.props';
 // export * from './collapsible';
 // export * from './definition-list';

--- a/packages/radix-ui-themes/src/components/index.ts
+++ b/packages/radix-ui-themes/src/components/index.ts
@@ -143,13 +143,7 @@ export { Callout, CalloutRoot, CalloutIcon, CalloutText } from './callout';
 export * from './callout.props';
 export { Card } from './card';
 export * from './card.props';
-export {
-  DataListRoot,
-  DataListRootGrid,
-  DataListData,
-  DataListItem,
-  DataListLabel,
-} from './data-list';
+export { DataListRoot, DataListData, DataListItem, DataListLabel } from './data-list';
 export * from './data-list.props';
 // export * from './collapsible';
 // export * from './definition-list';

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -1,17 +1,15 @@
 import { weightProp, alignProp, trimProp, colorProp, highContrastProp } from '../helpers';
-import type { PropDef } from '../helpers';
-
-const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+import { textSize } from '../helpers/props/text-size.prop';
 
 const textPropDefs = {
-  size: { type: 'enum', values: sizes, default: undefined, responsive: true },
+  size: textSize,
   weight: weightProp,
   align: alignProp,
   trim: trimProp,
   color: colorProp,
   highContrast: highContrastProp,
 } satisfies {
-  size: PropDef<(typeof sizes)[number]>;
+  size: typeof textSize;
   weight: typeof weightProp;
   align: typeof alignProp;
   trim: typeof trimProp;

--- a/packages/radix-ui-themes/src/helpers/props/index.ts
+++ b/packages/radix-ui-themes/src/helpers/props/index.ts
@@ -7,4 +7,5 @@ export * from './margin.props';
 export * from './prop-def';
 export * from './radius.prop';
 export * from './text-align.prop';
+export * from './text-size.prop';
 export * from './weight.prop';

--- a/packages/radix-ui-themes/src/helpers/props/text-size.prop.ts
+++ b/packages/radix-ui-themes/src/helpers/props/text-size.prop.ts
@@ -1,0 +1,12 @@
+import type { PropDef } from '..';
+
+const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
+
+const textSize = {
+  type: 'enum',
+  values: sizes,
+  default: undefined,
+  responsive: true,
+} satisfies PropDef<(typeof sizes)[number]>;
+
+export { textSize };

--- a/packages/radix-ui-themes/src/styles/index.css
+++ b/packages/radix-ui-themes/src/styles/index.css
@@ -22,6 +22,7 @@
 @import '../components/code.css';
 @import '../components/container.css';
 @import '../components/context-menu.css';
+@import '../components/data-list.css';
 @import '../components/dialog.css';
 @import '../components/dropdown-menu.css';
 @import '../components/em.css';


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

🚧 WIP

## Description

[See testing page](https://themes-playground-git-ksadds-data-list-grid-exploration-modulz.vercel.app/test-data-list)

This exploration reworks the layout using `flex` instead of `table` styles. The intention here is that we can support responsive `width` properties with the `Label` component. 

The 'gotcha' here is that this won't work with `trim` at the root level since the `::before` & `::after` pseudoelements are treated as a flex item and will add extra gap. 

### Still todo
- Fix props defs
- Support `gapX` and `gapY`
- Support `min-width` and `max-width` for the label. 

## Testing steps

<!-- Describe step by step how to test the change being introduced -->

## Relates issues / PRs

#231 
#230 

<!-- List out related issues and PR links -->
