### PR TITLE
`TextField`: Fix getSelectionRange issue

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -45,6 +45,8 @@
   - Add `color` and `highContrast` props to `TabsList`
 - `TextArea`
   - Add `radius` prop
+- `TextField`
+  - Fix an issue with some input `type`s not supporting `getSelectionRange`
 
 ## 2.0.3
 

--- a/packages/radix-ui-themes/src/components/text-field.tsx
+++ b/packages/radix-ui-themes/src/components/text-field.tsx
@@ -47,7 +47,11 @@ const TextFieldRoot = React.forwardRef<TextFieldRootElement, TextFieldRootProps>
           const cursorPosition = targetIsBeforeInput ? 0 : input.value.length;
 
           requestAnimationFrame(() => {
-            input.setSelectionRange(cursorPosition, cursorPosition);
+            // Only some input types support this, browsers will throw an error if not supported
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange#:~:text=Note%20that%20according,not%20support%20selection%22.
+            try {
+              input.setSelectionRange(cursorPosition, cursorPosition);
+            } catch (e) {}
             input.focus();
           });
         })}


### PR DESCRIPTION
See https://linear.app/workos/issue/UI-41/textfield-bug-with-certain-input-types for context