### PR TITLE
Remove native color attribute from types

### DIFF
--- a/apps/playground/app/test-textfield/page.tsx
+++ b/apps/playground/app/test-textfield/page.tsx
@@ -56,14 +56,14 @@ export default function Test() {
                     <TextFieldRoot size="1">
                       <TextFieldInput placeholder="Your password" />
                       <TextFieldSlot>
-                        <Spinner size="1" color="gray" />
+                        <Spinner size="1" />
                       </TextFieldSlot>
                     </TextFieldRoot>
 
                     <TextFieldRoot size="2">
                       <TextFieldInput placeholder="Your password" />
                       <TextFieldSlot>
-                        <Spinner size="2" color="gray" />
+                        <Spinner size="2" />
                       </TextFieldSlot>
                     </TextFieldRoot>
 

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -23,6 +23,7 @@
   - Update the type signature of the layout props so that code editor suggestions use just space scale values when possible. CSS keywords and other values such as `"auto"` or `"100vw"` are still available as manual string values.
   - Fix an issue with responsive props when using a breakpoints object without the `initial` key would not apply the default prop value
   - Make sure `highContrast` text colors work consistently when nested within other components that accept an accent color
+  - Remove the native `color` attribute from components that don’t have own `color` props
 - 6 new components
   - `Progress`
   - `RadioCardGroup`

--- a/packages/radix-ui-themes/src/components/alert-dialog.tsx
+++ b/packages/radix-ui-themes/src/components/alert-dialog.tsx
@@ -9,10 +9,9 @@ import { Heading } from './heading';
 import { Text } from './text';
 import { Theme } from '../theme';
 
-import type { ExtractPropsForTag, GetPropDefTypes } from '../helpers';
+import type { ExtractPropsForTag, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
-interface AlertDialogRootProps
-  extends React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Root> {}
+interface AlertDialogRootProps extends PropsWithoutRefOrColor<typeof AlertDialogPrimitive.Root> {}
 const AlertDialogRoot: React.FC<AlertDialogRootProps> = (props) => (
   <AlertDialogPrimitive.Root {...props} />
 );
@@ -20,7 +19,7 @@ AlertDialogRoot.displayName = 'AlertDialogRoot';
 
 type AlertDialogTriggerElement = React.ElementRef<typeof AlertDialogPrimitive.Trigger>;
 interface AlertDialogTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof AlertDialogPrimitive.Trigger>, 'asChild'> {}
 const AlertDialogTrigger = React.forwardRef<AlertDialogTriggerElement, AlertDialogTriggerProps>(
   (props, forwardedRef) => <AlertDialogPrimitive.Trigger {...props} ref={forwardedRef} asChild />
 );
@@ -29,7 +28,7 @@ AlertDialogTrigger.displayName = 'AlertDialogTrigger';
 type AlertDialogContentElement = React.ElementRef<typeof AlertDialogPrimitive.Content>;
 type AlertDialogContentOwnProps = GetPropDefTypes<typeof alertDialogContentPropDefs>;
 interface AlertDialogContentProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>, 'asChild'>,
+  extends Omit<PropsWithoutRefOrColor<typeof AlertDialogPrimitive.Content>, 'asChild'>,
     AlertDialogContentOwnProps {
   container?: React.ComponentProps<typeof AlertDialogPrimitive.Portal>['container'];
 }
@@ -81,7 +80,7 @@ AlertDialogDescription.displayName = 'AlertDialogDescription';
 
 type AlertDialogActionElement = React.ElementRef<typeof AlertDialogPrimitive.Action>;
 interface AlertDialogActionProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof AlertDialogPrimitive.Action>, 'asChild'> {}
 const AlertDialogAction = React.forwardRef<AlertDialogActionElement, AlertDialogActionProps>(
   (props, forwardedRef) => <AlertDialogPrimitive.Action {...props} ref={forwardedRef} asChild />
 );
@@ -89,7 +88,7 @@ AlertDialogAction.displayName = 'AlertDialogAction';
 
 type AlertDialogCancelElement = React.ElementRef<typeof AlertDialogPrimitive.Cancel>;
 interface AlertDialogCancelProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof AlertDialogPrimitive.Cancel>, 'asChild'> {}
 const AlertDialogCancel = React.forwardRef<AlertDialogCancelElement, AlertDialogCancelProps>(
   (props, forwardedRef) => <AlertDialogPrimitive.Cancel {...props} ref={forwardedRef} asChild />
 );

--- a/packages/radix-ui-themes/src/components/card.tsx
+++ b/packages/radix-ui-themes/src/components/card.tsx
@@ -4,11 +4,11 @@ import { Slot } from '@radix-ui/react-slot';
 import { cardPropDefs } from './card.props';
 import { extractProps, marginPropDefs } from '../helpers';
 
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type CardElement = React.ElementRef<'div'>;
 type CardOwnProps = GetPropDefTypes<typeof cardPropDefs>;
-interface CardProps extends React.ComponentPropsWithoutRef<'div'>, MarginProps, CardOwnProps {
+interface CardProps extends PropsWithoutRefOrColor<'div'>, MarginProps, CardOwnProps {
   asChild?: boolean;
 }
 const Card = React.forwardRef<CardElement, CardProps>((props, forwardedRef) => {

--- a/packages/radix-ui-themes/src/components/container.tsx
+++ b/packages/radix-ui-themes/src/components/container.tsx
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 import { containerPropDefs } from './container.props';
 import { deprecatedLayoutPropDefs, extractProps, layoutPropDefs, marginPropDefs } from '../helpers';
 
-import type { MarginProps, LayoutProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, LayoutProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type ContainerElement = React.ElementRef<'div'>;
 type ContainerOwnProps = GetPropDefTypes<typeof containerPropDefs>;
 interface ContainerProps
-  extends React.ComponentPropsWithoutRef<'div'>,
+  extends PropsWithoutRefOrColor<'div'>,
     MarginProps,
     LayoutProps,
     ContainerOwnProps {}

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -18,8 +18,7 @@ import { ThickCheckIcon, ThickChevronRightIcon } from '../icons';
 import type { PropsWithoutRefOrColor, GetPropDefTypes } from '../helpers';
 import { baseMenuContentPropDefs } from './base-menu.props';
 
-interface ContextMenuRootProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Root> {}
+interface ContextMenuRootProps extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Root> {}
 const ContextMenuRoot: React.FC<ContextMenuRootProps> = (props) => (
   <ContextMenuPrimitive.Root {...props} />
 );
@@ -27,7 +26,7 @@ ContextMenuRoot.displayName = 'ContextMenuRoot';
 
 type ContextMenuTriggerElement = React.ElementRef<typeof ContextMenuPrimitive.Trigger>;
 interface ContextMenuTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Trigger>, 'asChild'> {}
 const ContextMenuTrigger = React.forwardRef<ContextMenuTriggerElement, ContextMenuTriggerProps>(
   (props, forwardedRef) => <ContextMenuPrimitive.Trigger {...props} ref={forwardedRef} asChild />
 );
@@ -92,8 +91,7 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
 ContextMenuContent.displayName = 'ContextMenuContent';
 
 type ContextMenuLabelElement = React.ElementRef<typeof ContextMenuPrimitive.Label>;
-interface ContextMenuLabelProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> {}
+interface ContextMenuLabelProps extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Label> {}
 const ContextMenuLabel = React.forwardRef<ContextMenuLabelElement, ContextMenuLabelProps>(
   (props, forwardedRef) => (
     <ContextMenuPrimitive.Label
@@ -135,8 +133,7 @@ const ContextMenuItem = React.forwardRef<ContextMenuItemElement, ContextMenuItem
 ContextMenuItem.displayName = 'ContextMenuItem';
 
 type ContextMenuGroupElement = React.ElementRef<typeof ContextMenuPrimitive.Group>;
-interface ContextMenuGroupProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Group> {}
+interface ContextMenuGroupProps extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Group> {}
 const ContextMenuGroup = React.forwardRef<ContextMenuGroupElement, ContextMenuGroupProps>(
   (props, forwardedRef) => (
     <ContextMenuPrimitive.Group
@@ -150,7 +147,7 @@ ContextMenuGroup.displayName = 'ContextMenuGroup';
 
 type ContextMenuRadioGroupElement = React.ElementRef<typeof ContextMenuPrimitive.RadioGroup>;
 interface ContextMenuRadioGroupProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioGroup> {}
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.RadioGroup> {}
 const ContextMenuRadioGroup = React.forwardRef<
   ContextMenuRadioGroupElement,
   ContextMenuRadioGroupProps
@@ -239,8 +236,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
 });
 ContextMenuCheckboxItem.displayName = 'ContextMenuCheckboxItem';
 
-interface ContextMenuSubProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Sub> {}
+interface ContextMenuSubProps extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Sub> {}
 const ContextMenuSub: React.FC<ContextMenuSubProps> = (props) => (
   <ContextMenuPrimitive.Sub {...props} />
 );
@@ -248,7 +244,7 @@ ContextMenuSub.displayName = 'ContextMenuSub';
 
 type ContextMenuSubTriggerElement = React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>;
 interface ContextMenuSubTriggerProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> {}
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.SubTrigger> {}
 const ContextMenuSubTrigger = React.forwardRef<
   ContextMenuSubTriggerElement,
   ContextMenuSubTriggerProps
@@ -277,7 +273,7 @@ ContextMenuSubTrigger.displayName = 'ContextMenuSubTrigger';
 
 type ContextMenuSubContentElement = React.ElementRef<typeof ContextMenuPrimitive.SubContent>;
 interface ContextMenuSubContentProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent> {
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.SubContent> {
   container?: React.ComponentProps<typeof ContextMenuPrimitive.Portal>['container'];
 }
 const ContextMenuSubContent = React.forwardRef<
@@ -323,7 +319,7 @@ ContextMenuSubContent.displayName = 'ContextMenuSubContent';
 
 type ContextMenuSeparatorElement = React.ElementRef<typeof ContextMenuPrimitive.Separator>;
 interface ContextMenuSeparatorProps
-  extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator> {}
+  extends PropsWithoutRefOrColor<typeof ContextMenuPrimitive.Separator> {}
 const ContextMenuSeparator = React.forwardRef<
   ContextMenuSeparatorElement,
   ContextMenuSeparatorProps

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -9,7 +9,7 @@ import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../he
 type DataListRootElement = HTMLDListElement;
 type DataListRootOwnProps = GetPropDefTypes<typeof dataListPropDefs>;
 interface DataListRootProps
-  extends React.ComponentPropsWithoutRef<'dl'>,
+  extends PropsWithoutRefOrColor<'dl'>,
     MarginProps,
     DataListRootOwnProps {}
 const DataListRoot = React.forwardRef<DataListRootElement, DataListRootProps>(
@@ -30,7 +30,7 @@ DataListRoot.displayName = 'DataListRoot';
 
 type DataListItemElement = HTMLDivElement;
 type DataListItemOwnProps = GetPropDefTypes<typeof dataListItemPropDefs>;
-interface DataListItemProps extends React.ComponentPropsWithoutRef<'div'>, DataListItemOwnProps {}
+interface DataListItemProps extends PropsWithoutRefOrColor<'div'>, DataListItemOwnProps {}
 const DataListItem = React.forwardRef<DataListItemElement, DataListItemProps>(
   (props, forwardedRef) => {
     const { className, ...itemProps } = extractProps(props, dataListItemPropDefs);
@@ -60,7 +60,7 @@ const DataListLabel = React.forwardRef<DataListLabelElement, DataListLabelProps>
 DataListLabel.displayName = 'DataListLabel';
 
 type DataListDataElement = React.ElementRef<'dd'>;
-interface DataListDataProps extends React.ComponentPropsWithoutRef<'dd'> {}
+interface DataListDataProps extends PropsWithoutRefOrColor<'dd'> {}
 const DataListData = React.forwardRef<DataListDataElement, DataListDataProps>(
   ({ children, className, ...props }, forwardedRef) => (
     <dd

--- a/packages/radix-ui-themes/src/components/dialog.tsx
+++ b/packages/radix-ui-themes/src/components/dialog.tsx
@@ -9,16 +9,16 @@ import { Heading } from './heading';
 import { Text } from './text';
 import { Theme } from '../theme';
 
-import type { ExtractPropsForTag, GetPropDefTypes } from '../helpers';
+import type { ExtractPropsForTag, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 interface DialogRootProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root>, 'modal'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof DialogPrimitive.Root>, 'modal'> {}
 const DialogRoot: React.FC<DialogRootProps> = (props) => <DialogPrimitive.Root {...props} modal />;
 DialogRoot.displayName = 'DialogRoot';
 
 type DialogTriggerElement = React.ElementRef<typeof DialogPrimitive.Trigger>;
 interface DialogTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof DialogPrimitive.Trigger>, 'asChild'> {}
 const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>(
   (props, forwardedRef) => <DialogPrimitive.Trigger {...props} ref={forwardedRef} asChild />
 );
@@ -27,7 +27,7 @@ DialogTrigger.displayName = 'DialogTrigger';
 type DialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
 type DialogContentOwnProps = GetPropDefTypes<typeof dialogContentPropDefs>;
 interface DialogContentProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>, 'asChild'>,
+  extends Omit<PropsWithoutRefOrColor<typeof DialogPrimitive.Content>, 'asChild'>,
     DialogContentOwnProps {
   container?: React.ComponentProps<typeof DialogPrimitive.Portal>['container'];
 }
@@ -78,7 +78,7 @@ DialogDescription.displayName = 'DialogDescription';
 
 type DialogCloseElement = React.ElementRef<typeof DialogPrimitive.Close>;
 interface DialogCloseProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof DialogPrimitive.Close>, 'asChild'> {}
 const DialogClose = React.forwardRef<DialogCloseElement, DialogCloseProps>(
   (props, forwardedRef) => <DialogPrimitive.Close {...props} ref={forwardedRef} asChild />
 );

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -18,8 +18,7 @@ import { ThickCheckIcon, ThickChevronRightIcon } from '../icons';
 import type { PropsWithoutRefOrColor, GetPropDefTypes } from '../helpers';
 import { baseMenuContentPropDefs } from './base-menu.props';
 
-interface DropdownMenuRootProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}
+interface DropdownMenuRootProps extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Root> {}
 const DropdownMenuRoot: React.FC<DropdownMenuRootProps> = (props) => (
   <DropdownMenuPrimitive.Root {...props} />
 );
@@ -27,7 +26,7 @@ DropdownMenuRoot.displayName = 'DropdownMenuRoot';
 
 type DropdownMenuTriggerElement = React.ElementRef<typeof DropdownMenuPrimitive.Trigger>;
 interface DropdownMenuTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Trigger>, 'asChild'> {}
 const DropdownMenuTrigger = React.forwardRef<DropdownMenuTriggerElement, DropdownMenuTriggerProps>(
   (props, forwardedRef) => <DropdownMenuPrimitive.Trigger {...props} ref={forwardedRef} asChild />
 );
@@ -94,7 +93,7 @@ DropdownMenuContent.displayName = 'DropdownMenuContent';
 
 type DropdownMenuLabelElement = React.ElementRef<typeof DropdownMenuPrimitive.Label>;
 interface DropdownMenuLabelProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Label> {}
 const DropdownMenuLabel = React.forwardRef<DropdownMenuLabelElement, DropdownMenuLabelProps>(
   (props, forwardedRef) => (
     <DropdownMenuPrimitive.Label
@@ -137,7 +136,7 @@ DropdownMenuItem.displayName = 'DropdownMenuItem';
 
 type DropdownMenuGroupElement = React.ElementRef<typeof DropdownMenuPrimitive.Group>;
 interface DropdownMenuGroupProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Group> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Group> {}
 const DropdownMenuGroup = React.forwardRef<DropdownMenuGroupElement, DropdownMenuGroupProps>(
   (props, forwardedRef) => (
     <DropdownMenuPrimitive.Group
@@ -151,7 +150,7 @@ DropdownMenuGroup.displayName = 'DropdownMenuGroup';
 
 type DropdownMenuRadioGroupElement = React.ElementRef<typeof DropdownMenuPrimitive.RadioGroup>;
 interface DropdownMenuRadioGroupProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioGroup> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.RadioGroup> {}
 const DropdownMenuRadioGroup = React.forwardRef<
   DropdownMenuRadioGroupElement,
   DropdownMenuRadioGroupProps
@@ -240,8 +239,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 });
 DropdownMenuCheckboxItem.displayName = 'DropdownMenuCheckboxItem';
 
-interface DropdownMenuSubProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Sub> {}
+interface DropdownMenuSubProps extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Sub> {}
 const DropdownMenuSub: React.FC<DropdownMenuSubProps> = (props) => (
   <DropdownMenuPrimitive.Sub {...props} />
 );
@@ -249,7 +247,7 @@ DropdownMenuSub.displayName = 'DropdownMenuSub';
 
 type DropdownMenuSubTriggerElement = React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>;
 interface DropdownMenuSubTriggerProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.SubTrigger> {}
 const DropdownMenuSubTrigger = React.forwardRef<
   DropdownMenuSubTriggerElement,
   DropdownMenuSubTriggerProps
@@ -278,7 +276,7 @@ DropdownMenuSubTrigger.displayName = 'DropdownMenuSubTrigger';
 
 type DropdownMenuSubContentElement = React.ElementRef<typeof DropdownMenuPrimitive.SubContent>;
 interface DropdownMenuSubContentProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> {
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.SubContent> {
   container?: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>['container'];
 }
 const DropdownMenuSubContent = React.forwardRef<
@@ -324,7 +322,7 @@ DropdownMenuSubContent.displayName = 'DropdownMenuSubContent';
 
 type DropdownMenuSeparatorElement = React.ElementRef<typeof DropdownMenuPrimitive.Separator>;
 interface DropdownMenuSeparatorProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> {}
+  extends PropsWithoutRefOrColor<typeof DropdownMenuPrimitive.Separator> {}
 const DropdownMenuSeparator = React.forwardRef<
   DropdownMenuSeparatorElement,
   DropdownMenuSeparatorProps

--- a/packages/radix-ui-themes/src/components/em.tsx
+++ b/packages/radix-ui-themes/src/components/em.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import type { PropsWithoutRefOrColor } from '../helpers';
+
 type EmElement = React.ElementRef<'em'>;
-interface EmProps extends React.ComponentPropsWithoutRef<'em'> {}
+interface EmProps extends PropsWithoutRefOrColor<'em'> {}
 const Em = React.forwardRef<EmElement, EmProps>((props, forwardedRef) => (
   <em {...props} ref={forwardedRef} className={classNames('rt-Em', props.className)} />
 ));

--- a/packages/radix-ui-themes/src/components/hover-card.tsx
+++ b/packages/radix-ui-themes/src/components/hover-card.tsx
@@ -7,10 +7,9 @@ import { hoverCardContentPropDefs } from './hover-card.props';
 import { extractProps } from '../helpers';
 import { Theme } from '../theme';
 
-import type { GetPropDefTypes } from '../helpers';
+import type { GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
-interface HoverCardRootProps
-  extends React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root> {}
+interface HoverCardRootProps extends PropsWithoutRefOrColor<typeof HoverCardPrimitive.Root> {}
 const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => (
   <HoverCardPrimitive.Root closeDelay={150} openDelay={200} {...props} />
 );
@@ -18,7 +17,7 @@ HoverCardRoot.displayName = 'HoverCardRoot';
 
 type HoverCardTriggerElement = React.ElementRef<typeof HoverCardPrimitive.Trigger>;
 interface HoverCardTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof HoverCardPrimitive.Trigger>, 'asChild'> {}
 const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTriggerProps>(
   (props, forwardedRef) => (
     <HoverCardPrimitive.Trigger
@@ -34,7 +33,7 @@ HoverCardTrigger.displayName = 'HoverCardTrigger';
 type HoverCardContentElement = React.ElementRef<typeof HoverCardPrimitive.Content>;
 type HoverCardContentOwnProps = GetPropDefTypes<typeof hoverCardContentPropDefs>;
 interface HoverCardContentProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>, 'asChild'>,
+  extends Omit<PropsWithoutRefOrColor<typeof HoverCardPrimitive.Content>, 'asChild'>,
     HoverCardContentOwnProps {
   container?: React.ComponentProps<typeof HoverCardPrimitive.Portal>['container'];
 }

--- a/packages/radix-ui-themes/src/components/inset.tsx
+++ b/packages/radix-ui-themes/src/components/inset.tsx
@@ -3,11 +3,11 @@ import classNames from 'classnames';
 import { insetPropDefs } from './inset.props';
 import { extractProps, marginPropDefs } from '../helpers';
 
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type InsetElement = React.ElementRef<'div'>;
 type InsetOwnProps = GetPropDefTypes<typeof insetPropDefs>;
-interface InsetProps extends React.ComponentPropsWithoutRef<'div'>, MarginProps, InsetOwnProps {}
+interface InsetProps extends PropsWithoutRefOrColor<'div'>, MarginProps, InsetOwnProps {}
 
 const Inset = React.forwardRef<InsetElement, InsetProps>((props, forwardedRef) => {
   const { className, ...insetProps } = extractProps(props, insetPropDefs, marginPropDefs);

--- a/packages/radix-ui-themes/src/components/kbd.tsx
+++ b/packages/radix-ui-themes/src/components/kbd.tsx
@@ -3,11 +3,11 @@ import classNames from 'classnames';
 import { kbdPropDefs } from './kbd.props';
 import { extractProps, GetPropDefTypes, marginPropDefs } from '../helpers';
 
-import type { MarginProps } from '../helpers';
+import type { MarginProps, PropsWithoutRefOrColor } from '../helpers';
 
 type KbdElement = React.ElementRef<'kbd'>;
 type KbdOwnProps = GetPropDefTypes<typeof kbdPropDefs>;
-interface KbdProps extends React.ComponentPropsWithoutRef<'kbd'>, MarginProps, KbdOwnProps {}
+interface KbdProps extends PropsWithoutRefOrColor<'kbd'>, MarginProps, KbdOwnProps {}
 const Kbd = React.forwardRef<KbdElement, KbdProps>((props, forwardedRef) => {
   const { className, ...kbdProps } = extractProps(props, kbdPropDefs, marginPropDefs);
   return <kbd {...kbdProps} ref={forwardedRef} className={classNames('rt-Kbd', className)} />;

--- a/packages/radix-ui-themes/src/components/popover.tsx
+++ b/packages/radix-ui-themes/src/components/popover.tsx
@@ -7,9 +7,9 @@ import { popoverContentPropDefs } from './popover.props';
 import { extractProps } from '../helpers';
 import { Theme } from '../theme';
 
-import type { GetPropDefTypes } from '../helpers';
+import type { GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
-interface PopoverRootProps extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root> {}
+interface PopoverRootProps extends PropsWithoutRefOrColor<typeof PopoverPrimitive.Root> {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => (
   <PopoverPrimitive.Root {...props} />
 );
@@ -17,7 +17,7 @@ PopoverRoot.displayName = 'PopoverRoot';
 
 type PopoverTriggerElement = React.ElementRef<typeof PopoverPrimitive.Trigger>;
 interface PopoverTriggerProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof PopoverPrimitive.Trigger>, 'asChild'> {}
 const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerProps>(
   (props, forwardedRef) => <PopoverPrimitive.Trigger {...props} ref={forwardedRef} asChild />
 );
@@ -26,7 +26,7 @@ PopoverTrigger.displayName = 'PopoverTrigger';
 type PopoverContentElement = React.ElementRef<typeof PopoverPrimitive.Content>;
 type PopoverContentOwnProps = GetPropDefTypes<typeof popoverContentPropDefs>;
 interface PopoverContentProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>, 'asChild'>,
+  extends Omit<PropsWithoutRefOrColor<typeof PopoverPrimitive.Content>, 'asChild'>,
     PopoverContentOwnProps {
   container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container'];
 }
@@ -56,7 +56,7 @@ PopoverContent.displayName = 'PopoverContent';
 
 type PopoverCloseElement = React.ElementRef<typeof PopoverPrimitive.Close>;
 interface PopoverCloseProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Close>, 'asChild'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof PopoverPrimitive.Close>, 'asChild'> {}
 const PopoverClose = React.forwardRef<PopoverCloseElement, PopoverCloseProps>(
   (props, forwardedRef) => <PopoverPrimitive.Close {...props} ref={forwardedRef} asChild />
 );

--- a/packages/radix-ui-themes/src/components/quote.tsx
+++ b/packages/radix-ui-themes/src/components/quote.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import type { PropsWithoutRefOrColor } from '../helpers';
+
 type QuoteElement = React.ElementRef<'q'>;
-interface QuoteProps extends React.ComponentPropsWithoutRef<'q'> {}
+interface QuoteProps extends PropsWithoutRefOrColor<'q'> {}
 const Quote = React.forwardRef<QuoteElement, QuoteProps>((props, forwardedRef) => (
   <q {...props} ref={forwardedRef} className={classNames('rt-Quote', props.className)} />
 ));

--- a/packages/radix-ui-themes/src/components/radio-card-group.tsx
+++ b/packages/radix-ui-themes/src/components/radio-card-group.tsx
@@ -38,7 +38,7 @@ RadioCardGroupRoot.displayName = 'RadioCardGroupRoot';
 
 type RadioCardGroupItemElement = React.ElementRef<typeof RadioGroupPrimitive.Item>;
 interface RadioCardGroupItemProps
-  extends React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>,
+  extends PropsWithoutRefOrColor<typeof RadioGroupPrimitive.Item>,
     MarginProps {}
 const RadioCardGroupItem = React.forwardRef<RadioCardGroupItemElement, RadioCardGroupItemProps>(
   ({ className, ...props }, forwardedRef) => (

--- a/packages/radix-ui-themes/src/components/radio-group.tsx
+++ b/packages/radix-ui-themes/src/components/radio-group.tsx
@@ -35,7 +35,7 @@ RadioGroupRoot.displayName = 'RadioGroupRoot';
 
 type RadioGroupItemElement = React.ElementRef<typeof RadioGroupPrimitive.Item>;
 interface RadioGroupItemProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>, 'children'>,
+  extends Omit<PropsWithoutRefOrColor<typeof RadioGroupPrimitive.Item>, 'children'>,
     MarginProps {}
 const RadioGroupItem = React.forwardRef<RadioGroupItemElement, RadioGroupItemProps>(
   (props, forwardedRef) => {

--- a/packages/radix-ui-themes/src/components/scroll-area.tsx
+++ b/packages/radix-ui-themes/src/components/scroll-area.tsx
@@ -11,13 +11,13 @@ import {
   mergeStyles,
 } from '../helpers';
 
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type ScrollAreaElement = React.ElementRef<typeof ScrollAreaPrimitive.Viewport>;
 type ScrollAreaOwnProps = GetPropDefTypes<typeof scrollAreaPropDefs>;
 interface ScrollAreaProps
-  extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>,
-    Omit<React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Viewport>, 'dir'>,
+  extends PropsWithoutRefOrColor<typeof ScrollAreaPrimitive.Root>,
+    Omit<PropsWithoutRefOrColor<typeof ScrollAreaPrimitive.Viewport>, 'dir'>,
     MarginProps,
     ScrollAreaOwnProps {}
 const ScrollArea = React.forwardRef<ScrollAreaElement, ScrollAreaProps>((props, forwardedRef) => {

--- a/packages/radix-ui-themes/src/components/section.tsx
+++ b/packages/radix-ui-themes/src/components/section.tsx
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 import { sectionPropDefs } from './section.props';
 import { deprecatedLayoutPropDefs, extractProps, layoutPropDefs, marginPropDefs } from '../helpers';
 
-import type { MarginProps, LayoutProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, LayoutProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type SectionElement = React.ElementRef<'div'>;
 type SectionOwnProps = GetPropDefTypes<typeof sectionPropDefs>;
 interface SectionProps
-  extends React.ComponentPropsWithoutRef<'div'>,
+  extends PropsWithoutRefOrColor<'div'>,
     MarginProps,
     LayoutProps,
     SectionOwnProps {}

--- a/packages/radix-ui-themes/src/components/select.tsx
+++ b/packages/radix-ui-themes/src/components/select.tsx
@@ -17,7 +17,7 @@ type SelectContextValue = SelectRootOwnProps;
 const SelectContext = React.createContext<SelectContextValue>({});
 
 interface SelectRootProps
-  extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>,
+  extends PropsWithoutRefOrColor<typeof SelectPrimitive.Root>,
     SelectContextValue {}
 const SelectRoot: React.FC<SelectRootProps> = (props) => {
   const { children, size = selectRootPropDefs.size.default, ...rootProps } = props;
@@ -128,7 +128,7 @@ const SelectContent = React.forwardRef<SelectContentElement, SelectContentProps>
 SelectContent.displayName = 'SelectContent';
 
 type SelectItemElement = React.ElementRef<typeof SelectPrimitive.Item>;
-interface SelectItemProps extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> {}
+interface SelectItemProps extends PropsWithoutRefOrColor<typeof SelectPrimitive.Item> {}
 const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>((props, forwardedRef) => {
   const { className, children, ...itemProps } = props;
   return (
@@ -147,7 +147,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>((props, 
 SelectItem.displayName = 'SelectItem';
 
 type SelectGroupElement = React.ElementRef<typeof SelectPrimitive.Group>;
-interface SelectGroupProps extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group> {}
+interface SelectGroupProps extends PropsWithoutRefOrColor<typeof SelectPrimitive.Group> {}
 const SelectGroup = React.forwardRef<SelectGroupElement, SelectGroupProps>(
   (props, forwardedRef) => (
     <SelectPrimitive.Group
@@ -160,7 +160,7 @@ const SelectGroup = React.forwardRef<SelectGroupElement, SelectGroupProps>(
 SelectGroup.displayName = 'SelectGroup';
 
 type SelectLabelElement = React.ElementRef<typeof SelectPrimitive.Label>;
-interface SelectLabelProps extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> {}
+interface SelectLabelProps extends PropsWithoutRefOrColor<typeof SelectPrimitive.Label> {}
 const SelectLabel = React.forwardRef<SelectLabelElement, SelectLabelProps>(
   (props, forwardedRef) => (
     <SelectPrimitive.Label
@@ -173,8 +173,7 @@ const SelectLabel = React.forwardRef<SelectLabelElement, SelectLabelProps>(
 SelectLabel.displayName = 'SelectLabel';
 
 type SelectSeparatorElement = React.ElementRef<typeof SelectPrimitive.Separator>;
-interface SelectSeparatorProps
-  extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> {}
+interface SelectSeparatorProps extends PropsWithoutRefOrColor<typeof SelectPrimitive.Separator> {}
 const SelectSeparator = React.forwardRef<SelectSeparatorElement, SelectSeparatorProps>(
   (props, forwardedRef) => (
     <SelectPrimitive.Separator

--- a/packages/radix-ui-themes/src/components/skeleton.tsx
+++ b/packages/radix-ui-themes/src/components/skeleton.tsx
@@ -4,14 +4,11 @@ import { Slot } from '@radix-ui/react-slot';
 import { skeletonPropDefs } from './skeleton.props';
 import { extractProps, marginPropDefs } from '../helpers';
 
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type SkeletonElement = React.ElementRef<'span'>;
 type SkeletonOwnProps = GetPropDefTypes<typeof skeletonPropDefs>;
-interface SkeletonProps
-  extends React.ComponentPropsWithoutRef<'span'>,
-    MarginProps,
-    SkeletonOwnProps {}
+interface SkeletonProps extends PropsWithoutRefOrColor<'span'>, MarginProps, SkeletonOwnProps {}
 const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwardedRef) => {
   const { children, className, loading, ...skeletonProps } = extractProps(
     props,

--- a/packages/radix-ui-themes/src/components/spinner.tsx
+++ b/packages/radix-ui-themes/src/components/spinner.tsx
@@ -5,14 +5,11 @@ import { spinnerPropDefs } from './spinner.props';
 import { extractProps, marginPropDefs } from '../helpers';
 import { VisuallyHidden } from './visually-hidden';
 
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type SpinnerElement = React.ElementRef<'span'>;
 type SpinnerOwnProps = GetPropDefTypes<typeof spinnerPropDefs>;
-interface SpinnerProps
-  extends React.ComponentPropsWithoutRef<'span'>,
-    MarginProps,
-    SpinnerOwnProps {}
+interface SpinnerProps extends PropsWithoutRefOrColor<'span'>, MarginProps, SpinnerOwnProps {}
 const Spinner = React.forwardRef<SpinnerElement, SpinnerProps>((props, forwardedRef) => {
   const { className, children, loading, ...spinnerProps } = extractProps(
     props,

--- a/packages/radix-ui-themes/src/components/strong.tsx
+++ b/packages/radix-ui-themes/src/components/strong.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import type { PropsWithoutRefOrColor } from '../helpers';
+
 type StrongElement = React.ElementRef<'strong'>;
-interface StrongProps extends React.ComponentPropsWithoutRef<'strong'> {}
+interface StrongProps extends PropsWithoutRefOrColor<'strong'> {}
 const Strong = React.forwardRef<StrongElement, StrongProps>((props, forwardedRef) => (
   <strong {...props} ref={forwardedRef} className={classNames('rt-Strong', props.className)} />
 ));

--- a/packages/radix-ui-themes/src/components/tab-nav.tsx
+++ b/packages/radix-ui-themes/src/components/tab-nav.tsx
@@ -39,7 +39,7 @@ TabNavRoot.displayName = 'TabNavRoot';
 
 type TabNavLinkElement = React.ElementRef<typeof NavigationMenu.Link>;
 interface TabNavLinkProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof NavigationMenu.Link>, 'onSelect'> {}
+  extends Omit<PropsWithoutRefOrColor<typeof NavigationMenu.Link>, 'onSelect'> {}
 const TabNavLink = React.forwardRef<TabNavLinkElement, TabNavLinkProps>((props, forwardedRef) => {
   const { asChild = false, className, children, ...linkProps } = props;
   return (

--- a/packages/radix-ui-themes/src/components/table.tsx
+++ b/packages/radix-ui-themes/src/components/table.tsx
@@ -3,14 +3,12 @@ import classNames from 'classnames';
 import { tableRootPropDefs, tableRowPropDefs, tableCellPropDefs } from './table.props';
 import { extractProps, getResponsiveClassNames, marginPropDefs } from '../helpers';
 import { ScrollArea } from './scroll-area';
-import type { MarginProps, GetPropDefTypes } from '../helpers';
+
+import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type TableRootElement = React.ElementRef<'div'>;
 type TableRootOwnProps = GetPropDefTypes<typeof tableRootPropDefs>;
-interface TableRootProps
-  extends React.ComponentPropsWithoutRef<'div'>,
-    MarginProps,
-    TableRootOwnProps {}
+interface TableRootProps extends PropsWithoutRefOrColor<'div'>, MarginProps, TableRootOwnProps {}
 const TableRoot = React.forwardRef<TableRootElement, TableRootProps>((props, forwardedRef) => {
   const { layout: layoutPropDef, ...rootPropDefs } = tableRootPropDefs;
   const { className, children, layout, ...rootProps } = extractProps(
@@ -34,7 +32,7 @@ const TableRoot = React.forwardRef<TableRootElement, TableRootProps>((props, for
 TableRoot.displayName = 'Table';
 
 type TableHeaderElement = React.ElementRef<'thead'>;
-interface TableHeaderProps extends React.ComponentPropsWithoutRef<'thead'> {}
+interface TableHeaderProps extends PropsWithoutRefOrColor<'thead'> {}
 const TableHeader = React.forwardRef<TableHeaderElement, TableHeaderProps>(
   (props, forwardedRef) => (
     <thead
@@ -47,7 +45,7 @@ const TableHeader = React.forwardRef<TableHeaderElement, TableHeaderProps>(
 TableHeader.displayName = 'TableHeader';
 
 type TableBodyElement = React.ElementRef<'tbody'>;
-interface TableBodyProps extends React.ComponentPropsWithoutRef<'tbody'> {}
+interface TableBodyProps extends PropsWithoutRefOrColor<'tbody'> {}
 const TableBody = React.forwardRef<TableBodyElement, TableBodyProps>((props, forwardedRef) => (
   <tbody {...props} ref={forwardedRef} className={classNames('rt-TableBody', props.className)} />
 ));
@@ -56,7 +54,7 @@ TableBody.displayName = 'TableBody';
 type TableRowElement = React.ElementRef<'tr'>;
 type TableRowOwnProps = GetPropDefTypes<typeof tableRowPropDefs>;
 interface TableRowProps
-  extends Omit<React.ComponentPropsWithoutRef<'tr'>, keyof TableRowOwnProps>,
+  extends Omit<PropsWithoutRefOrColor<'tr'>, keyof TableRowOwnProps>,
     TableRowOwnProps {}
 const TableRow = React.forwardRef<TableRowElement, TableRowProps>((props, forwardedRef) => {
   const { className, ...rowProps } = extractProps(props, tableRowPropDefs);
@@ -67,7 +65,7 @@ TableRow.displayName = 'TableRow';
 type TableCellImplElement = React.ElementRef<'td'>;
 type TableCellImplOwnProps = GetPropDefTypes<typeof tableCellPropDefs>;
 interface TableCellImplProps
-  extends Omit<React.ComponentPropsWithoutRef<'td'>, keyof TableCellImplOwnProps>,
+  extends Omit<PropsWithoutRefOrColor<'td'>, keyof TableCellImplOwnProps>,
     TableCellImplOwnProps {
   tag?: 'td' | 'th';
 }
@@ -82,8 +80,7 @@ const TableCellImpl = React.forwardRef<TableCellImplElement, TableCellImplProps>
 TableCellImpl.displayName = 'TableCellImpl';
 
 type TableCellElement = React.ElementRef<typeof TableCellImpl>;
-interface TableCellProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof TableCellImpl>, 'tag'> {}
+interface TableCellProps extends Omit<PropsWithoutRefOrColor<typeof TableCellImpl>, 'tag'> {}
 const TableCell = React.forwardRef<TableCellElement, TableCellProps>((props, forwardedRef) => (
   <TableCellImpl {...props} tag="td" ref={forwardedRef} />
 ));
@@ -91,7 +88,7 @@ TableCell.displayName = 'TableCell';
 
 type TableColumnHeaderCellElement = React.ElementRef<'th'>;
 interface TableColumnHeaderCellProps
-  extends Omit<React.ComponentPropsWithoutRef<'th'>, keyof TableCellImplOwnProps>,
+  extends Omit<PropsWithoutRefOrColor<'th'>, keyof TableCellImplOwnProps>,
     TableCellImplOwnProps {}
 const TableColumnHeaderCell = React.forwardRef<
   TableColumnHeaderCellElement,
@@ -109,7 +106,7 @@ TableColumnHeaderCell.displayName = 'TableColumnHeaderCell';
 
 type TableRowHeaderCellElement = React.ElementRef<'th'>;
 interface TableRowHeaderCellProps
-  extends Omit<React.ComponentPropsWithoutRef<'th'>, keyof TableCellImplOwnProps>,
+  extends Omit<PropsWithoutRefOrColor<'th'>, keyof TableCellImplOwnProps>,
     TableCellImplOwnProps {}
 const TableRowHeaderCell = React.forwardRef<TableRowHeaderCellElement, TableRowHeaderCellProps>(
   (props, forwardedRef) => (

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -9,9 +9,7 @@ import { extractProps, marginPropDefs } from '../helpers';
 import type { MarginProps, GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type TabsRootElement = React.ElementRef<typeof TabsPrimitive.Root>;
-interface TabsRootProps
-  extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>,
-    MarginProps {}
+interface TabsRootProps extends PropsWithoutRefOrColor<typeof TabsPrimitive.Root>, MarginProps {}
 const TabsRoot = React.forwardRef<TabsRootElement, TabsRootProps>((props, forwardedRef) => {
   const { className, ...rootProps } = extractProps(props, marginPropDefs);
   return (
@@ -43,7 +41,7 @@ const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwar
 TabsList.displayName = 'TabsList';
 
 type TabsTriggerElement = React.ElementRef<typeof TabsPrimitive.Trigger>;
-interface TabsTriggerProps extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {}
+interface TabsTriggerProps extends PropsWithoutRefOrColor<typeof TabsPrimitive.Trigger> {}
 const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
   (props, forwardedRef) => {
     const { className, children, ...triggerProps } = props;
@@ -64,7 +62,7 @@ const TabsTrigger = React.forwardRef<TabsTriggerElement, TabsTriggerProps>(
 TabsTrigger.displayName = 'TabsTrigger';
 
 type TabsContentElement = React.ElementRef<typeof TabsPrimitive.Content>;
-interface TabsContentProps extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> {}
+interface TabsContentProps extends PropsWithoutRefOrColor<typeof TabsPrimitive.Content> {}
 const TabsContent = React.forwardRef<TabsContentElement, TabsContentProps>(
   (props, forwardedRef) => (
     <TabsPrimitive.Content

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -7,13 +7,13 @@ import { Text } from './text';
 import { tooltipPropDefs } from './tooltip.props';
 import { Theme } from '../theme';
 
-import type { GetPropDefTypes } from '../helpers';
+import type { GetPropDefTypes, PropsWithoutRefOrColor } from '../helpers';
 
 type TooltipElement = React.ElementRef<typeof TooltipPrimitive.Content>;
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;
 interface TooltipProps
-  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>,
-    Omit<React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>, 'content'>,
+  extends PropsWithoutRefOrColor<typeof TooltipPrimitive.Root>,
+    Omit<PropsWithoutRefOrColor<typeof TooltipPrimitive.Content>, 'content'>,
     TooltipOwnProps {
   // TODO: See if we can automate making prop defs with `required: true` non nullable
   content: NonNullable<TooltipOwnProps['content']>;

--- a/packages/radix-ui-themes/src/icons.tsx
+++ b/packages/radix-ui-themes/src/icons.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import type { PropsWithoutRefOrColor } from './helpers';
 
 type IconElement = React.ElementRef<'svg'>;
-interface IconProps extends React.ComponentPropsWithoutRef<'svg'> {
+interface IconProps extends PropsWithoutRefOrColor<'svg'> {
   children?: never;
   color?: string;
 }

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -26,7 +26,7 @@ import {
   Popover,
 } from './index';
 
-import type { ThemeOptions } from './index';
+import type { PropsWithoutRefOrColor, ThemeOptions } from './index';
 
 interface ThemePanelProps extends Omit<ThemePanelImplProps, keyof ThemePanelImplPrivateProps> {
   defaultOpen?: boolean;
@@ -44,9 +44,7 @@ interface ThemePanelImplPrivateProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
-interface ThemePanelImplProps
-  extends React.ComponentPropsWithoutRef<'div'>,
-    ThemePanelImplPrivateProps {
+interface ThemePanelImplProps extends PropsWithoutRefOrColor<'div'>, ThemePanelImplPrivateProps {
   onAppearanceChange?: (value: Exclude<ThemeOptions['appearance'], 'inherit'>) => void;
 }
 const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplProps>(

--- a/packages/radix-ui-themes/src/theme.tsx
+++ b/packages/radix-ui-themes/src/theme.tsx
@@ -8,6 +8,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { themePropDefs, getMatchingGrayColor } from './theme-options';
 
 import type { ThemeOptions } from './theme-options';
+import type { PropsWithoutRefOrColor } from './helpers';
 
 const noop = () => {};
 
@@ -142,7 +143,7 @@ ThemeRoot.displayName = 'ThemeRoot';
 type ThemeImplElement = React.ElementRef<'div'>;
 interface ThemeImplProps extends ThemeImplPublicProps, ThemeImplPrivateProps {}
 interface ThemeImplPublicProps
-  extends Omit<React.ComponentPropsWithoutRef<'div'>, 'dir'>,
+  extends Omit<PropsWithoutRefOrColor<'div'>, 'dir'>,
     Partial<ThemeOptions> {
   asChild?: boolean;
   isRoot?: boolean;


### PR DESCRIPTION
Remove native color attribute from types for components that don't support own `color` prop to avoid confusion between the two