### PR TITLE
Assorted fixes and improvements (without broken merge)

### DIFF
--- a/apps/playground/app/explore-components/page.tsx
+++ b/apps/playground/app/explore-components/page.tsx
@@ -60,7 +60,7 @@ import {
   DataListRoot,
   DataListItem,
   DataListLabel,
-  DataListData,
+  DataListValue,
   dataListPropDefs,
   //
   DialogRoot,
@@ -1617,15 +1617,15 @@ export default function ExploreComponents() {
                         <DataListRoot>
                           <DataListItem>
                             <DataListLabel width="200px">Name</DataListLabel>
-                            <DataListData>Susan Kare</DataListData>
+                            <DataListValue>Susan Kare</DataListValue>
                           </DataListItem>
                           <DataListItem>
                             <DataListLabel>Email</DataListLabel>
-                            <DataListData>susan.kare@apple.com</DataListData>
+                            <DataListValue>susan.kare@apple.com</DataListValue>
                           </DataListItem>
                           <DataListItem>
                             <DataListLabel>Occupation</DataListLabel>
-                            <DataListData>Graphic Designer</DataListData>
+                            <DataListValue>Graphic Designer</DataListValue>
                           </DataListItem>
                         </DataListRoot>
                       </Box>
@@ -1642,11 +1642,11 @@ export default function ExploreComponents() {
                                   <DataListRoot orientation={orientation} my="3">
                                     <DataListItem>
                                       <DataListLabel>Name</DataListLabel>
-                                      <DataListData>Susan Kare</DataListData>
+                                      <DataListValue>Susan Kare</DataListValue>
                                     </DataListItem>
                                     <DataListItem>
                                       <DataListLabel>Email</DataListLabel>
-                                      <DataListData>susan.kare@apple.com</DataListData>
+                                      <DataListValue>susan.kare@apple.com</DataListValue>
                                     </DataListItem>
                                   </DataListRoot>
                                 </td>
@@ -1668,11 +1668,11 @@ export default function ExploreComponents() {
                                   <DataListRoot size={size} my="3">
                                     <DataListItem>
                                       <DataListLabel>Name</DataListLabel>
-                                      <DataListData>Susan Kare</DataListData>
+                                      <DataListValue>Susan Kare</DataListValue>
                                     </DataListItem>
                                     <DataListItem>
                                       <DataListLabel>Email</DataListLabel>
-                                      <DataListData>susan.kare@apple.com</DataListData>
+                                      <DataListValue>susan.kare@apple.com</DataListValue>
                                     </DataListItem>
                                   </DataListRoot>
                                 </td>

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -8,8 +8,6 @@ import {
   Share2Icon,
   InfoCircledIcon,
   StarIcon,
-  StarFilledIcon,
-  MagicWandIcon,
   Cross1Icon,
   CodeIcon,
 } from '@radix-ui/react-icons';
@@ -73,9 +71,8 @@ import {
   DataListRoot,
   DataListItem,
   DataListLabel,
-  DataListData,
+  DataListValue,
   dataListPropDefs,
-  dataListItemPropDefs,
   dataListLabelPropDefs,
   //
   DialogRoot,
@@ -4856,33 +4853,33 @@ export default function Sink() {
                             <DataListRoot>
                               <DataListItem>
                                 <DataListLabel width="200px">Name</DataListLabel>
-                                <DataListData>Susan Kare</DataListData>
+                                <DataListValue>Susan Kare</DataListValue>
                               </DataListItem>
                               <DataListItem>
                                 <DataListLabel>Email</DataListLabel>
-                                <DataListData>susan.kare@apple.com</DataListData>
+                                <DataListValue>susan.kare@apple.com</DataListValue>
                               </DataListItem>
                               <DataListItem>
                                 <DataListLabel>Status</DataListLabel>
-                                <DataListData>
+                                <DataListValue>
                                   <Badge color="green" size="1" style={{ marginLeft: -2 }}>
                                     Active
                                   </Badge>
-                                </DataListData>
+                                </DataListValue>
                               </DataListItem>
                               <DataListItem>
                                 <DataListLabel>Organization</DataListLabel>
-                                <DataListData>
+                                <DataListValue>
                                   <Link href="https://workos.com">WorkOS</Link>
-                                </DataListData>
+                                </DataListValue>
                               </DataListItem>
                               <DataListItem>
                                 <DataListLabel>Bio</DataListLabel>
-                                <DataListData>
+                                <DataListValue>
                                   Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ac
                                   nisl et libero ultricies viverra quis vitae quam. Proin a feugiat
                                   metus.
-                                </DataListData>
+                                </DataListValue>
                               </DataListItem>
                             </DataListRoot>
                           </Box>
@@ -4899,11 +4896,11 @@ export default function Sink() {
                                       <DataListRoot orientation={orientation} my="3">
                                         <DataListItem>
                                           <DataListLabel>Name</DataListLabel>
-                                          <DataListData>Susan Kare</DataListData>
+                                          <DataListValue>Susan Kare</DataListValue>
                                         </DataListItem>
                                         <DataListItem>
                                           <DataListLabel>Email</DataListLabel>
-                                          <DataListData>susan.kare@apple.com</DataListData>
+                                          <DataListValue>susan.kare@apple.com</DataListValue>
                                         </DataListItem>
                                       </DataListRoot>
                                     </td>
@@ -4925,11 +4922,11 @@ export default function Sink() {
                                       <DataListRoot size={size} my="3">
                                         <DataListItem>
                                           <DataListLabel>Name</DataListLabel>
-                                          <DataListData>Susan Kare</DataListData>
+                                          <DataListValue>Susan Kare</DataListValue>
                                         </DataListItem>
                                         <DataListItem>
                                           <DataListLabel>Email</DataListLabel>
-                                          <DataListData>susan.kare@apple.com</DataListData>
+                                          <DataListValue>susan.kare@apple.com</DataListValue>
                                         </DataListItem>
                                       </DataListRoot>
                                     </td>
@@ -4962,11 +4959,11 @@ export default function Sink() {
                                 <DataListRoot gap={gap} my="3">
                                   <DataListItem>
                                     <DataListLabel>Name</DataListLabel>
-                                    <DataListData>Susan Kare</DataListData>
+                                    <DataListValue>Susan Kare</DataListValue>
                                   </DataListItem>
                                   <DataListItem>
                                     <DataListLabel>Email</DataListLabel>
-                                    <DataListData>susan.kare@apple.com</DataListData>
+                                    <DataListValue>susan.kare@apple.com</DataListValue>
                                   </DataListItem>
                                 </DataListRoot>
                               </td>
@@ -4982,11 +4979,11 @@ export default function Sink() {
                                 <DataListRoot gapX={gapX} my="3">
                                   <DataListItem>
                                     <DataListLabel>Name</DataListLabel>
-                                    <DataListData>Susan Kare</DataListData>
+                                    <DataListValue>Susan Kare</DataListValue>
                                   </DataListItem>
                                   <DataListItem>
                                     <DataListLabel>Email</DataListLabel>
-                                    <DataListData>susan.kare@apple.com</DataListData>
+                                    <DataListValue>susan.kare@apple.com</DataListValue>
                                   </DataListItem>
                                 </DataListRoot>
                               </td>
@@ -5002,11 +4999,11 @@ export default function Sink() {
                                 <DataListRoot gapY={gapY} my="3">
                                   <DataListItem>
                                     <DataListLabel>Name</DataListLabel>
-                                    <DataListData>Susan Kare</DataListData>
+                                    <DataListValue>Susan Kare</DataListValue>
                                   </DataListItem>
                                   <DataListItem>
                                     <DataListLabel>Email</DataListLabel>
-                                    <DataListData>susan.kare@apple.com</DataListData>
+                                    <DataListValue>susan.kare@apple.com</DataListValue>
                                   </DataListItem>
                                 </DataListRoot>
                               </td>
@@ -5045,11 +5042,11 @@ export default function Sink() {
                                 <DataListRoot my="3">
                                   <DataListItem>
                                     <DataListLabel color={color}>Name</DataListLabel>
-                                    <DataListData>Susan Kare</DataListData>
+                                    <DataListValue>Susan Kare</DataListValue>
                                   </DataListItem>
                                   <DataListItem>
                                     <DataListLabel color={color}>Email</DataListLabel>
-                                    <DataListData>susan.kare@apple.com</DataListData>
+                                    <DataListValue>susan.kare@apple.com</DataListValue>
                                   </DataListItem>
                                 </DataListRoot>
                               </td>
@@ -5059,13 +5056,13 @@ export default function Sink() {
                                     <DataListLabel highContrast color={color}>
                                       Name
                                     </DataListLabel>
-                                    <DataListData>Susan Kare</DataListData>
+                                    <DataListValue>Susan Kare</DataListValue>
                                   </DataListItem>
                                   <DataListItem>
                                     <DataListLabel highContrast color={color}>
                                       Email
                                     </DataListLabel>
-                                    <DataListData>susan.kare@apple.com</DataListData>
+                                    <DataListValue>susan.kare@apple.com</DataListValue>
                                   </DataListItem>
                                 </DataListRoot>
                               </td>
@@ -5099,11 +5096,11 @@ export default function Sink() {
                                   <DataListRoot my="3">
                                     <DataListItem>
                                       <DataListLabel width={`${labelWidth}px`}>Name</DataListLabel>
-                                      <DataListData>Susan Kare</DataListData>
+                                      <DataListValue>Susan Kare</DataListValue>
                                     </DataListItem>
                                     <DataListItem>
                                       <DataListLabel>Email</DataListLabel>
-                                      <DataListData>susan.kare@apple.com</DataListData>
+                                      <DataListValue>susan.kare@apple.com</DataListValue>
                                     </DataListItem>
                                   </DataListRoot>
                                 </td>

--- a/apps/playground/app/test-reset/page.tsx
+++ b/apps/playground/app/test-reset/page.tsx
@@ -1,0 +1,195 @@
+import * as React from 'react';
+import { Theme, Container, Section, Reset, Box, Flex, Text } from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Container size="1" px="8">
+                <Section size="3">
+                  <ResetChildren>
+                    <RadixLogo />
+                    <a href="https://example.com">Anchor</a>
+                    <abbr>Abbreviation</abbr>
+                    <address>Contact information</address>
+                    <article>Article</article>
+                    <aside>Aside content</aside>
+                    <audio>Audio content</audio>
+                    <b>Bold text</b>
+                    <bdi>Bi-directional Isolation</bdi>
+                    <bdo>Bi-directional Override</bdo>
+                    <blockquote>Block quote</blockquote>
+                    <button>Button</button>
+                    <cite>Cited text</cite>
+                    <code>Computer code</code>
+                    <data>Machine-readable equivalent</data>
+                    <dd>Description in a description list</dd>
+                    <del>Deleted text</del>
+                    <details>
+                      Additional details
+                      <summary>Summary for a details element</summary>
+                    </details>
+                    <dfn>Defining term</dfn>
+                    <div>Div</div>
+                    <dl>Description list</dl>
+                    <dt>Term in a description list</dt>
+                    <em>Emphasized text</em>
+                    <fieldset>Group of form-related elements</fieldset>
+                    <figcaption>Caption for a figure element</figcaption>
+                    <figure>Self-contained content</figure>
+                    <footer>Document or section footer</footer>
+                    <form>HTML form</form>
+                    <h1>HTML heading 1</h1>
+                    <h2>HTML heading 2</h2>
+                    <h3>HTML heading 3</h3>
+                    <h4>HTML heading 4</h4>
+                    <h5>HTML heading 5</h5>
+                    <h6>HTML heading 6</h6>
+                    <header>Document or section header</header>
+                    <hr />
+                    <i>Italic text</i>
+                    <iframe src="https://example.com" />
+                    <img src="https://source.unsplash.com/random" />
+                    <input placeholder="Input control" />
+                    <ins>Inserted text</ins>
+                    <kbd>Keyboard input</kbd>
+                    <label>Form field label text</label>
+                    <legend>Caption for a fieldset element</legend>
+                    <li>List item</li>
+                    <main>Main content</main>
+                    <mark>Marked or highlighted text</mark>
+                    <nav>Navigation links</nav>
+                    <ol>
+                      <li>Coffee</li>
+                      <li>Tea</li>
+                      <li>Milk</li>
+                    </ol>
+                    <output>Result of a calculation</output>
+                    <p>Paragraph</p>
+                    <picture>Container for multiple image sources</picture>
+                    <pre>Preformatted text: {'"    "'}</pre>
+                    <q>Short quote</q>
+                    <s>Text that is no longer correct</s>
+                    <samp>Sample output</samp>
+                    <section>Section in a document</section>
+                    <select name="select" id="select">
+                      <option value="1">Select Option 1</option>
+                      <option value="2">Select Option 2</option>
+                      <option value="3">Select Option 3</option>
+                      <option value="4">Select Option 4</option>
+                    </select>
+                    <small>Smaller text</small>
+                    <span>Inline element</span>
+                    <strong>Important text</strong>
+                    <sub>Subscripted text</sub>
+                    <sup>Superscripted text</sup>
+                    <table>
+                      <ResetChildren>
+                        <caption>Table</caption>
+                        <thead>
+                          <ResetChildren>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="col">Person</th>
+                                <th scope="col">Most interest in</th>
+                                <th scope="col">Age</th>
+                              </ResetChildren>
+                            </tr>
+                          </ResetChildren>
+                        </thead>
+                        <tbody>
+                          <ResetChildren>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="row">Chris</th>
+                                <td>HTML tables</td>
+                                <td>22</td>
+                              </ResetChildren>
+                            </tr>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="row">Dennis</th>
+                                <td>Web accessibility</td>
+                                <td>45</td>
+                              </ResetChildren>
+                            </tr>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="row">Sarah</th>
+                                <td>JavaScript frameworks</td>
+                                <td>29</td>
+                              </ResetChildren>
+                            </tr>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="row">Karen</th>
+                                <td>Web performance</td>
+                                <td>36</td>
+                              </ResetChildren>
+                            </tr>
+                          </ResetChildren>
+                        </tbody>
+                        <tfoot>
+                          <ResetChildren>
+                            <tr>
+                              <ResetChildren>
+                                <th scope="row" colSpan={2}>
+                                  Average age
+                                </th>
+                                <td>33</td>
+                              </ResetChildren>
+                            </tr>
+                          </ResetChildren>
+                        </tfoot>
+                      </ResetChildren>
+                    </table>
+
+                    <textarea placeholder="Multi-line textarea" />
+                    <ul>
+                      <li>Coffee</li>
+                      <li>Tea</li>
+                      <li>Milk</li>
+                    </ul>
+                    <u>Text with unarticulated annotation</u>
+                    <var>Variable</var>
+                  </ResetChildren>
+                </Section>
+              </Container>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+const ResetChildren = ({ children }: { children: React.ReactNode }) => {
+  return React.Children.map(children, (child) => <Reset>{child}</Reset>);
+};
+
+const RadixLogo = (props: React.ComponentPropsWithoutRef<'svg'>) => {
+  return (
+    <svg
+      width="76"
+      height="24"
+      viewBox="0 0 76 24"
+      fill="currentcolor"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path d="M43.9022 20.0061H46.4499C46.2647 19.0375 46.17 18.1161 46.17 17.0058V12.3753C46.17 9.25687 44.3893 7.72127 41.1943 7.72127C38.3003 7.72127 36.3324 9.23324 36.0777 11.8083H38.9254C39.0181 10.698 39.8052 9.96561 41.1017 9.96561C42.4446 9.96561 43.3243 10.6743 43.3243 12.1391V12.7061L39.8052 13.1077C37.4206 13.3912 35.5684 14.3834 35.5684 16.7931C35.5684 18.9666 37.2353 20.2659 39.5274 20.2659C41.4027 20.2659 42.9845 19.4863 43.6401 18.1161C43.6689 18.937 43.9022 20.0061 43.9022 20.0061ZM40.3377 18.1634C39.157 18.1634 38.5087 17.5727 38.5087 16.6278C38.5087 15.3757 39.4579 15.0922 40.7082 14.9268L43.3243 14.6197V15.352C43.3243 17.242 41.8658 18.1634 40.3377 18.1634ZM56.2588 20.0061H59.176V3H56.2125V9.96561C55.6569 8.76075 54.3141 7.72127 52.4851 7.72127C49.3058 7.72127 47.099 10.2963 47.099 14.0054C47.099 17.7381 49.3058 20.2896 52.4851 20.2896C54.2678 20.2896 55.68 19.2973 56.2588 18.0925V20.0061ZM56.282 14.218C56.282 16.5569 55.1938 18.0689 53.3185 18.0689C51.3969 18.0689 50.1856 16.486 50.1856 14.0054C50.1856 11.5485 51.3969 9.94198 53.3185 9.94198C55.1938 9.94198 56.282 11.454 56.282 13.7928V14.218ZM60.9066 5.97304H64.0553V3.01996H60.9066V5.97304ZM60.9992 20.0061H63.9627V8.00476H60.9992V20.0061ZM67.6638 20.0061L70.6041 15.8954L73.5212 20.0061H76.9246L72.3636 13.7219L76.5542 8.00476H73.3823L70.7661 11.7138L68.1731 8.00476H64.7697L69.0066 13.8637L64.4919 20.0061H67.6638Z"></path>
+      <path
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M24.9132 20V14.0168H28.7986L32.4513 20H35.7006L31.6894 13.5686C33.5045 12.986 35.0955 11.507 35.0955 9.01961C35.0955 5.7479 32.7994 4 28.9571 4H22V20H24.9132ZM24.9132 6.35294V11.6863H28.821C31.0395 11.6863 32.1599 10.7675 32.1599 9.01961C32.1599 7.27171 30.9395 6.35294 28.621 6.35294H24.9132Z"
+      ></path>
+      <path d="M7 23C3.13401 23 0 19.6422 0 15.5C0 11.3578 3.13401 8 7 8V23Z"></path>
+      <path d="M7 0H0V7H7V0Z"></path>
+      <path d="M11.5 7C13.433 7 15 5.433 15 3.5C15 1.567 13.433 0 11.5 0C9.56704 0 8 1.567 8 3.5C8 5.433 9.56704 7 11.5 7Z"></path>
+    </svg>
+  );
+};

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -24,9 +24,14 @@
   - Fix an issue with responsive props when using a breakpoints object without the `initial` key would not apply the default prop value
   - Make sure `highContrast` text colors work consistently when nested within other components that accept an accent color
   - Remove the native `color` attribute from components that don’t have own `color` props
-- 6 new components
+  - Rework the availability of `asChild` prop on all components and parts
+  - Ensure all elements that have padding or border styles use `box-sizing: border-box`
+  - Ensure that disabled cursor styles are applied correctly
+  - Tweak the background color of all `variant="soft"` menu items
+- 7 new components
   - `Progress`
   - `RadioCardGroup`
+  - `Reset`
   - `Skeleton`
   - `Spinner`
   - `TabNav`
@@ -36,6 +41,8 @@
   - Rework the scroll container so that it displays scrollbars on the viewport rather than confined to the dialog content
 - `Code`
   - `variant="ghost"` color now works similarly to Text, inheriting the color unless set explicitly using the `color` prop
+- `Container`
+  - Add `align` prop to control whether the container content is aligned to the left, center, or right
 - `Container`, `Section`
   - Change the incorrect `display="block"` value to `display="initial"`
 - `ContextMenu`, `DropdownMenu`
@@ -51,6 +58,8 @@
   - Add `gapX` and `gapY` props
 - `Popover`, `HoverCard`, `Tooltip`
   - Add `position: relative` to support absolutely positioned children.
+- `ScrollArea`
+  - Fix an issue when Scroll Area would be unable to stretch to 100% height when informed by the parent’s auto height
 - `Slider`
   - Change the size of the bounding box to match the size of the Slider track
 - `Table`
@@ -73,6 +82,8 @@
 - `TextField`
   - Fix an issue with some input `type`s not supporting `getSelectionRange`
   - Fix an issue when Grammarly extension would break the component styles
+- `Tooltip`
+  - Change the default delay duration to 200ms
 
 ## 2.0.3
 

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -1,7 +1,6 @@
 .rt-Badge {
   display: inline-flex;
   align-items: center;
-  box-sizing: border-box;
   white-space: nowrap;
   font-weight: var(--font-weight-medium);
   flex-shrink: 0;

--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -2,7 +2,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  box-sizing: border-box;
   flex-shrink: 0;
   user-select: none;
   vertical-align: top;
@@ -220,7 +219,6 @@
     }
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-2);
     background-image: none;
@@ -289,7 +287,6 @@
     }
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a3);
     filter: none;
@@ -305,7 +302,6 @@
     color: var(--accent-12);
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a3);
   }
@@ -330,7 +326,6 @@
     background-color: var(--accent-a5);
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a3);
   }
@@ -353,7 +348,6 @@
     background-color: var(--accent-a4);
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: transparent;
   }
@@ -385,7 +379,6 @@
     color: var(--accent-12);
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
     background-color: transparent;
@@ -419,7 +412,6 @@
     color: var(--accent-12);
   }
   &:where([data-disabled]) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     box-shadow: inset 0 0 0 1px var(--gray-a6);
     background-color: var(--gray-a2);

--- a/packages/radix-ui-themes/src/components/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/base-dialog.css
@@ -18,7 +18,12 @@
 }
 
 .rt-BaseDialogScrollPadding {
-  margin: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  box-sizing: border-box;
   padding-top: var(--space-6);
   padding-bottom: max(var(--space-6), 6vh);
   padding-left: var(--space-4);

--- a/packages/radix-ui-themes/src/components/base-menu.css
+++ b/packages/radix-ui-themes/src/components/base-menu.css
@@ -17,6 +17,7 @@
   flex-direction: column;
   overflow: auto;
   padding: var(--base-menu-content-padding);
+  box-sizing: border-box;
 
   :where(.rt-BaseMenuContent:has(.rt-ScrollAreaScrollbar[data-orientation='vertical'])) & {
     padding-right: var(--space-3);
@@ -30,17 +31,18 @@
   height: var(--base-menu-item-height);
   padding-left: var(--base-menu-item-padding-left);
   padding-right: var(--base-menu-item-padding-right);
-  position: relative;
   box-sizing: border-box;
+  position: relative;
   outline: none;
-  cursor: var(--cursor-menu-item);
   scroll-margin: var(--base-menu-content-padding) 0;
 
   /* Fix sticky text highlighting after selection in Firefox */
   user-select: none;
 
+  /* Cursors */
+  cursor: var(--cursor-menu-item);
   &:where([data-disabled]) {
-    pointer-events: none;
+    cursor: default;
   }
 }
 
@@ -78,6 +80,7 @@
   height: var(--base-menu-item-height);
   padding-left: var(--base-menu-item-padding-left);
   padding-right: var(--base-menu-item-padding-right);
+  box-sizing: border-box;
   color: var(--gray-a10);
   user-select: none;
   cursor: default;
@@ -236,7 +239,7 @@
     background-color: var(--accent-a3);
   }
   & :where(.rt-BaseMenuItem[data-highlighted]) {
-    background-color: var(--accent-a5);
+    background-color: var(--accent-a4);
 
     &:where([data-accent-color]) {
       color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/base-tab-list.css
+++ b/packages/radix-ui-themes/src/components/base-tab-list.css
@@ -13,7 +13,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-sizing: border-box;
   flex-shrink: 0;
   position: relative;
   user-select: none;
@@ -55,6 +54,7 @@
  ***************************************************************************************************/
 
 .rt-BaseTabListTrigger {
+  box-sizing: border-box;
   height: var(--tab-height);
   padding-left: var(--tab-padding-x);
   padding-right: var(--tab-padding-x);
@@ -62,6 +62,7 @@
 
 .rt-BaseTabListTriggerInner,
 .rt-BaseTabListTriggerInnerHidden {
+  box-sizing: border-box;
   padding: var(--tab-inner-padding-y) var(--tab-inner-padding-x);
   border-radius: var(--tab-inner-border-radius);
 }

--- a/packages/radix-ui-themes/src/components/blockquote.css
+++ b/packages/radix-ui-themes/src/components/blockquote.css
@@ -1,4 +1,5 @@
 .rt-Blockquote {
+  box-sizing: border-box;
   border-left: max(var(--space-1), 0.25em) solid var(--accent-a6);
   padding-left: min(var(--space-5), max(var(--space-3), 0.5em));
 }

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -28,6 +28,10 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
+.rt-CalloutRoot {
+  box-sizing: border-box;
+}
+
 @breakpoints {
   .rt-CalloutRoot {
     &:where(.rt-r-size-1) {

--- a/packages/radix-ui-themes/src/components/card.css
+++ b/packages/radix-ui-themes/src/components/card.css
@@ -36,10 +36,10 @@
   --inset-border-width: var(--card-border-width);
   --inset-border-radius: var(--card-border-radius);
   position: relative;
-  box-sizing: border-box;
   border-radius: inherit;
   overflow: hidden;
   padding: var(--card-padding);
+  box-sizing: border-box;
 
   /*
    * Some layout acrobatics with `var(--card-border-width)` because we want:

--- a/packages/radix-ui-themes/src/components/checkbox.css
+++ b/packages/radix-ui-themes/src/components/checkbox.css
@@ -5,8 +5,13 @@
   justify-content: center;
   vertical-align: top;
   flex-shrink: 0;
-  cursor: var(--cursor-checkbox);
   height: var(--line-height, var(--checkbox-size));
+
+  cursor: var(--cursor-checkbox);
+  &:where(:disabled) {
+    cursor: var(--cursor-disabled);
+  }
+
   &::before {
     content: '';
     display: block;
@@ -90,7 +95,6 @@
     &::before {
       box-shadow: inset 0 0 0 1px var(--gray-a6);
       background-color: var(--gray-a3);
-      cursor: var(--cursor-disabled);
     }
     & :where(.rt-CheckboxIndicator) {
       color: var(--gray-a8);
@@ -133,7 +137,6 @@
       box-shadow: var(--shadow-1);
       background-color: var(--gray-a3);
       background-image: none;
-      cursor: var(--cursor-disabled);
     }
     & :where(.rt-CheckboxIndicator) {
       color: var(--gray-a8);
@@ -163,7 +166,6 @@
   &:where(:disabled) {
     &::before {
       background-color: var(--gray-a3);
-      cursor: var(--cursor-disabled);
     }
     & :where(.rt-CheckboxIndicator) {
       color: var(--gray-a8);

--- a/packages/radix-ui-themes/src/components/container.props.ts
+++ b/packages/radix-ui-themes/src/components/container.props.ts
@@ -3,6 +3,7 @@ import type { PropDef } from '../helpers';
 
 const sizes = ['1', '2', '3', '4'] as const;
 const displayValues = ['none', 'initial'] as const;
+const alignValues = ['left', 'center', 'right'] as const;
 
 const containerPropDefs = {
   asChild: asChildProp,
@@ -21,14 +22,27 @@ const containerPropDefs = {
     default: undefined,
     responsive: true,
   },
+  align: {
+    type: 'enum',
+    className: 'rt-r-ai',
+    values: alignValues,
+    parseValue: parseAlignValue,
+    default: undefined,
+    responsive: true,
+  },
 } satisfies {
   asChild: typeof asChildProp;
   size: PropDef<(typeof sizes)[number]>;
   display: PropDef<(typeof displayValues)[number]>;
+  align: PropDef<(typeof alignValues)[number]>;
 };
 
 function parseDisplayValue(value: string) {
   return value === 'initial' ? 'flex' : value;
+}
+
+function parseAlignValue(value: string) {
+  return value === 'left' ? 'start' : value === 'right' ? 'end' : value;
 }
 
 export { containerPropDefs };

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -59,20 +59,20 @@ const DataListLabel = React.forwardRef<DataListLabelElement, DataListLabelProps>
 );
 DataListLabel.displayName = 'DataListLabel';
 
-type DataListDataElement = React.ElementRef<'dd'>;
-interface DataListDataProps extends PropsWithoutRefOrColor<'dd'> {}
-const DataListData = React.forwardRef<DataListDataElement, DataListDataProps>(
+type DataListValueElement = React.ElementRef<'dd'>;
+interface DataListValueProps extends PropsWithoutRefOrColor<'dd'> {}
+const DataListValue = React.forwardRef<DataListValueElement, DataListValueProps>(
   ({ children, className, ...props }, forwardedRef) => (
     <dd
       {...props}
       ref={forwardedRef}
-      className={classNames(className, 'rt-reset', 'rt-DataListData')}
+      className={classNames(className, 'rt-reset', 'rt-DataListValue')}
     >
       {children}
     </dd>
   )
 );
-DataListData.displayName = 'DataListData';
+DataListValue.displayName = 'DataListValue';
 
 const DataList = Object.assign(
   {},
@@ -80,8 +80,8 @@ const DataList = Object.assign(
     Root: DataListRoot,
     Item: DataListItem,
     Label: DataListLabel,
-    Data: DataListData,
+    Data: DataListValue,
   }
 );
-export { DataList, DataListRoot, DataListItem, DataListLabel, DataListData };
-export type { DataListRootProps, DataListItemProps, DataListLabelProps, DataListDataProps };
+export { DataList, DataListRoot, DataListItem, DataListLabel, DataListValue };
+export type { DataListRootProps, DataListItemProps, DataListLabelProps, DataListValueProps };

--- a/packages/radix-ui-themes/src/components/hover-card.css
+++ b/packages/radix-ui-themes/src/components/hover-card.css
@@ -6,6 +6,7 @@
 
   --inset-padding: var(--hover-card-content-padding);
   padding: var(--hover-card-content-padding);
+  box-sizing: border-box;
 
   transform-origin: var(--radix-hover-card-content-transform-origin);
 }

--- a/packages/radix-ui-themes/src/components/index.ts
+++ b/packages/radix-ui-themes/src/components/index.ts
@@ -149,7 +149,7 @@ export { Callout, CalloutRoot, CalloutIcon, CalloutText } from './callout';
 export * from './callout.props';
 export { Card } from './card';
 export * from './card.props';
-export { DataListRoot, DataListData, DataListItem, DataListLabel } from './data-list';
+export { DataListRoot, DataListItem, DataListLabel, DataListValue } from './data-list';
 export * from './data-list.props';
 // export * from './collapsible';
 // export * from './definition-list';
@@ -189,5 +189,6 @@ export * from './tabs.props';
 //------------------------------------------------------------------------------
 export { AccessibleIcon } from './accessible-icon';
 export { Portal } from './portal';
+export { Reset } from './reset';
 export { Slot, Slottable } from './slot';
 export { VisuallyHidden } from './visually-hidden';

--- a/packages/radix-ui-themes/src/components/kbd.css
+++ b/packages/radix-ui-themes/src/components/kbd.css
@@ -24,7 +24,6 @@
 }
 
 .rt-Kbd {
-  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -41,6 +40,7 @@
   font-size: 0.75em;
   min-width: 1.75em;
   line-height: 1.7em;
+  box-sizing: border-box;
   padding-left: 0.5em;
   padding-right: 0.5em;
   padding-bottom: 0.05em;

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -1,7 +1,12 @@
 .rt-Link {
-  cursor: var(--cursor-link);
   color: var(--accent-a11);
   border-radius: calc(0.07em * var(--radius-factor));
+
+  /* Override the cursor on the HTML element even if rendering a <button> */
+  cursor: var(--cursor-link);
+  &:where(:disabled, [data-disabled]) {
+    cursor: var(--cursor-disabled);
+  }
 
   &:where(:focus-visible) {
     outline-color: var(--color-focus-root);

--- a/packages/radix-ui-themes/src/components/popover.css
+++ b/packages/radix-ui-themes/src/components/popover.css
@@ -8,6 +8,7 @@
 
   --inset-padding: var(--popover-content-padding);
   padding: var(--popover-content-padding);
+  box-sizing: border-box;
 
   transform-origin: var(--radix-popover-content-transform-origin);
 }

--- a/packages/radix-ui-themes/src/components/radio-card-group.css
+++ b/packages/radix-ui-themes/src/components/radio-card-group.css
@@ -31,6 +31,7 @@
 }
 
 .rt-RadioCardGroupItem {
+  box-sizing: border-box;
   padding: var(--radio-card-group-item-padding);
   border-radius: var(--radio-card-group-item-radius);
   gap: var(--radio-card-group-item-gap);

--- a/packages/radix-ui-themes/src/components/radio-group.css
+++ b/packages/radix-ui-themes/src/components/radio-group.css
@@ -15,6 +15,9 @@
     cursor: var(--cursor-radio);
     border-radius: 100%;
   }
+  &:where([data-disabled])::before {
+    cursor: var(--cursor-disabled);
+  }
 
   &:where(:focus-visible)::before {
     outline: 2px solid var(--color-focus-root);
@@ -83,7 +86,6 @@
   & :where(.rt-RadioGroupItem[data-disabled])::before {
     box-shadow: inset 0 0 0 1px var(--gray-a6);
     background-color: var(--gray-a3);
-    cursor: var(--cursor-disabled);
   }
   & :where(.rt-RadioGroupIndicator[data-disabled]) {
     background-color: var(--gray-a8);
@@ -119,7 +121,6 @@
     box-shadow: var(--shadow-1);
     background-color: var(--gray-a3);
     background-image: none;
-    cursor: var(--cursor-disabled);
   }
   & :where(.rt-RadioGroupIndicator[data-disabled]) {
     background-color: var(--gray-a8);
@@ -130,7 +131,7 @@
 
 .rt-RadioGroupRoot:where(.rt-variant-soft) {
   & :where(.rt-RadioGroupItem)::before {
-    background-color: var(--accent-a5);
+    background-color: var(--accent-a4);
   }
   & :where(.rt-RadioGroupIndicator) {
     background-color: var(--accent-a11);
@@ -149,7 +150,6 @@
 
   & :where(.rt-RadioGroupItem[data-disabled])::before {
     background-color: var(--gray-a3);
-    cursor: var(--cursor-disabled);
   }
   & :where(.rt-RadioGroupIndicator[data-disabled]) {
     background-color: var(--gray-a8);

--- a/packages/radix-ui-themes/src/components/reset.css
+++ b/packages/radix-ui-themes/src/components/reset.css
@@ -2,55 +2,173 @@
 /* Disable selector-max-type rule to target individual element types. */
 /* Make sure these tags are wrapped in `:where()` for 0 specificity. */
 
-.rt-reset:where(a) {
-  cursor: auto;
-  text-decoration: none;
-  color: inherit;
-  outline: none;
-}
+.rt-reset {
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*              Margins                */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
 
-.rt-reset:where(a[href]) {
-  cursor: var(--cursor-link);
-}
+  &:where(body, blockquote, dl, dd, figure, p) {
+    margin: 0;
+  }
 
-.rt-reset:where(button) {
-  appearance: none;
-  cursor: var(--cursor-button);
-  background-color: transparent;
-  border: none;
-  font-size: inherit;
-  font-family: inherit;
-  line-height: inherit;
-  letter-spacing: inherit;
-  outline: none;
-  color: inherit;
-  padding: 0;
-  margin: 0;
-  text-align: initial;
-  -webkit-tap-highlight-color: transparent;
-}
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*             Typography              */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
 
-.rt-reset:where(h1, h2, h3, h4, h5, h6) {
-  font-size: inherit;
-  font-weight: inherit;
-  margin: 0;
-}
+  &:where(address, b, cite, code, dfn, em, i, kbd, q, samp, small, strong, var) {
+    font: unset;
+  }
+  &:where(h1, h2, h3, h4, h5, h6) {
+    font: unset;
+    margin: 0;
+  }
 
-.rt-reset:where(ol, ul) {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*        Interactive elements         */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
 
-.rt-reset:where(p) {
-  margin: 0;
-}
+  &:where(a, button, input, textarea, select) {
+    all: unset;
+    display: inline-block;
+    -webkit-tap-highlight-color: transparent;
+  }
+  &:where(:focus) {
+    outline: none;
+  }
+  &::placeholder {
+    color: unset;
+    opacity: unset;
+  }
 
-.rt-reset:where(pre) {
-  font-family: inherit;
-  margin: 0;
-}
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*               Tables                */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
 
-.rt-reset:where(dd) {
-  margin: 0;
+  &:where(table) {
+    all: unset;
+    display: table;
+  }
+  &:where(caption) {
+    text-align: inherit;
+  }
+  &:where(td) {
+    padding: 0;
+  }
+  &:where(th) {
+    font-weight: unset;
+    text-align: inherit;
+    padding: 0;
+  }
+
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*       Individual style tweaks       */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
+
+  &:where(canvas, object, picture, summary) {
+    display: block;
+  }
+  &:where(del, s) {
+    text-decoration: unset;
+  }
+  &:where(fieldset, hr) {
+    all: unset;
+    display: block;
+  }
+  &:where(legend) {
+    padding: 0;
+    border: none;
+  }
+  &:where(li) {
+    display: block;
+    text-align: unset;
+  }
+  &:where(ol, ul) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  &:where(iframe) {
+    display: block;
+    border: none;
+  }
+  @supports (width: -webkit-fill-available) {
+    &:where(iframe, input, textarea) {
+      width: -webkit-fill-available;
+    }
+  }
+  @supports (width: -moz-available) {
+    &:where(iframe, input, textarea) {
+      width: -moz-available;
+    }
+  }
+  &:where(ins, u) {
+    text-decoration: none;
+  }
+  &:where(img) {
+    display: block;
+    max-width: 100%;
+  }
+  &:where(svg) {
+    display: block;
+    max-width: 100%;
+    flex-shrink: 0;
+  }
+  &:where(mark) {
+    all: unset;
+  }
+  &:where(pre) {
+    font: unset;
+    margin: unset;
+  }
+  &:where(q)::before,
+  &:where(q)::after {
+    content: '';
+  }
+  &:where(sub, sup) {
+    font: unset;
+    vertical-align: unset;
+  }
+
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*               Cursors               */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
+
+  &:where(a[href]) {
+    cursor: var(--cursor-link);
+  }
+  &:where(button) {
+    cursor: var(--cursor-button);
+  }
+  &:where(:disabled, [data-disabled]) {
+    cursor: var(--cursor-disabled);
+  }
+  &:where(input[type='checkbox']) {
+    cursor: var(--cursor-checkbox);
+  }
+  &:where(input[type='radio']) {
+    cursor: var(--cursor-radio);
+  }
+
+  /* * * * * * * * * * * * * * * * * * * */
+  /*                                     */
+  /*             Box sizing              */
+  /*                                     */
+  /* * * * * * * * * * * * * * * * * * * */
+
+  & {
+    /* Don't reorder this rule or remove "&" */
+    box-sizing: border-box;
+  }
 }

--- a/packages/radix-ui-themes/src/components/reset.tsx
+++ b/packages/radix-ui-themes/src/components/reset.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { Slot } from '@radix-ui/react-slot';
+import { extractProps, marginPropDefs, requireReactElement } from '../helpers';
+
+import type { MarginProps, PropsWithoutRefOrColor } from '../helpers';
+
+type ResetElement = React.ElementRef<'div'>;
+interface ResetProps extends PropsWithoutRefOrColor<typeof Slot>, MarginProps {}
+const Reset = React.forwardRef<ResetElement, ResetProps>((props, forwardedRef) => {
+  const { className, children, ...resetProps } = extractProps(props, marginPropDefs);
+  return (
+    <Slot {...resetProps} ref={forwardedRef} className={classNames('rt-reset', className)}>
+      {requireReactElement(children)}
+    </Slot>
+  );
+});
+Reset.displayName = 'Reset';
+
+export { Reset };
+export type { ResetProps };

--- a/packages/radix-ui-themes/src/components/scroll-area.css
+++ b/packages/radix-ui-themes/src/components/scroll-area.css
@@ -18,6 +18,8 @@
 }
 
 .rt-ScrollAreaViewport {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   height: 100%;
 
@@ -31,6 +33,12 @@
     outline: 2px solid var(--color-focus-root);
     outline-offset: -2px;
   }
+}
+
+.rt-ScrollAreaViewport > * {
+  display: block !important;
+  width: fit-content;
+  flex-grow: 1;
 }
 
 .rt-ScrollAreaScrollbar {

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -2,7 +2,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: space-between;
-  box-sizing: border-box;
   flex-shrink: 0;
   user-select: none;
   vertical-align: top;
@@ -62,11 +61,16 @@
   position: relative;
   box-sizing: border-box;
   outline: none;
-  cursor: var(--cursor-menu-item);
   scroll-margin: var(--select-content-padding) 0;
 
   /* Fix sticky text highlighting after selection in Firefox */
   user-select: none;
+
+  /* Cursors */
+  cursor: var(--cursor-menu-item);
+  &:where([data-disabled]) {
+    cursor: default;
+  }
 }
 
 .rt-SelectItemIndicator {
@@ -111,6 +115,7 @@
   color: var(--gray-12);
 
   &:where(:not(.rt-variant-ghost)) {
+    box-sizing: border-box;
     height: var(--select-trigger-height);
   }
   &:where(.rt-variant-ghost) {
@@ -297,7 +302,6 @@
     box-shadow: inset 0 0 0 1px var(--gray-a8);
   }
   &:where(:disabled) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a2);
     box-shadow: inset 0 0 0 1px var(--gray-a6);
@@ -369,7 +373,6 @@
     }
   }
   &:where(:disabled) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     /* Use disabled button style for the shadow */
     box-shadow: var(--base-button-classic-disabled-box-shadow);
@@ -415,7 +418,6 @@
     outline-color: var(--accent-8);
   }
   &:where(:disabled) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a3);
   }
@@ -431,7 +433,6 @@
     background-color: var(--accent-a3);
   }
   &:where(:disabled) {
-    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: transparent;
   }
@@ -472,6 +473,6 @@
 
 .rt-SelectContent:where(.rt-variant-soft) {
   & :where(.rt-SelectItem[data-highlighted]) {
-    background-color: var(--accent-a5);
+    background-color: var(--accent-a4);
   }
 }

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -254,4 +254,8 @@
     background-image: none;
     box-shadow: none;
   }
+  .rt-SliderThumb:where(&),
+  .rt-SliderThumb:where(&)::after {
+    cursor: var(--cursor-disabled);
+  }
 }

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -32,7 +32,6 @@
     width: var(--switch-width);
     height: var(--switch-height);
     border-radius: var(--switch-border-radius);
-    cursor: var(--cursor-switch);
     transition: background-position, background-color, box-shadow, filter;
     transition-timing-function: linear, ease-in-out, ease-in-out, ease-in-out;
     background-repeat: no-repeat;
@@ -58,6 +57,14 @@
   &:where(:focus-visible)::before {
     outline: 2px solid var(--color-focus-root);
     outline-offset: 2px;
+  }
+
+  /* Cursors */
+  &::before {
+    cursor: var(--cursor-switch);
+  }
+  &:where([data-disabled])::before {
+    cursor: var(--cursor-disabled);
   }
 }
 
@@ -146,7 +153,6 @@
       background-image: none;
       background-color: var(--gray-a3);
       box-shadow: inset 0 0 0 1px var(--gray-a3);
-      cursor: var(--cursor-disabled);
     }
   }
 
@@ -222,7 +228,6 @@
       background-color: var(--gray-a5);
       box-shadow: var(--shadow-1);
       opacity: 0.5;
-      cursor: var(--cursor-disabled);
     }
   }
 
@@ -288,7 +293,6 @@
       filter: none;
       background-image: none;
       background-color: var(--gray-a4);
-      cursor: var(--cursor-disabled);
     }
   }
 

