### PR TITLE
Make sure `asChild` prop is not passed to DOM elements

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.12",
-    "@types/react": "^18.0.22",
-    "@types/react-dom": "^18.0.7",
+    "@types/react": "^18.2.53",
+    "@types/react-dom": "^18.2.18",
     "eslint-config-custom": "*",
     "typescript": "^5.3.3"
   }

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -124,8 +124,8 @@
     }
   },
   "devDependencies": {
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.4",
+    "@types/react": "^18.2.53",
+    "@types/react-dom": "^18.2.18",
     "autoprefixer": "^10.4.16",
     "esbuild": "^0.20.0",
     "eslint": "^8.15.0",
@@ -137,8 +137,8 @@
     "postcss-discard-empty": "^6.0.1",
     "postcss-import": "^16.0.0",
     "postcss-nesting": "^12.0.2",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "stylelint": "^16.1.0",
     "typescript": "^5.3.3"
   },

--- a/packages/radix-ui-themes/src/helpers/get-root.tsx
+++ b/packages/radix-ui-themes/src/helpers/get-root.tsx
@@ -8,7 +8,7 @@ interface GetChildrenArgs<T extends React.ElementType> {
 }
 
 export const getRoot = <
-  T extends React.ElementType,
+  T extends React.ComponentType<any> | keyof JSX.IntrinsicElements,
   U extends React.ComponentProps<T> extends { asChild?: boolean } ? T : Exclude<T, typeof Slot>
 >({
   asChild,
@@ -28,10 +28,12 @@ export const getRoot = <
         });
 
         // Make sure we don't pass `asChild` to DOM elements
-        const asChildProp = (Parent as unknown) === Slot ? undefined : asChild;
+        if ((Parent as unknown) === Slot) {
+          return <Parent {...props}>{child}</Parent>;
+        }
 
         return (
-          <Parent asChild={asChildProp} {...props}>
+          <Parent asChild={asChild} {...props}>
             {child}
           </Parent>
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,14 +978,14 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
-"@types/react-dom@^18.0.4", "@types/react-dom@^18.0.7":
+"@types/react-dom@^18.2.18":
   version "18.2.18"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
   integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.22", "@types/react@^18.0.9":
+"@types/react@*", "@types/react@^18.2.53":
   version "18.2.53"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.53.tgz#09c21b4621aaad5fed6a5045b33a7430749d8dc5"
   integrity sha512-52IHsMDT8qATp9B9zoOyobW8W3/0QhaJQTw1HwRj0UY2yBpCAQ7+S/CqHYQ8niAm3p4ji+rWUQ9UCib0GxQ60w==
@@ -3287,7 +3287,7 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dom@^18.1.0, react-dom@^18.2.0:
+react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -3353,7 +3353,7 @@ react-use@^17.4.0:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react@^18.1.0, react@^18.2.0:
+react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
When testing the new version in the WorkOS monorepo I noticed a warning about `asChild={undefined}` being passed to the Card’s DOM element