### PR TITLE
Simplify dark theme logic

### DIFF
--- a/apps/playground/app/demo/page.tsx
+++ b/apps/playground/app/demo/page.tsx
@@ -29,7 +29,7 @@ import styles from './page.module.css';
 
 export default function Demo() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body className={styles.body}>
         <Theme asChild appearance="dark" accentColor="mint" radius="large" scaling="110%">
           <div id="root">

--- a/apps/playground/app/ghost-balance/page.tsx
+++ b/apps/playground/app/ghost-balance/page.tsx
@@ -22,7 +22,7 @@ import {
 
 export default function Ghost() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
         <Theme asChild accentColor="mint">
           <div id="root">

--- a/apps/playground/app/home-os/page.tsx
+++ b/apps/playground/app/home-os/page.tsx
@@ -31,7 +31,7 @@ export default function HomeOS() {
   const totalCount = adultCount + childCount + infantCount;
 
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
         <Theme asChild accentColor="orange" radius="large">
           <div id="root">

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -4111,43 +4111,45 @@ export default function Sink() {
                     </Flex>
                   </DocsSection>
 
-                  <DocsSection title="Tab Nav">
-                    <table className={styles.table}>
-                      <tbody>
-                        {tabsListPropDefs.size.values.map((size) => (
-                          <tr key={size}>
-                            <RowHeaderCell>size {size}</RowHeaderCell>
-                            <td>
-                              <TabNavDemo size={size} />
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                    <Text as="p" my="5">
-                      <Code>color</Code> can be set per instance:
-                    </Text>
-                    <details>
-                      <summary>
-                        <Text size="2" color="gray">
-                          See color combinations
-                        </Text>
-                      </summary>
-                      <Grid gap="5" columns="3" align="center">
-                        {tabsListPropDefs.color.values.map((color, i) => (
-                          <React.Fragment key={color}>
-                            <Text>{color}</Text>
-                            <Flex>
-                              <TabNavDemo size="1" color={color} />
-                            </Flex>
-                            <Flex>
-                              <TabNavDemo size="1" color={color} highContrast />
-                            </Flex>
-                          </React.Fragment>
-                        ))}
-                      </Grid>
-                    </details>
-                  </DocsSection>
+                  <React.Suspense fallback={null}>
+                    <DocsSection title="Tab Nav">
+                      <table className={styles.table}>
+                        <tbody>
+                          {tabsListPropDefs.size.values.map((size) => (
+                            <tr key={size}>
+                              <RowHeaderCell>size {size}</RowHeaderCell>
+                              <td>
+                                <TabNavDemo size={size} />
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <Text as="p" my="5">
+                        <Code>color</Code> can be set per instance:
+                      </Text>
+                      <details>
+                        <summary>
+                          <Text size="2" color="gray">
+                            See color combinations
+                          </Text>
+                        </summary>
+                        <Grid gap="5" columns="3" align="center">
+                          {tabsListPropDefs.color.values.map((color, i) => (
+                            <React.Fragment key={color}>
+                              <Text>{color}</Text>
+                              <Flex>
+                                <TabNavDemo size="1" color={color} />
+                              </Flex>
+                              <Flex>
+                                <TabNavDemo size="1" color={color} highContrast />
+                              </Flex>
+                            </React.Fragment>
+                          ))}
+                        </Grid>
+                      </details>
+                    </DocsSection>
+                  </React.Suspense>
 
                   <DocsSection title="Tabs">
                     <table className={styles.table}>

--- a/apps/playground/app/snapshot/page.tsx
+++ b/apps/playground/app/snapshot/page.tsx
@@ -32,7 +32,7 @@ import styles from './page.module.css';
 
 export default function Snapshot() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
         <Theme asChild appearance="dark" accentColor="grass" radius="small" scaling="110%">
           <div id="root">

--- a/apps/playground/app/test-appearance/page.tsx
+++ b/apps/playground/app/test-appearance/page.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {
   Theme,
-  Avatar,
   Flex,
   ThemePanel,
   Heading,
@@ -17,9 +16,13 @@ import {
 
 export default function Test() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
-        <Theme asChild appearance="dark">
+        {/* For testing: */}
+        {/* <Theme asChild appearance="inherit"> */}
+        {/* <Theme asChild appearance="light"> */}
+        {/* <Theme asChild appearance="dark"> */}
+        <Theme asChild>
           <div id="root">
             <ThemePanel />
 

--- a/apps/playground/app/test-classic-button/page.tsx
+++ b/apps/playground/app/test-classic-button/page.tsx
@@ -13,7 +13,7 @@ import { Pencil2Icon } from '@radix-ui/react-icons';
 
 export default function Test() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
         <Theme asChild>
           <div id="root">

--- a/apps/playground/app/test-textfield/page.tsx
+++ b/apps/playground/app/test-textfield/page.tsx
@@ -30,7 +30,7 @@ import {
 
 export default function Test() {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en">
       <body>
         <Theme asChild>
           <div id="root">

--- a/apps/playground/app/test-theme-toggle/page.tsx
+++ b/apps/playground/app/test-theme-toggle/page.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import * as React from 'react';
+import { Theme, Flex, ThemePanel, IconButton } from '@radix-ui/themes';
+import { useTheme } from 'next-themes';
+import { SunIcon, MoonIcon } from '@radix-ui/react-icons';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <ThemeTogglePanel />
+              <Flex height="100vh" width="100vw" align="center" justify="center">
+                <ThemeToggle />
+              </Flex>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+function ThemeTogglePanel() {
+  const { systemTheme, setTheme } = useTheme();
+  return (
+    <ThemePanel
+      onAppearanceChange={(newTheme) => {
+        const newThemeMatchesSystem = newTheme === systemTheme;
+        setTheme(newThemeMatchesSystem ? 'system' : (newTheme as 'light' | 'dark'));
+      }}
+    />
+  );
+}
+
+function ThemeToggle({ children, ...props }: React.ComponentPropsWithoutRef<typeof IconButton>) {
+  const { theme, systemTheme, setTheme } = useTheme();
+
+  return (
+    <>
+      <style>{`
+        :root, .light, .light-theme {
+          --theme-toggle-sun-icon-display: block;
+          --theme-toggle-moon-icon-display: none;
+        }
+        .dark, .dark-theme {
+          --theme-toggle-sun-icon-display: none;
+          --theme-toggle-moon-icon-display: block;
+        }
+      `}</style>
+
+      <IconButton
+        size="3"
+        variant="ghost"
+        color="gray"
+        onClick={() => {
+          // Set 'system' theme if the next theme matches the system theme
+          const resolvedTheme = theme === 'system' ? systemTheme : theme;
+          const newTheme = resolvedTheme === 'dark' ? 'light' : 'dark';
+          const newThemeMatchesSystem = newTheme === systemTheme;
+          setTheme(newThemeMatchesSystem ? 'system' : newTheme);
+        }}
+        {...props}
+      >
+        <SunIcon
+          width="16"
+          height="16"
+          style={{ display: 'var(--theme-toggle-sun-icon-display)' }}
+        />
+        <MoonIcon
+          width="16"
+          height="16"
+          style={{ display: 'var(--theme-toggle-moon-icon-display)' }}
+        />
+      </IconButton>
+    </>
+  );
+}

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/themes": "*",
-    "next": "^13.4.1",
+    "next": "^14.1.0",
     "next-themes": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -88,13 +88,12 @@
 - `Theme`
   - Set `min-height: 100vh` on the root `Theme` component
   - Fix an issue when in certain situations, `hasBackground` prop value would have no effect
-  - Refine the logic for when `Theme` has a background color by default.
-    - When there no explicit `hasBackground` prop value is passed, `Theme` will display background color:
-      - When it is the root `Theme` component
-      - When it has an explicit appearance value, e.g. `<Theme apperance="light">` or `<Theme apperance="dark">`
-    - Body background color and is no longer set automatically. The background color is now provided by the root `Theme` by default.
-      - [**Breaking**] The CSS variable `--color-page-background` is no longer available. In most cases, it can be safely replaced with `--color-background` available on the `.radix-themes` element.
-      - `suppressHydrationWarning` on `html` is no longer needed (unless required by other libraries, like `next-themes`)
+  - Refine the logic for when `Theme` has a background color by default. `Theme` without an explicit `hasBackground` prop will display a background color:
+    - When it is the root `Theme` component
+    - When it has an explicit appearance value, e.g. `<Theme apperance="light">` or `<Theme apperance="dark">`
+  - Body background color and is no longer set automatically. The background color is now provided by the root `Theme` by default.
+    - [**Breaking**] The CSS variable `--color-page-background` is no longer available. In most cases, it can be safely replaced with `--color-background` available on the `.radix-themes` element.
+    - `suppressHydrationWarning` on `html` is no longer needed (unless required by other libraries, like `next-themes`)
 - `Tooltip`
   - Change the default delay duration to 200ms
 

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -85,6 +85,16 @@
 - `TextField`
   - Fix an issue with some input `type`s not supporting `getSelectionRange`
   - Fix an issue when Grammarly extension would break the component styles
+- `Theme`
+  - Set `min-height: 100vh` on the root `Theme` component
+  - Fix an issue when in certain situations, `hasBackground` prop value would have no effect
+  - Refine the logic for when `Theme` has a background color by default.
+    - When there no explicit `hasBackground` prop value is passed, `Theme` will display background color:
+      - When it is the root `Theme` component
+      - When it has an explicit appearance value, e.g. `<Theme apperance="light">` or `<Theme apperance="dark">`
+    - Body background color and is no longer set automatically. The background color is now provided by the root `Theme` by default.
+      - [**Breaking**] The CSS variable `--color-page-background` is no longer available. In most cases, it can be safely replaced with `--color-background` available on the `.radix-themes` element.
+      - `suppressHydrationWarning` on `html` is no longer needed (unless required by other libraries, like `next-themes`)
 - `Tooltip`
   - Change the default delay duration to 200ms
 

--- a/packages/radix-ui-themes/src/components/index.css
+++ b/packages/radix-ui-themes/src/components/index.css
@@ -49,7 +49,13 @@
 @import './tooltip.css';
 
 .radix-themes:where([data-is-root-theme='true']) {
-  /* create new stacking context on the root `Theme` so layered components work out of the box */
+  /* Create a new stacking context on the root `Theme` so layered components work out of the box */
   position: relative;
   z-index: 0;
+
+  /* Make sure root `Theme` background covers the viewport */
+  min-height: 100vh;
+  @supports (min-height: 100dvh) {
+    min-height: 100dvh;
+  }
 }

--- a/packages/radix-ui-themes/src/index.ts
+++ b/packages/radix-ui-themes/src/index.ts
@@ -1,4 +1,4 @@
-export { Theme, useThemeContext, updateThemeAppearanceClass } from './theme.js';
+export { Theme, useThemeContext } from './theme.js';
 export * from './theme-options.js';
 export * from './components/index.js';
 export * from './helpers/index.js';

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -203,12 +203,21 @@
 /*                                     */
 /* * * * * * * * * * * * * * * * * * * */
 
-/* Make sure that forced light/dark appearance also sets corresponding browser colors, like input autofill color */
+/*
+ * Make sure that forced light/dark appearance also sets corresponding browser colors,
+ * like input autofill color and body scrollbar
+ */
 .radix-themes:where(.light, .light-theme) {
-  color-scheme: light;
+  &,
+  html:where(:has(&[data-is-root-theme='true'])) {
+    color-scheme: light;
+  }
 }
 .radix-themes:where(.dark, .dark-theme) {
-  color-scheme: dark;
+  &,
+  html:where(:has(&[data-is-root-theme='true'])) {
+    color-scheme: dark;
+  }
 }
 
 /* * * * * * * * * * * * * * * * * * * */

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -209,13 +209,13 @@
  */
 .radix-themes:where(.light, .light-theme) {
   &,
-  html:where(:has(&[data-is-root-theme='true'])) {
+  :root:where(:has(&[data-is-root-theme='true'])) {
     color-scheme: light;
   }
 }
 .radix-themes:where(.dark, .dark-theme) {
   &,
-  html:where(:has(&[data-is-root-theme='true'])) {
+  :root:where(:has(&[data-is-root-theme='true'])) {
     color-scheme: dark;
   }
 }

--- a/packages/radix-ui-themes/src/theme-panel.css
+++ b/packages/radix-ui-themes/src/theme-panel.css
@@ -36,7 +36,7 @@
 .rt-ThemePanelSwatchInput {
   outline-offset: 2px;
 
-  &:where([data-checked]) {
+  &:where(:checked) {
     outline-style: solid;
     outline-color: var(--gray-12);
   }
@@ -54,7 +54,7 @@
 .rt-ThemePanelRadioCardInput {
   outline-offset: -1px;
 
-  &:where([data-checked]) {
+  &:where(:checked) {
     outline-style: solid;
     outline-color: var(--gray-12);
   }

--- a/packages/radix-ui-themes/src/theme-panel.css
+++ b/packages/radix-ui-themes/src/theme-panel.css
@@ -21,6 +21,10 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
+
+  /* iOS Safari */
+  width: 100%;
+  height: 100%;
 }
 
 .rt-ThemePanelSwatch {
@@ -32,7 +36,7 @@
 .rt-ThemePanelSwatchInput {
   outline-offset: 2px;
 
-  &:where(:checked) {
+  &:where([data-checked]) {
     outline-style: solid;
     outline-color: var(--gray-12);
   }
@@ -50,7 +54,7 @@
 .rt-ThemePanelRadioCardInput {
   outline-offset: -1px;
 
-  &:where(:checked) {
+  &:where([data-checked]) {
     outline-style: solid;
     outline-color: var(--gray-12);
   }

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -251,7 +251,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                         name="accentColor"
                         value={color}
                         checked={accentColor === color}
-                        data-checked={accentColor === color || undefined}
                         onChange={(event) =>
                           onAccentColorChange(event.target.value as ThemeOptions['accentColor'])
                         }
@@ -295,7 +294,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                           name="grayColor"
                           value={gray}
                           checked={grayColor === gray}
-                          data-checked={grayColor === gray || undefined}
                           onChange={(event) =>
                             onGrayColorChange(event.target.value as ThemeOptions['grayColor'])
                           }
@@ -319,7 +317,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="appearance"
                       value={value}
                       checked={resolvedAppearance === value}
-                      data-checked={resolvedAppearance === value || undefined}
                       // TODO: Currently using `onClick` as a stop-gap solution for `onChange` not working after a few changes
                       onChange={(event) => {
                         // handleAppearanceChange(event.target.value as ThemeOptions['appearance']);
@@ -383,7 +380,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                         id={`theme-panel-radius-${value}`}
                         value={value}
                         checked={radius === value}
-                        data-checked={radius === value || undefined}
                         onChange={(event) =>
                           onRadiusChange(event.target.value as ThemeOptions['radius'])
                         }
@@ -425,7 +421,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="scaling"
                       value={value}
                       checked={scaling === value}
-                      data-checked={scaling === value || undefined}
                       onChange={(event) =>
                         onScalingChange(event.target.value as ThemeOptions['scaling'])
                       }
@@ -482,7 +477,6 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="panelBackground"
                       value={value}
                       checked={panelBackground === value}
-                      data-checked={panelBackground === value || undefined}
                       onChange={(event) =>
                         onPanelBackgroundChange(
                           event.target.value as ThemeOptions['panelBackground']

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -317,11 +317,9 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="appearance"
                       value={value}
                       checked={resolvedAppearance === value}
-                      // TODO: Currently using `onClick` as a stop-gap solution for `onChange` not working after a few changes
                       onChange={(event) => {
-                        // handleAppearanceChange(event.target.value as ThemeOptions['appearance']);
+                        handleAppearanceChange(event.target.value as 'light' | 'dark');
                       }}
-                      onClick={() => handleAppearanceChange(value)}
                     />
                     <Flex align="center" justify="center" height="6" gap="2">
                       {value === 'light' ? (

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -317,9 +317,9 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="appearance"
                       value={value}
                       checked={resolvedAppearance === value}
-                      onChange={(event) => {
-                        handleAppearanceChange(event.target.value as 'light' | 'dark');
-                      }}
+                      onChange={(event) =>
+                        handleAppearanceChange(event.target.value as 'light' | 'dark')
+                      }
                     />
                     <Flex align="center" justify="center" height="6" gap="2">
                       {value === 'light' ? (

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -172,7 +172,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
 
       update();
 
-      // Observe <html> and <body> for `class` changes only when the apperaance is inherited from them
+      // Observe <html> and <body> for `class` changes only when the appearance is inherited from them
       if (appearance === 'inherit') {
         classNameObserver.observe(root, { attributes: true });
         classNameObserver.observe(body, { attributes: true });

--- a/packages/radix-ui-themes/src/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/theme-panel.tsx
@@ -19,7 +19,7 @@ import {
   Text,
   Tooltip,
 } from './components/index.js';
-import { Theme, updateThemeAppearanceClass, useThemeContext } from './theme.js';
+import { Theme, useThemeContext } from './theme.js';
 import { getMatchingGrayColor, themeAccentColorsOrdered } from './theme-options.js';
 import { radixGrayScalesDesaturated, themePropDefs } from './helpers/index.js';
 
@@ -67,19 +67,24 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
     const hasOnAppearanceChangeProp = onAppearanceChangeProp !== undefined;
     const handleAppearanceChangeProp = useCallbackRef(onAppearanceChangeProp);
     const handleAppearanceChange = React.useCallback(
-      (appearance: ThemeOptions['appearance']) => {
-        onAppearanceChange(appearance);
+      (value: 'light' | 'dark') => {
         const cleanup = disableAnimation();
 
+        if (appearance !== 'inherit') {
+          onAppearanceChange(value);
+          return;
+        }
+
         if (hasOnAppearanceChangeProp) {
-          handleAppearanceChangeProp(appearance as Exclude<ThemeOptions['appearance'], 'inherit'>);
+          handleAppearanceChangeProp(value);
         } else {
-          updateThemeAppearanceClass(appearance);
+          setResolvedAppearance(value);
+          updateRootAppearanceClass(value);
         }
 
         cleanup();
       },
-      [onAppearanceChange, hasOnAppearanceChangeProp, handleAppearanceChangeProp]
+      [appearance, onAppearanceChange, hasOnAppearanceChangeProp, handleAppearanceChangeProp]
     );
 
     const autoMatchedGray = getMatchingGrayColor(accentColor);
@@ -110,6 +115,10 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
       setTimeout(() => setCopyState('idle'), 2000);
     }
 
+    const [resolvedAppearance, setResolvedAppearance] = React.useState<'light' | 'dark' | null>(
+      appearance === 'inherit' ? null : appearance
+    );
+
     // quickly show/hide using ⌘C
     React.useEffect(() => {
       function handleKeydown(event: KeyboardEvent) {
@@ -128,16 +137,13 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
       function handleKeydown(event: KeyboardEvent) {
         if (event.metaKey && event.key === 'd') {
           event.preventDefault();
-          handleAppearanceChange(appearance === 'dark' ? 'light' : 'dark');
+          handleAppearanceChange(resolvedAppearance === 'light' ? 'dark' : 'light');
         }
       }
       document.addEventListener('keydown', handleKeydown);
       return () => document.removeEventListener('keydown', handleKeydown);
-    }, [appearance, handleAppearanceChange]);
+    }, [handleAppearanceChange, resolvedAppearance]);
 
-    const [resolvedAppearance, setResolvedAppearance] = React.useState<'light' | 'dark' | null>(
-      appearance === 'inherit' ? null : appearance
-    );
     React.useEffect(() => {
       const root = document.documentElement;
       const body = document.body;
@@ -149,26 +155,31 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
           body.classList.contains('dark') ||
           body.classList.contains('dark-theme');
 
-        const nextAppearance = hasDarkClass ? 'dark' : 'light';
-
-        if (nextAppearance !== appearance && appearance !== 'inherit') {
-          handleAppearanceChange(nextAppearance);
+        if (appearance === 'inherit') {
+          setResolvedAppearance(hasDarkClass ? 'dark' : 'light');
+        } else {
+          setResolvedAppearance(appearance);
         }
-
-        setResolvedAppearance(hasDarkClass ? 'dark' : 'light');
       }
+
+      const classNameObserver = new MutationObserver(function (mutations) {
+        mutations.forEach(function (mutation) {
+          if (mutation.attributeName === 'class') {
+            update();
+          }
+        });
+      });
 
       update();
 
-      var observer = new MutationObserver(function (mutations) {
-        mutations.forEach(function (mutation) {
-          if (mutation.attributeName === 'class') update();
-        });
-      });
-      observer.observe(root, { attributes: true });
-      observer.observe(body, { attributes: true });
-      return () => observer.disconnect();
-    }, [appearance, handleAppearanceChange]);
+      // Observe <html> and <body> for `class` changes only when the apperaance is inherited from them
+      if (appearance === 'inherit') {
+        classNameObserver.observe(root, { attributes: true });
+        classNameObserver.observe(body, { attributes: true });
+      }
+
+      return () => classNameObserver.disconnect();
+    }, [appearance]);
 
     return (
       <Theme asChild radius="medium" scaling="100%">
@@ -240,6 +251,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                         name="accentColor"
                         value={color}
                         checked={accentColor === color}
+                        data-checked={accentColor === color || undefined}
                         onChange={(event) =>
                           onAccentColorChange(event.target.value as ThemeOptions['accentColor'])
                         }
@@ -283,6 +295,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                           name="grayColor"
                           value={gray}
                           checked={grayColor === gray}
+                          data-checked={grayColor === gray || undefined}
                           onChange={(event) =>
                             onGrayColorChange(event.target.value as ThemeOptions['grayColor'])
                           }
@@ -306,6 +319,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="appearance"
                       value={value}
                       checked={resolvedAppearance === value}
+                      data-checked={resolvedAppearance === value || undefined}
                       // TODO: Currently using `onClick` as a stop-gap solution for `onChange` not working after a few changes
                       onChange={(event) => {
                         // handleAppearanceChange(event.target.value as ThemeOptions['appearance']);
@@ -369,6 +383,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                         id={`theme-panel-radius-${value}`}
                         value={value}
                         checked={radius === value}
+                        data-checked={radius === value || undefined}
                         onChange={(event) =>
                           onRadiusChange(event.target.value as ThemeOptions['radius'])
                         }
@@ -410,6 +425,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="scaling"
                       value={value}
                       checked={scaling === value}
+                      data-checked={scaling === value || undefined}
                       onChange={(event) =>
                         onScalingChange(event.target.value as ThemeOptions['scaling'])
                       }
@@ -466,6 +482,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       name="panelBackground"
                       value={value}
                       checked={panelBackground === value}
+                      data-checked={panelBackground === value || undefined}
                       onChange={(event) =>
                         onPanelBackgroundChange(
                           event.target.value as ThemeOptions['panelBackground']
@@ -619,6 +636,31 @@ function disableAnimation() {
 
 function upperFirst(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function updateRootAppearanceClass(appearance: 'light' | 'dark') {
+  const root = document.documentElement;
+  const hasLightTheme = root.classList.contains('light-theme');
+  const hasDarkTheme = root.classList.contains('dark-theme');
+  const hasLight = root.classList.contains('light');
+  const hasDark = root.classList.contains('dark');
+
+  if (hasLightTheme || hasDarkTheme) {
+    root.classList.remove('light-theme', 'dark-theme');
+    root.style.colorScheme = appearance;
+    root.classList.add(`${appearance}-theme`);
+  }
+
+  if (hasLight || hasDark) {
+    root.classList.remove('light', 'dark');
+    root.style.colorScheme = appearance;
+    root.classList.add(appearance);
+  }
+
+  if (!hasLightTheme && !hasDarkTheme && !hasLight && !hasDark) {
+    root.style.colorScheme = appearance;
+    root.classList.add(appearance);
+  }
 }
 
 export { ThemePanel };

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,10 +271,10 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@next/env@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.5.6.tgz#c1148e2e1aa166614f05161ee8f77ded467062bc"
-  integrity sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==
+"@next/env@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-14.1.0.tgz#43d92ebb53bc0ae43dcc64fb4d418f8f17d7a341"
+  integrity sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==
 
 "@next/eslint-plugin-next@13.5.6":
   version "13.5.6"
@@ -283,50 +283,50 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz#b15d139d8971360fca29be3bdd703c108c9a45fb"
-  integrity sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==
+"@next/swc-darwin-arm64@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz#70a57c87ab1ae5aa963a3ba0f4e59e18f4ecea39"
+  integrity sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==
 
-"@next/swc-darwin-x64@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz#9c72ee31cc356cb65ce6860b658d807ff39f1578"
-  integrity sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==
+"@next/swc-darwin-x64@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz#0863a22feae1540e83c249384b539069fef054e9"
+  integrity sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==
 
-"@next/swc-linux-arm64-gnu@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz#59f5f66155e85380ffa26ee3d95b687a770cfeab"
-  integrity sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==
+"@next/swc-linux-arm64-gnu@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz#893da533d3fce4aec7116fe772d4f9b95232423c"
+  integrity sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==
 
-"@next/swc-linux-arm64-musl@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz#f012518228017052736a87d69bae73e587c76ce2"
-  integrity sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==
+"@next/swc-linux-arm64-musl@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz#d81ddcf95916310b8b0e4ad32b637406564244c0"
+  integrity sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==
 
-"@next/swc-linux-x64-gnu@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz#339b867a7e9e7ee727a700b496b269033d820df4"
-  integrity sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==
+"@next/swc-linux-x64-gnu@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz#18967f100ec19938354332dcb0268393cbacf581"
+  integrity sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==
 
-"@next/swc-linux-x64-musl@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz#ae0ae84d058df758675830bcf70ca1846f1028f2"
-  integrity sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==
+"@next/swc-linux-x64-musl@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz#77077cd4ba8dda8f349dc7ceb6230e68ee3293cf"
+  integrity sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==
 
-"@next/swc-win32-arm64-msvc@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz#a5cc0c16920485a929a17495064671374fdbc661"
-  integrity sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==
+"@next/swc-win32-arm64-msvc@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz#5f0b8cf955644104621e6d7cc923cad3a4c5365a"
+  integrity sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==
 
-"@next/swc-win32-ia32-msvc@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz#6a2409b84a2cbf34bf92fe714896455efb4191e4"
-  integrity sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==
+"@next/swc-win32-ia32-msvc@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz#21f4de1293ac5e5a168a412b139db5d3420a89d0"
+  integrity sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==
 
-"@next/swc-win32-x64-msvc@13.5.6":
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz#4a3e2a206251abc729339ba85f60bc0433c2865d"
-  integrity sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==
+"@next/swc-win32-x64-msvc@14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz#e561fb330466d41807123d932b365cf3d33ceba2"
+  integrity sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1346,7 +1346,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001580:
+caniuse-lite@^1.0.30001578, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001580:
   version "1.0.30001584"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001584.tgz#5e3ea0625d048d5467670051687655b1f7bf7dfd"
   integrity sha512-LOz7CCQ9M1G7OjJOF9/mzmqmj3jE/7VOmrfw6Mgs0E8cjOsbRXQJHsPBfmBOXDskXKrHLyyW3n7kpDW/4BsfpQ==
@@ -2238,11 +2238,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-to-regexp@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-
 glob@7.1.7:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
@@ -2344,7 +2339,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -2932,28 +2927,28 @@ next-themes@^0.2.1:
   resolved "https://registry.yarnpkg.com/next-themes/-/next-themes-0.2.1.tgz#0c9f128e847979daf6c67f70b38e6b6567856e45"
   integrity sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==
 
-next@^13.4.1:
-  version "13.5.6"
-  resolved "https://registry.yarnpkg.com/next/-/next-13.5.6.tgz#e964b5853272236c37ce0dd2c68302973cf010b1"
-  integrity sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==
+next@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/next/-/next-14.1.0.tgz#b31c0261ff9caa6b4a17c5af019ed77387174b69"
+  integrity sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==
   dependencies:
-    "@next/env" "13.5.6"
+    "@next/env" "14.1.0"
     "@swc/helpers" "0.5.2"
     busboy "1.6.0"
-    caniuse-lite "^1.0.30001406"
+    caniuse-lite "^1.0.30001579"
+    graceful-fs "^4.2.11"
     postcss "8.4.31"
     styled-jsx "5.1.1"
-    watchpack "2.4.0"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "13.5.6"
-    "@next/swc-darwin-x64" "13.5.6"
-    "@next/swc-linux-arm64-gnu" "13.5.6"
-    "@next/swc-linux-arm64-musl" "13.5.6"
-    "@next/swc-linux-x64-gnu" "13.5.6"
-    "@next/swc-linux-x64-musl" "13.5.6"
-    "@next/swc-win32-arm64-msvc" "13.5.6"
-    "@next/swc-win32-ia32-msvc" "13.5.6"
-    "@next/swc-win32-x64-msvc" "13.5.6"
+    "@next/swc-darwin-arm64" "14.1.0"
+    "@next/swc-darwin-x64" "14.1.0"
+    "@next/swc-linux-arm64-gnu" "14.1.0"
+    "@next/swc-linux-arm64-musl" "14.1.0"
+    "@next/swc-linux-x64-gnu" "14.1.0"
+    "@next/swc-linux-x64-musl" "14.1.0"
+    "@next/swc-win32-arm64-msvc" "14.1.0"
+    "@next/swc-win32-ia32-msvc" "14.1.0"
+    "@next/swc-win32-x64-msvc" "14.1.0"
 
 node-releases@^2.0.14:
   version "2.0.14"
@@ -4041,14 +4036,6 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-watchpack@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
-  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
-  dependencies:
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.2"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Set `min-height: 100vh` on the root `Theme` component
- Fix an issue when in certain situations `hasBackground` prop value would have no effect
- Refine the logic for when `Theme` has a background color by default.
  - When there is no explicit `hasBackground` prop value is passed, `Theme` will display background color:
    - When it is the root `Theme` component
    - When it has an explicit appearance value, e.g. `<Theme apperance="light">` or `<Theme apperance="dark">`
  - Body background color and is no longer set automatically. The background color is now provided by the root `Theme` by default.
    - [**Breaking**] The CSS variable `--color-page-background` is no longer available. In most cases, it can be safely replaced with `--color-background` available on the `.radix-themes` element.
    - `suppressHydrationWarning` on `html` is no longer needed (unless required by other libraries, like `next-themes`)

Closes https://github.com/radix-ui/themes/issues/6, https://github.com/radix-ui/themes/issues/19, https://github.com/radix-ui/themes/issues/22, https://github.com/radix-ui/themes/issues/26, https://github.com/radix-ui/themes/issues/111, https://github.com/radix-ui/themes/issues/168, https://github.com/radix-ui/themes/issues/280