--- a/packages/radix-ui-themes/src/components/table.css
+++ b/packages/radix-ui-themes/src/components/table.css
@@ -101,6 +101,7 @@
 /* surface */
 
 .rt-TableRoot:where(.rt-variant-surface) {
+  box-sizing: border-box;
   border: 1px solid var(--gray-a5);
   border-radius: var(--table-border-radius);
   background-color: var(--color-panel);

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -15,16 +15,9 @@
 }
 
 .rt-TextAreaInput {
-  appearance: none;
-  padding: 0;
-  outline: 0;
   border-radius: inherit;
-  background-color: transparent;
-  font-family: inherit;
-  -webkit-tap-highlight-color: transparent;
   resize: none;
 
-  box-sizing: border-box;
   position: relative;
   display: block;
   width: 100%;
@@ -77,6 +70,7 @@
 .rt-TextAreaChrome {
   position: absolute;
   border-radius: inherit;
+  box-sizing: border-box;
   z-index: 0;
   inset: 0;
 }
@@ -245,7 +239,7 @@
       opacity: 0.5;
     }
     &:where(:placeholder-shown) {
-      cursor: default;
+      cursor: var(--cursor-disabled);
     }
     &::selection {
       background-color: var(--gray-a5);

--- a/packages/radix-ui-themes/src/components/text-area.tsx
+++ b/packages/radix-ui-themes/src/components/text-area.tsx
@@ -24,7 +24,7 @@ const TextArea = React.forwardRef<TextAreaElement, TextAreaProps>((props, forwar
       className={classNames('rt-TextAreaRoot', className)}
       style={style}
     >
-      <textarea className="rt-TextAreaInput" ref={forwardedRef} {...textAreaProps} />
+      <textarea className="rt-reset rt-TextAreaInput" ref={forwardedRef} {...textAreaProps} />
       <div className="rt-TextAreaChrome" />
     </div>
   );

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -7,14 +7,7 @@
 
 .rt-TextFieldInput {
   display: block;
-  box-sizing: border-box;
-  padding: 0;
   width: 100%;
-  appearance: none;
-  -webkit-tap-highlight-color: transparent;
-  outline: none;
-  font-family: inherit;
-  background-color: transparent;
   position: relative;
   z-index: 1;
 
@@ -30,6 +23,7 @@
 
 .rt-TextFieldChrome {
   position: absolute;
+  box-sizing: border-box;
   inset: 0;
   z-index: 0;
   pointer-events: none;
@@ -264,7 +258,7 @@
       opacity: 0.5;
     }
     &:where(:placeholder-shown) {
-      cursor: default;
+      cursor: var(--cursor-disabled);
     }
     &::selection {
       background-color: var(--gray-a5);
@@ -272,7 +266,7 @@
 
     /* Cursor in slots, as an enhancement */
     .rt-TextFieldRoot:where(:has(&:placeholder-shown)) :where(.rt-TextFieldSlot) {
-      cursor: default;
+      cursor: var(--cursor-disabled);
     }
   }
 }

--- a/packages/radix-ui-themes/src/components/text-field.tsx
+++ b/packages/radix-ui-themes/src/components/text-field.tsx
@@ -113,7 +113,7 @@ const TextFieldInput = React.forwardRef<TextFieldInputElement, TextFieldInputPro
           spellCheck="false"
           {...inputProps}
           ref={forwardedRef}
-          className={classNames('rt-TextFieldInput', className)}
+          className={classNames('rt-reset', 'rt-TextFieldInput', className)}
         />
         <div data-accent-color={color} data-radius={radius} className="rt-TextFieldChrome" />
       </>

--- a/packages/radix-ui-themes/src/components/tooltip.css
+++ b/packages/radix-ui-themes/src/components/tooltip.css
@@ -1,4 +1,5 @@
 .rt-TooltipContent {
+  box-sizing: border-box;
   padding: var(--space-1) var(--space-2);
   background-color: var(--gray-12);
   border-radius: var(--radius-2);

--- a/packages/radix-ui-themes/src/helpers/extract-props.ts
+++ b/packages/radix-ui-themes/src/helpers/extract-props.ts
@@ -57,11 +57,6 @@ function extractProps<
         continue;
       }
 
-      if (propDef.type === 'string') {
-        className = classNames(className, propDef.className);
-        continue;
-      }
-
       if (propDef.type === 'enum') {
         const propClassName = getResponsiveClassNames({
           allowArbitraryValues: false,
@@ -75,11 +70,13 @@ function extractProps<
         continue;
       }
 
-      if (propDef.type === 'enum | string') {
+      if (propDef.type === 'string' || propDef.type === 'enum | string') {
+        const propDefValues = propDef.type === 'string' ? [] : propDef.values;
+
         const [propClassNames, propCustomProperties] = getResponsiveStyles({
           className: propDef.className,
           customProperties: propDef.customProperties,
-          propValues: propDef.values,
+          propValues: propDefValues,
           parseValue: propDef.parseValue,
           value,
         });

--- a/packages/radix-ui-themes/src/helpers/props/map-prop-values.ts
+++ b/packages/radix-ui-themes/src/helpers/props/map-prop-values.ts
@@ -29,8 +29,8 @@ function mapButtonSizeToSpinnerSize(
 ): (typeof spinnerPropDefs.size.values)[number] {
   switch (size) {
     case '1':
-    case '2':
       return '1';
+    case '2':
     case '3':
       return '2';
     case '4':

--- a/packages/radix-ui-themes/src/theme.tsx
+++ b/packages/radix-ui-themes/src/theme.tsx
@@ -40,7 +40,7 @@ const Theme = React.forwardRef<ThemeImplElement, ThemeProps>((props, forwardedRe
   const isRoot = context === undefined;
   if (isRoot) {
     return (
-      <TooltipPrimitive.Provider>
+      <TooltipPrimitive.Provider delayDuration={200}>
         <DirectionProvider dir="ltr">
           <ThemeRoot {...props} ref={forwardedRef} />
         </DirectionProvider>


### PR DESCRIPTION
- Add a comprehensive Reset component
- Ensure all elements that have padding or border styles use `box-sizing: border-box`
- Fix buggy disabled cursor styles
- Tweak the background color of all `variant="soft"` menu items
- Fix a regression when values for `type: 'string'` prop defs wouldn't work (props like `gridColumn`, `gridRow`, etc)
- Fix an issue when Scroll Area would be unable to stretch to 100% height when informed by the parent’s auto height (originally battle-tested via https://github.com/workos/workos/pull/23554, no regressions from that)
- Change the default Tooltip delay duration to 200ms
- Map size 2 loading button to size 2 spinner
- Rename DataList.Data to DataList.Value