### PR TITLE
Callout link color regression

### DIFF
--- a/packages/radix-ui-themes/src/components/heading.tsx
+++ b/packages/radix-ui-themes/src/components/heading.tsx
@@ -31,7 +31,7 @@ const Heading = React.forwardRef<HeadingElement, HeadingProps>((props, forwarded
   } = extractProps(props, headingPropDefs, marginPropDefs);
   return (
     <Slot
-      data-accent-color={color}
+      data-accent-color={color || undefined}
       {...headingProps}
       ref={forwardedRef}
       className={classNames('rt-Heading', className)}

--- a/packages/radix-ui-themes/src/components/text.tsx
+++ b/packages/radix-ui-themes/src/components/text.tsx
@@ -33,7 +33,7 @@ const Text = React.forwardRef<TextElement, TextProps>((props, forwardedRef) => {
   } = extractProps(props, textPropDefs, marginPropDefs);
   return (
     <Slot
-      data-accent-color={color}
+      data-accent-color={color || undefined}
       {...textProps}
       ref={forwardedRef}
       className={classNames('rt-Text', className)}


### PR DESCRIPTION
Noticed that link color in callouts was not high contrast anymore due to `CalloutText` receiving an empty string color through callout context