### PR TITLE
Add color prop to CheckboxItem and RadioItem

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4771,7 +4771,7 @@ function DropdownMenuContentDemo(props: React.ComponentProps<typeof DropdownMenu
         <>
           <DropdownMenuSeparator />
 
-          <DropdownMenuCheckboxItem color="indigo" shortcut="⌘+B" checked>
+          <DropdownMenuCheckboxItem shortcut="⌘+B" checked>
             Show Bookmarks
           </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem>Show Full URLs</DropdownMenuCheckboxItem>
@@ -4780,9 +4780,7 @@ function DropdownMenuContentDemo(props: React.ComponentProps<typeof DropdownMenu
 
           <DropdownMenuLabel>People</DropdownMenuLabel>
           <DropdownMenuRadioGroup value="pedro">
-            <DropdownMenuRadioItem color="indigo" value="pedro">
-              Pedro Duarte
-            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="pedro">Pedro Duarte</DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="colm">Colm Tuite</DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
 
@@ -4828,7 +4826,7 @@ function ContextMenuContentDemo(props: React.ComponentProps<typeof ContextMenuCo
         <>
           <ContextMenuSeparator />
 
-          <ContextMenuCheckboxItem color="indigo" shortcut="⌘+B" checked>
+          <ContextMenuCheckboxItem shortcut="⌘+B" checked>
             Show Bookmarks
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem>Show Full URLs</ContextMenuCheckboxItem>
@@ -4837,9 +4835,7 @@ function ContextMenuContentDemo(props: React.ComponentProps<typeof ContextMenuCo
 
           <ContextMenuLabel>People</ContextMenuLabel>
           <ContextMenuRadioGroup value="pedro">
-            <ContextMenuRadioItem color="indigo" value="pedro">
-              Pedro Duarte
-            </ContextMenuRadioItem>
+            <ContextMenuRadioItem value="pedro">Pedro Duarte</ContextMenuRadioItem>
             <ContextMenuRadioItem value="colm">Colm Tuite</ContextMenuRadioItem>
           </ContextMenuRadioGroup>
 

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4771,7 +4771,7 @@ function DropdownMenuContentDemo(props: React.ComponentProps<typeof DropdownMenu
         <>
           <DropdownMenuSeparator />
 
-          <DropdownMenuCheckboxItem shortcut="⌘+B" checked>
+          <DropdownMenuCheckboxItem color="indigo" shortcut="⌘+B" checked>
             Show Bookmarks
           </DropdownMenuCheckboxItem>
           <DropdownMenuCheckboxItem>Show Full URLs</DropdownMenuCheckboxItem>
@@ -4780,7 +4780,9 @@ function DropdownMenuContentDemo(props: React.ComponentProps<typeof DropdownMenu
 
           <DropdownMenuLabel>People</DropdownMenuLabel>
           <DropdownMenuRadioGroup value="pedro">
-            <DropdownMenuRadioItem value="pedro">Pedro Duarte</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem color="indigo" value="pedro">
+              Pedro Duarte
+            </DropdownMenuRadioItem>
             <DropdownMenuRadioItem value="colm">Colm Tuite</DropdownMenuRadioItem>
           </DropdownMenuRadioGroup>
 
@@ -4826,7 +4828,7 @@ function ContextMenuContentDemo(props: React.ComponentProps<typeof ContextMenuCo
         <>
           <ContextMenuSeparator />
 
-          <ContextMenuCheckboxItem shortcut="⌘+B" checked>
+          <ContextMenuCheckboxItem color="indigo" shortcut="⌘+B" checked>
             Show Bookmarks
           </ContextMenuCheckboxItem>
           <ContextMenuCheckboxItem>Show Full URLs</ContextMenuCheckboxItem>
@@ -4835,7 +4837,9 @@ function ContextMenuContentDemo(props: React.ComponentProps<typeof ContextMenuCo
 
           <ContextMenuLabel>People</ContextMenuLabel>
           <ContextMenuRadioGroup value="pedro">
-            <ContextMenuRadioItem value="pedro">Pedro Duarte</ContextMenuRadioItem>
+            <ContextMenuRadioItem color="indigo" value="pedro">
+              Pedro Duarte
+            </ContextMenuRadioItem>
             <ContextMenuRadioItem value="colm">Colm Tuite</ContextMenuRadioItem>
           </ContextMenuRadioGroup>
 

--- a/packages/radix-ui-themes/src/components/base-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/base-menu.props.ts
@@ -36,9 +36,22 @@ const baseMenuItemPropDefs = {
 };
 
 const baseMenuCheckboxItemPropDefs = {
+  color: colorProp,
   shortcut: { type: 'string', default: undefined },
 } satisfies {
+  color: typeof colorProp;
   shortcut: PropDef<string>;
 };
 
-export { baseMenuContentPropDefs, baseMenuItemPropDefs, baseMenuCheckboxItemPropDefs };
+const baseMenuRadioItemPropDefs = {
+  color: colorProp,
+} satisfies {
+  color: typeof colorProp;
+};
+
+export {
+  baseMenuContentPropDefs,
+  baseMenuItemPropDefs,
+  baseMenuCheckboxItemPropDefs,
+  baseMenuRadioItemPropDefs,
+};

--- a/packages/radix-ui-themes/src/components/context-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/context-menu.props.ts
@@ -2,4 +2,5 @@ export {
   baseMenuContentPropDefs as contextMenuContentPropDefs,
   baseMenuItemPropDefs as contextMenuItemPropDefs,
   baseMenuCheckboxItemPropDefs as contextMenuCheckboxItemPropDefs,
+  baseMenuRadioItemPropDefs as contextMenuRadioItemPropDefs,
 } from './base-menu.props';

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -9,6 +9,7 @@ import {
   contextMenuContentPropDefs,
   contextMenuItemPropDefs,
   contextMenuCheckboxItemPropDefs,
+  contextMenuRadioItemPropDefs,
 } from './context-menu.props';
 import { extractProps } from '../helpers';
 import { Theme, useThemeContext } from '../theme';
@@ -166,7 +167,7 @@ const ContextMenuRadioGroup = React.forwardRef<
 ContextMenuRadioGroup.displayName = 'ContextMenuRadioGroup';
 
 type ContextMenuRadioItemElement = React.ElementRef<typeof ContextMenuPrimitive.RadioItem>;
-type ContextMenuRadioItemOwnProps = GetPropDefTypes<typeof contextMenuItemPropDefs>;
+type ContextMenuRadioItemOwnProps = GetPropDefTypes<typeof contextMenuRadioItemPropDefs>;
 interface ContextMenuRadioItemProps
   extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.RadioItem>,
     ContextMenuRadioItemOwnProps {}
@@ -177,7 +178,7 @@ const ContextMenuRadioItem = React.forwardRef<
   const {
     children,
     className,
-    color = contextMenuItemPropDefs.color.default,
+    color = contextMenuRadioItemPropDefs.color.default,
     ...itemProps
   } = props;
   return (
@@ -215,7 +216,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
     children,
     className,
     shortcut,
-    color = contextMenuItemPropDefs.color.default,
+    color = contextMenuCheckboxItemPropDefs.color.default,
     ...itemProps
   } = props;
   return (

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -166,17 +166,25 @@ const ContextMenuRadioGroup = React.forwardRef<
 ContextMenuRadioGroup.displayName = 'ContextMenuRadioGroup';
 
 type ContextMenuRadioItemElement = React.ElementRef<typeof ContextMenuPrimitive.RadioItem>;
+type ContextMenuRadioItemOwnProps = GetPropDefTypes<typeof contextMenuItemPropDefs>;
 interface ContextMenuRadioItemProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem> {}
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.RadioItem>,
+    ContextMenuRadioItemOwnProps {}
 const ContextMenuRadioItem = React.forwardRef<
   ContextMenuRadioItemElement,
   ContextMenuRadioItemProps
 >((props, forwardedRef) => {
-  const { children, className, ...itemProps } = props;
+  const {
+    children,
+    className,
+    color = contextMenuItemPropDefs.color.default,
+    ...itemProps
+  } = props;
   return (
     <ContextMenuPrimitive.RadioItem
       {...itemProps}
       ref={forwardedRef}
+      data-accent-color={color}
       className={classNames(
         'rt-BaseMenuItem',
         'rt-BaseMenuRadioItem',
@@ -197,17 +205,24 @@ ContextMenuRadioItem.displayName = 'ContextMenuRadioItem';
 type ContextMenuCheckboxItemElement = React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>;
 type ContextMenuCheckboxItemOwnProps = GetPropDefTypes<typeof contextMenuCheckboxItemPropDefs>;
 interface ContextMenuCheckboxItemProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.CheckboxItem>,
     ContextMenuCheckboxItemOwnProps {}
 const ContextMenuCheckboxItem = React.forwardRef<
   ContextMenuCheckboxItemElement,
   ContextMenuCheckboxItemProps
 >((props, forwardedRef) => {
-  const { children, className, shortcut, ...itemProps } = props;
+  const {
+    children,
+    className,
+    shortcut,
+    color = contextMenuItemPropDefs.color.default,
+    ...itemProps
+  } = props;
   return (
     <ContextMenuPrimitive.CheckboxItem
       {...itemProps}
       ref={forwardedRef}
+      data-accent-color={color}
       className={classNames(
         'rt-BaseMenuItem',
         'rt-BaseMenuCheckboxItem',

--- a/packages/radix-ui-themes/src/components/dropdown-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.props.ts
@@ -2,4 +2,5 @@ export {
   baseMenuContentPropDefs as dropdownMenuContentPropDefs,
   baseMenuItemPropDefs as dropdownMenuItemPropDefs,
   baseMenuCheckboxItemPropDefs as dropdownMenuCheckboxItemPropDefs,
+  baseMenuRadioItemPropDefs as dropdownMenuRadioItemPropDefs,
 } from './base-menu.props';

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -9,6 +9,7 @@ import {
   dropdownMenuContentPropDefs,
   dropdownMenuItemPropDefs,
   dropdownMenuCheckboxItemPropDefs,
+  dropdownMenuRadioItemPropDefs,
 } from './dropdown-menu.props';
 import { extractProps } from '../helpers';
 import { Theme, useThemeContext } from '../theme';
@@ -167,7 +168,7 @@ const DropdownMenuRadioGroup = React.forwardRef<
 DropdownMenuRadioGroup.displayName = 'DropdownMenuRadioGroup';
 
 type DropdownMenuRadioItemElement = React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>;
-type DropdownMenuRadioItemOwnProps = GetPropDefTypes<typeof dropdownMenuItemPropDefs>;
+type DropdownMenuRadioItemOwnProps = GetPropDefTypes<typeof dropdownMenuRadioItemPropDefs>;
 interface DropdownMenuRadioItemProps
   extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.RadioItem>,
     DropdownMenuRadioItemOwnProps {}
@@ -178,7 +179,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   const {
     children,
     className,
-    color = dropdownMenuItemPropDefs.color.default,
+    color = dropdownMenuRadioItemPropDefs.color.default,
     ...itemProps
   } = props;
   return (
@@ -216,7 +217,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     children,
     className,
     shortcut,
-    color = dropdownMenuItemPropDefs.color.default,
+    color = dropdownMenuCheckboxItemPropDefs.color.default,
     ...itemProps
   } = props;
   return (

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -167,17 +167,25 @@ const DropdownMenuRadioGroup = React.forwardRef<
 DropdownMenuRadioGroup.displayName = 'DropdownMenuRadioGroup';
 
 type DropdownMenuRadioItemElement = React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>;
+type DropdownMenuRadioItemOwnProps = GetPropDefTypes<typeof dropdownMenuItemPropDefs>;
 interface DropdownMenuRadioItemProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.RadioItem>,
+    DropdownMenuRadioItemOwnProps {}
 const DropdownMenuRadioItem = React.forwardRef<
   DropdownMenuRadioItemElement,
   DropdownMenuRadioItemProps
 >((props, forwardedRef) => {
-  const { children, className, ...itemProps } = props;
+  const {
+    children,
+    className,
+    color = dropdownMenuItemPropDefs.color.default,
+    ...itemProps
+  } = props;
   return (
     <DropdownMenuPrimitive.RadioItem
       {...itemProps}
       ref={forwardedRef}
+      data-accent-color={color}
       className={classNames(
         'rt-BaseMenuItem',
         'rt-BaseMenuRadioItem',
@@ -198,17 +206,24 @@ DropdownMenuRadioItem.displayName = 'DropdownMenuRadioItem';
 type DropdownMenuCheckboxItemElement = React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>;
 type DropdownMenuCheckboxItemOwnProps = GetPropDefTypes<typeof dropdownMenuCheckboxItemPropDefs>;
 interface DropdownMenuCheckboxItemProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.CheckboxItem>,
     DropdownMenuCheckboxItemOwnProps {}
 const DropdownMenuCheckboxItem = React.forwardRef<
   DropdownMenuCheckboxItemElement,
   DropdownMenuCheckboxItemProps
 >((props, forwardedRef) => {
-  const { children, className, shortcut, ...itemProps } = props;
+  const {
+    children,
+    className,
+    shortcut,
+    color = dropdownMenuItemPropDefs.color.default,
+    ...itemProps
+  } = props;
   return (
     <DropdownMenuPrimitive.CheckboxItem
       {...itemProps}
       ref={forwardedRef}
+      data-accent-color={color}
       className={classNames(
         'rt-BaseMenuItem',
         'rt-BaseMenuCheckboxItem',


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

I've added the option to specify a color to `DropdownMenu.RadioItem`, `DropdownMenu.CheckboxItem`, `ContextMenu.RadioItem` and `ContextMenu.CheckboxItem`.

When I was using the library I found it unintuitive that you could specify a color the `DropdownMenu.Item` but not the the others. When reading the docs I thought I would be able to specify a color to these items also

## Testing steps

I've added examples in the sink: 

<img width="938" alt="image" src="https://github.com/radix-ui/themes/assets/32642720/f7033ef9-7aec-4280-97d4-ed04ceb729bd">

<img width="564" alt="image" src="https://github.com/radix-ui/themes/assets/32642720/e5942208-d112-4052-855a-b0c4cf4e8177">


## Relates issues / PRs

None, decided to fix it myself instead of creating an issue
