### PR TITLE
Fix dialog scroll regression

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -284,31 +284,29 @@ export default function Sink() {
                               <Button variant="solid">Open</Button>
                             </DialogTrigger>
                             <DialogContent asChild style={{ maxWidth: 450 }}>
-                              <ScrollArea>
-                                <Flex direction="column" gap="3">
-                                  <InfoCircledIcon
-                                    style={{ position: 'absolute', top: '24px', right: '20px' }}
-                                  />
-                                  <DialogTitle>Share resource</DialogTitle>
-                                  <DialogDescription>
-                                    Jan Tschichold was a German calligrapher, typographer and book
-                                    designer. He played a significant role in the development of
-                                    graphic design in the 20th century.
-                                  </DialogDescription>
-                                  <Flex gap="3" mt="4" justify="end">
-                                    <DialogClose>
-                                      <Button variant="soft" color="gray">
-                                        Cancel
-                                      </Button>
-                                    </DialogClose>
-                                    <DialogClose>
-                                      <Button variant="solid">
-                                        Share <Share2Icon />
-                                      </Button>
-                                    </DialogClose>
-                                  </Flex>
+                              <Flex direction="column" gap="3">
+                                <InfoCircledIcon
+                                  style={{ position: 'absolute', top: '24px', right: '20px' }}
+                                />
+                                <DialogTitle>Share resource</DialogTitle>
+                                <DialogDescription>
+                                  Jan Tschichold was a German calligrapher, typographer and book
+                                  designer. He played a significant role in the development of
+                                  graphic design in the 20th century.
+                                </DialogDescription>
+                                <Flex gap="3" mt="4" justify="end">
+                                  <DialogClose>
+                                    <Button variant="soft" color="gray">
+                                      Cancel
+                                    </Button>
+                                  </DialogClose>
+                                  <DialogClose>
+                                    <Button variant="solid">
+                                      Share <Share2Icon />
+                                    </Button>
+                                  </DialogClose>
                                 </Flex>
-                              </ScrollArea>
+                              </Flex>
                             </DialogContent>
                           </DialogRoot>
                         </DocsGridSectionItem>

--- a/packages/radix-ui-themes/src/components/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/base-dialog.css
@@ -18,12 +18,8 @@
 }
 
 .rt-BaseDialogScrollPadding {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  width: 100%;
-  box-sizing: border-box;
+  flex-grow: 1;
+  margin: auto;
   padding-top: var(--space-6);
   padding-bottom: max(var(--space-6), 6vh);
   padding-left: var(--space-4);
@@ -31,6 +27,7 @@
 }
 
 .rt-BaseDialogContent {
+  margin: auto;
   width: 100%;
   max-width: 580px;
   z-index: 1;


### PR DESCRIPTION
Fix a regression from https://github.com/radix-ui/themes/pull/274#discussion_r1474678336 when long dialogs would be cut off at the top without the ability to scroll (while maintaining the improvement from that PR)

See /test-dialog page for a comparison