### PR TITLE
Improve how accent color and high contrast work when components are nested

### DIFF
--- a/apps/playground/app/test-high-contrast/page.tsx
+++ b/apps/playground/app/test-high-contrast/page.tsx
@@ -1,0 +1,693 @@
+import * as React from 'react';
+import {
+  Text,
+  Theme,
+  Container,
+  Section,
+  Flex,
+  Heading,
+  CalloutRoot,
+  CalloutText,
+  Link,
+  Code,
+  Blockquote,
+} from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Container px="8">
+                <Section size="3">
+                  <Flex direction="column" gap="9">
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        No color
+                      </Text>
+
+                      <Heading>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Heading>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Code size="2">
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Code>
+
+                      <CalloutRoot>
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        No color, high contrast
+                      </Text>
+
+                      <Heading highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Heading>
+
+                      <Text highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text highContrast>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Blockquote highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote highContrast>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Code highContrast size="2">
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Code>
+
+                      <CalloutRoot highContrast>
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All inline components with {'color="indigo"'}
+                      </Text>
+
+                      <Heading>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Heading>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" href="#">
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" href="#">
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Code size="2">
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Code>
+
+                      <CalloutRoot>
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>{' '}
+                          to a{' '}
+                          <Link color="indigo" href="#">
+                            zephyr
+                          </Link>
+                          .
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All inline components with {'color="indigo"'} and high contrast
+                      </Text>
+
+                      <Heading>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Heading>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" highContrast href="#">
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text>
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" highContrast href="#">
+                          prefers{' '}
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" highContrast href="#">
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote>
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" highContrast href="#">
+                          prefers{' '}
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Code size="2">
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" highContrast href="#">
+                          prefers{' '}
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Code>
+
+                      <CalloutRoot>
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code color="indigo" highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>{' '}
+                          to a{' '}
+                          <Link color="indigo" highContrast href="#">
+                            zephyr
+                          </Link>
+                          .
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All wrapping components with {'color="indigo"'}
+                      </Text>
+
+                      <Heading color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Heading>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Code size="2" color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Code>
+
+                      <CalloutRoot color="indigo">
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All wrapping components with {'color="indigo"'} and high contrast
+                      </Text>
+
+                      <Heading color="indigo" highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Heading>
+
+                      <Text color="indigo" highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text color="indigo" highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Text color="indigo" highContrast>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Text>
+
+                      <Blockquote color="indigo" highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote color="indigo" highContrast>
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Blockquote color="indigo" highContrast>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Blockquote>
+
+                      <Code size="2" color="indigo" highContrast>
+                        Ambiguous voice of a heart which{' '}
+                        <Link href="#">
+                          prefers <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a <Link href="#">zephyr</Link>.
+                      </Code>
+
+                      <CalloutRoot color="indigo" highContrast>
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All wrapping components with {'color="indigo"'} and inline components with
+                        high contrast
+                      </Text>
+
+                      <Heading color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Heading>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link highContrast href="#">
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link highContrast href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Code size="2" color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Code>
+
+                      <CalloutRoot color="indigo">
+                        <CalloutText>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>{' '}
+                          to a{' '}
+                          <Link highContrast href="#">
+                            zephyr
+                          </Link>
+                          .
+                        </CalloutText>
+                      </CalloutRoot>
+                    </Flex>
+                  </Flex>
+                </Section>
+              </Container>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -21,6 +21,7 @@
     - `gridRow`, `gridRowStart`, `gridRowEnd`
   - Deprecate `shrink` and `grow` props in favour of `flexShrink` and `flexGrow`. The older `shrink` and `grow` props will be removed in the next major release.
   - Update the type signature of the layout props so that code editor suggestions use just space scale values when possible. CSS keywords and other values such as `"auto"` or `"100vw"` are still available as manual string values.
+  - Make sure `highContrast` text colors work consistently when nested within other components that accept accent color
 - 4 new components
   - `Progress`
   - `Skeleton`
