### PR TITLE
Fix trim classname

### DIFF
--- a/packages/radix-ui-themes/src/helpers/props/leading-trim.prop.ts
+++ b/packages/radix-ui-themes/src/helpers/props/leading-trim.prop.ts
@@ -4,7 +4,7 @@ const trimValues = ['normal', 'start', 'end', 'both'] as const;
 
 const trimProp = {
   type: 'enum',
-  className: 'rt-r-trim',
+  className: 'rt-r-lt',
   values: trimValues,
   default: undefined,
   responsive: true,


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

I believe this was a small bug from #235. See the classes [used in this file](https://github.com/radix-ui/themes/blob/main/packages/radix-ui-themes/src/styles/utilities/leading-trim.css) `rt-r-lt-*`