@@ -28,6 +29,8 @@
   - `TabNav`
 - `AlertDialog`, `Dialog`, `Popover`, `HoverCard`, `Tooltip`
   - Add `position: relative` to support absolutely positioned children.
+- `Code`
+  - `variant="ghost"` color now works similarly to Text, inheriting the color unless set explicitly using the `color` prop
 - `Container`, `Section`
   - Change the incorrect `display="block"` value to `display="initial"`
 - `Checkbox`, `RadioGroup`, `Switch`

--- a/packages/radix-ui-themes/src/components/avatar.props.ts
+++ b/packages/radix-ui-themes/src/components/avatar.props.ts
@@ -7,7 +7,7 @@ const variants = ['solid', 'soft'] as const;
 const avatarPropDefs = {
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '3', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  color: { ...colorProp, default: undefined },
+  color: colorProp,
   highContrast: highContrastProp,
   radius: radiusProp,
   fallback: { type: 'ReactNode', default: undefined, required: true },

--- a/packages/radix-ui-themes/src/components/badge.props.ts
+++ b/packages/radix-ui-themes/src/components/badge.props.ts
@@ -7,7 +7,7 @@ const variants = ['solid', 'soft', 'surface', 'outline'] as const;
 const badgePropDefs = {
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '1', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  color: { ...colorProp, default: undefined },
+  color: colorProp,
   highContrast: highContrastProp,
   radius: radiusProp,
 } satisfies {

--- a/packages/radix-ui-themes/src/components/base-tab-list.props.ts
+++ b/packages/radix-ui-themes/src/components/base-tab-list.props.ts
@@ -4,7 +4,7 @@ const sizes = ['1', '2'] as const;
 
 const baseTabListPropDefs = {
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
-  color: { ...colorProp, default: undefined },
+  color: colorProp,
   highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/callout.props.ts
+++ b/packages/radix-ui-themes/src/components/callout.props.ts
@@ -7,7 +7,7 @@ const variants = ['soft', 'surface', 'outline'] as const;
 const calloutRootPropDefs = {
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  color: { ...colorProp, default: undefined },
+  color: colorProp,
   highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/checkbox.css
+++ b/packages/radix-ui-themes/src/components/checkbox.css
@@ -150,7 +150,7 @@
 
   &:where([data-state='checked']) {
     & :where(.rt-CheckboxIndicator) {
-      color: var(--accent-11);
+      color: var(--accent-a11);
     }
 
     &:where(.rt-high-contrast) {

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -10,6 +10,10 @@
     var(--code-letter-spacing) + var(--letter-spacing, var(--default-letter-spacing))
   );
   border-radius: calc((0.5px + 0.2em) * var(--radius-factor));
+
+  & :where(&) {
+    font-size: inherit;
+  }
 }
 
 /***************************************************************************************************
@@ -78,24 +82,14 @@
 
 .rt-Code:where(.rt-variant-ghost) {
   --code-variant-font-size-adjust: var(--code-font-size-adjust);
-  color: var(--accent-a11);
 
-  &:where(.rt-high-contrast) {
+  &:where([data-accent-color]) {
+    color: var(--accent-a11);
+  }
+
+  &:where([data-accent-color].rt-high-contrast),
+  :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
-  }
-
-  :where(.rt-Link:not(.rt-underline-hover)) & {
-    text-decoration-line: underline;
-    text-decoration-color: inherit;
-    text-decoration-thickness: inherit;
-  }
-
-  :where(.rt-Link:has(&:only-child)) {
-    &:where(:focus-visible) .rt-Code {
-      text-decoration: none;
-      outline: 2px solid var(--color-focus-root);
-      outline-offset: 2px;
-    }
   }
 }
 
@@ -116,17 +110,17 @@
     color: var(--accent-12);
   }
 
-  :where(.rt-Link:has(&:only-child)) {
-    & .rt-Code {
-      @media (hover: hover) {
-        &:where(:hover) {
-          background-color: var(--accent-10);
-        }
-        &:where(.rt-high-contrast:hover) {
-          background-color: var(--accent-12);
-          /* Re-use base button hover filter */
-          filter: var(--base-button-solid-high-contrast-hover-filter);
-        }
+  :where(.rt-Link) & {
+    /* Create a new stacking context (otherwise, `filter` may do it on hover) */
+    isolation: isolate;
+    @media (hover: hover) {
+      &:where(:hover) {
+        background-color: var(--accent-10);
+      }
+      &:where(.rt-high-contrast:hover) {
+        background-color: var(--accent-12);
+        /* Re-use base button hover filter */
+        filter: var(--base-button-solid-high-contrast-hover-filter);
       }
     }
     &:where(:focus-visible) .rt-Code {
@@ -144,16 +138,14 @@
   color: var(--accent-a11);
 
   &:where(.rt-high-contrast) {
-    background-color: var(--accent-a4);
     color: var(--accent-12);
   }
 
-  :where(.rt-Link:has(&:only-child)) {
-    & .rt-Code {
-      @media (hover: hover) {
-        &:where(:hover) {
-          background-color: var(--accent-a4);
-        }
+  :where(.rt-Link) & {
+    isolation: isolate;
+    @media (hover: hover) {
+      &:where(:hover) {
+        background-color: var(--accent-a4);
       }
     }
     &:where(:focus-visible) .rt-Code {
@@ -177,17 +169,16 @@
     color: var(--accent-12);
   }
 
-  :where(.rt-Link:has(&:only-child)) {
-    & .rt-Code {
-      @media (hover: hover) {
-        &:where(:hover) {
-          background-color: var(--accent-a2);
-        }
+  :where(.rt-Link) & {
+    isolation: isolate;
+    @media (hover: hover) {
+      &:where(:hover) {
+        background-color: var(--accent-a2);
       }
     }
-    &:where(:focus-visible) .rt-Code {
-      outline: 2px solid var(--color-focus-root);
-      outline-offset: -1px;
-    }
+  }
+  &:where(:focus-visible) .rt-Code {
+    outline: 2px solid var(--color-focus-root);
+    outline-offset: -1px;
   }
 }

--- a/packages/radix-ui-themes/src/components/code.tsx
+++ b/packages/radix-ui-themes/src/components/code.tsx
@@ -9,7 +9,13 @@ type CodeElement = React.ElementRef<'code'>;
 type CodeOwnProps = GetPropDefTypes<typeof codePropDefs>;
 interface CodeProps extends PropsWithoutRefOrColor<'code'>, MarginProps, CodeOwnProps {}
 const Code = React.forwardRef<CodeElement, CodeProps>((props, forwardedRef) => {
-  const { className, color, ...codeProps } = extractProps(props, codePropDefs, marginPropDefs);
+  const {
+    className,
+    color: accent,
+    ...codeProps
+  } = extractProps(props, codePropDefs, marginPropDefs);
+  // Code ghost color prop should work as an inherited color by default
+  const color = props.variant === 'ghost' ? accent || undefined : accent;
   return (
     <code
       data-accent-color={color}

--- a/packages/radix-ui-themes/src/components/code.tsx
+++ b/packages/radix-ui-themes/src/components/code.tsx
@@ -9,16 +9,12 @@ type CodeElement = React.ElementRef<'code'>;
 type CodeOwnProps = GetPropDefTypes<typeof codePropDefs>;
 interface CodeProps extends PropsWithoutRefOrColor<'code'>, MarginProps, CodeOwnProps {}
 const Code = React.forwardRef<CodeElement, CodeProps>((props, forwardedRef) => {
-  const {
-    className,
-    color: accent,
-    ...codeProps
-  } = extractProps(props, codePropDefs, marginPropDefs);
+  const { className, color, ...codeProps } = extractProps(props, codePropDefs, marginPropDefs);
   // Code ghost color prop should work as an inherited color by default
-  const color = props.variant === 'ghost' ? accent || undefined : accent;
+  const resolvedColor = props.variant === 'ghost' ? color || undefined : color;
   return (
     <code
-      data-accent-color={color}
+      data-accent-color={resolvedColor}
       {...codeProps}
       ref={forwardedRef}
       className={classNames('rt-Code', className)}

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -50,19 +50,16 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
       variant = contextMenuContentPropDefs.variant.default,
       highContrast = contextMenuContentPropDefs.highContrast.default,
     } = props;
-    const {
-      className,
-      children,
-      color = themeContext.accentColor,
-      container,
-      forceMount,
-      ...contentProps
-    } = extractProps(props, baseMenuContentPropDefs);
+    const { className, children, color, container, forceMount, ...contentProps } = extractProps(
+      props,
+      baseMenuContentPropDefs
+    );
+    const resolvedColor = color || themeContext.accentColor;
     return (
       <ContextMenuPrimitive.Portal container={container} forceMount={forceMount}>
         <Theme asChild>
           <ContextMenuPrimitive.Content
-            data-accent-color={color}
+            data-accent-color={resolvedColor}
             alignOffset={-Number(size) * 4}
             collisionPadding={10}
             {...contentProps}

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -50,19 +50,16 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
       variant = dropdownMenuContentPropDefs.variant.default,
       highContrast = dropdownMenuContentPropDefs.highContrast.default,
     } = props;
-    const {
-      className,
-      children,
-      color = themeContext.accentColor,
-      container,
-      forceMount,
-      ...contentProps
-    } = extractProps(props, dropdownMenuContentPropDefs);
+    const { className, children, color, container, forceMount, ...contentProps } = extractProps(
+      props,
+      dropdownMenuContentPropDefs
+    );
+    const resolvedColor = color || themeContext.accentColor;
     return (
       <DropdownMenuPrimitive.Portal container={container} forceMount={forceMount}>
         <Theme asChild>
           <DropdownMenuPrimitive.Content
-            data-accent-color={color}
+            data-accent-color={resolvedColor}
             align="start"
             sideOffset={4}
             collisionPadding={10}

--- a/packages/radix-ui-themes/src/components/em.css
+++ b/packages/radix-ui-themes/src/components/em.css
@@ -9,4 +9,8 @@
     var(--em-letter-spacing) + var(--letter-spacing, var(--default-letter-spacing))
   );
   color: inherit;
+
+  & :where(&) {
+    font-size: inherit;
+  }
 }

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -8,10 +8,11 @@
 
   &:where([data-accent-color]) {
     color: var(--accent-a11);
+  }
 
-    &:where(.rt-high-contrast) {
-      color: var(--accent-12);
-    }
+  &:where([data-accent-color].rt-high-contrast),
+  :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
+    color: var(--accent-12);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/heading.props.ts
+++ b/packages/radix-ui-themes/src/components/heading.props.ts
@@ -1,4 +1,4 @@
-import { weightProp, alignProp, trimProp, colorProp, highContrastProp } from '../helpers';
+import { weightProp, alignProp, trimProp, inheritedColorProp, highContrastProp } from '../helpers';
 import type { PropDef } from '../helpers';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
@@ -15,14 +15,14 @@ const headingPropDefs = {
   weight: { ...weightProp, default: 'bold' },
   align: alignProp,
   trim: trimProp,
-  color: colorProp,
+  color: inheritedColorProp,
   highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
   weight: PropDef<(typeof weights)[number]>;
   align: typeof alignProp;
   trim: typeof trimProp;
-  color: typeof colorProp;
+  color: typeof inheritedColorProp;
   highContrast: typeof highContrastProp;
 };
 

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -10,9 +10,8 @@
     outline-offset: 2px;
   }
 
-  &:where(.rt-high-contrast),
-  :where(.rt-CalloutRoot:not(.rt-high-contrast)) &,
-  :where(.rt-Text, .rt-Heading):where([data-accent-color]:not(.rt-high-contrast)) & {
+  &:where([data-accent-color].rt-high-contrast),
+  :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) & {
     color: var(--accent-12);
   }
 }
@@ -42,9 +41,8 @@
       }
     }
 
-    &:where(.rt-high-contrast),
-    :where(.rt-CalloutRoot:not(.rt-high-contrast)) &,
-    :where(.rt-Text, .rt-Heading):where([data-accent-color]:not(.rt-high-contrast)) & {
+    &:where([data-accent-color].rt-high-contrast),
+    :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) & {
       text-decoration-line: underline;
       text-decoration-color: var(--accent-a6);
 
@@ -75,10 +73,6 @@
 }
 
 /* Enhancement – hide underline for when Link's only child is a Code where underline is hard to see */
-/* prettier-ignore */
 .rt-Link:where(:has(.rt-Code:not(.rt-variant-ghost):only-child)) {
-  text-decoration-line: none;
-}
-.rt-Link:where(:has(.rt-Code:only-child)) {
-  outline: none;
+  text-decoration-color: transparent;
 }

--- a/packages/radix-ui-themes/src/components/quote.css
+++ b/packages/radix-ui-themes/src/components/quote.css
@@ -9,4 +9,8 @@
     var(--quote-letter-spacing) + var(--letter-spacing, var(--default-letter-spacing))
   );
   color: inherit;
+
+  & :where(&) {
+    font-size: inherit;
+  }
 }

--- a/packages/radix-ui-themes/src/components/radio-group.css
+++ b/packages/radix-ui-themes/src/components/radio-group.css
@@ -133,7 +133,7 @@
     background-color: var(--accent-a5);
   }
   & :where(.rt-RadioGroupIndicator) {
-    background-color: var(--accent-11);
+    background-color: var(--accent-a11);
   }
 
   &:where(.rt-high-contrast) {

--- a/packages/radix-ui-themes/src/components/select.tsx
+++ b/packages/radix-ui-themes/src/components/select.tsx
@@ -88,7 +88,7 @@ const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>
       selectContentPropDefs
     );
     const themeContext = useThemeContext();
-    const resolvedColor = color ?? themeContext.accentColor;
+    const resolvedColor = color || themeContext.accentColor;
     return (
       <SelectPrimitive.Portal container={container}>
         <Theme asChild>

--- a/packages/radix-ui-themes/src/components/strong.css
+++ b/packages/radix-ui-themes/src/components/strong.css
@@ -6,4 +6,8 @@
   letter-spacing: calc(
     var(--strong-letter-spacing) + var(--letter-spacing, var(--default-letter-spacing))
   );
+
+  & :where(&) {
+    font-size: inherit;
+  }
 }

--- a/packages/radix-ui-themes/src/components/text-field.props.ts
+++ b/packages/radix-ui-themes/src/components/text-field.props.ts
@@ -1,5 +1,5 @@
 import type { PropDef } from '../helpers';
-import { colorProp, paddingPropDefs, radiusProp } from '../helpers';
+import { colorProp, inheritedColorProp, paddingPropDefs, radiusProp } from '../helpers';
 import { flexPropDefs } from './flex.props';
 
 const sizes = ['1', '2', '3'] as const;
@@ -18,13 +18,13 @@ const textFieldPropDefs = {
 };
 
 const textFieldSlotPropDefs = {
-  color: colorProp,
+  color: inheritedColorProp,
   gap: flexPropDefs.gap,
   px: paddingPropDefs.px,
   pl: paddingPropDefs.pl,
   pr: paddingPropDefs.pr,
 } satisfies {
-  color: typeof colorProp;
+  color: typeof inheritedColorProp;
   gap: typeof flexPropDefs.gap;
   px: typeof paddingPropDefs.px;
   pl: typeof paddingPropDefs.pl;

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -2,14 +2,13 @@
   margin: 0;
   line-height: var(--line-height, var(--default-line-height));
   letter-spacing: var(--letter-spacing, inherit);
-}
 
-:where([data-accent-color]) {
-  &.rt-Text {
+  &:where([data-accent-color]) {
     color: var(--accent-a11);
   }
-  &.rt-Text:where(.rt-high-contrast),
-  &:where(.rt-Text, .rt-Heading) .rt-Text:where(.rt-high-contrast) {
+
+  &:where([data-accent-color].rt-high-contrast),
+  :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
 }

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -1,4 +1,4 @@
-import { weightProp, alignProp, trimProp, colorProp, highContrastProp } from '../helpers';
+import { weightProp, alignProp, trimProp, highContrastProp, inheritedColorProp } from '../helpers';
 import type { PropDef } from '../helpers';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
@@ -14,14 +14,14 @@ const textPropDefs = {
   weight: weightProp,
   align: alignProp,
   trim: trimProp,
-  color: colorProp,
+  color: inheritedColorProp,
   highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
   weight: typeof weightProp;
   align: typeof alignProp;
   trim: typeof trimProp;
-  color: typeof colorProp;
+  color: typeof inheritedColorProp;
   highContrast: typeof highContrastProp;
 };
 

--- a/packages/radix-ui-themes/src/helpers/props/color.prop.ts
+++ b/packages/radix-ui-themes/src/helpers/props/color.prop.ts
@@ -19,5 +19,29 @@ type PropsWithoutRefOrColor<T extends React.ElementType> = Omit<
   'color'
 >;
 
+// Difference between `colorProp` and `inheritedColorProp` is in the defaults:
+//
+// default: '' sets an empty `data-accent-color` attribute to define the right
+// high-contrast colors for descendants that inherit a colour by default, e.g.:
+//
+// ```
+// <Text>
+//   This text inherits body color
+// </Text>
+//
+// <Callout.Root>
+//   <Callout.Text>
+//     <Text>
+//       This text inherits Callout color
+//     </Text>
+//     <Text highContrast>
+//       This text uses high-contrast version of the Callout color
+//     </Text>
+//   <Callout.Text>
+// </Callout.Root>
+// ```
+//
+// default: undefined allows Text to inherit color directly, but respond to the behaviour above.
+
 export { colorProp, inheritedColorProp };
 export type { PropsWithoutRefOrColor };

--- a/packages/radix-ui-themes/src/helpers/props/color.prop.ts
+++ b/packages/radix-ui-themes/src/helpers/props/color.prop.ts
@@ -4,6 +4,12 @@ import type { PropDef } from '..';
 const colorProp = {
   type: 'enum',
   values: themePropDefs.accentColor.values,
+  default: '' as (typeof themePropDefs.accentColor.values)[number] | undefined,
+} satisfies PropDef<(typeof themePropDefs.accentColor.values)[number]>;
+
+const inheritedColorProp = {
+  type: 'enum',
+  values: themePropDefs.accentColor.values,
   default: undefined as (typeof themePropDefs.accentColor.values)[number] | undefined,
 } satisfies PropDef<(typeof themePropDefs.accentColor.values)[number]>;
 
@@ -13,5 +19,5 @@ type PropsWithoutRefOrColor<T extends React.ElementType> = Omit<
   'color'
 >;
 
-export { colorProp };
+export { colorProp, inheritedColorProp };
 export type { PropsWithoutRefOrColor };


### PR DESCRIPTION
- Improve how accent color and high contrast work when components are nested
  - For components like Text and Heading, `--accent-12` is going to be resolved as long as there is some parent component with `data-accent-color` in the DOM that is not `.radix-themes`
- Make it so that `<Code variant="ghost">` color works just like Text, inheriting by default, but colored when an explicit `color` prop is passed
- Simplify styles for Code and Link combinations

Before:
https://themes-playground-jnjh1ct8k-modulz.vercel.app/test-high-contrast

After:
https://themes-playground-git-vlad-ghost-code-color-modulz.vercel.app/test-high-contrast