### PR TITLE
Fix cosmetic bugs from RC tests

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -10,6 +10,7 @@ import {
   StarIcon,
   Cross1Icon,
   CodeIcon,
+  TrashIcon,
 } from '@radix-ui/react-icons';
 import {
   Theme,
@@ -5406,6 +5407,12 @@ function DropdownMenuContentDemo(props: React.ComponentProps<typeof DropdownMenu
           <DropdownMenuItem>Name Window…</DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem>Developer Tools</DropdownMenuItem>
+          <DropdownMenuItem color="red">
+            <Box asChild mx="-3px">
+              <TrashIcon />
+            </Box>
+            Delete
+          </DropdownMenuItem>
         </DropdownMenuSubContent>
       </DropdownMenuSub>
 

--- a/apps/playground/app/test-textfield/page.tsx
+++ b/apps/playground/app/test-textfield/page.tsx
@@ -410,6 +410,66 @@ export default function Test() {
                       </TextFieldSlot>
                     </TextFieldRoot>
                   </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type date
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Date" type="date" />
+                    <TextFieldInput size="2" placeholder="Date" type="date" />
+                    <TextFieldInput size="3" placeholder="Date" type="date" />
+                  </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type datetime-local
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Local datetime" type="datetime-local" />
+                    <TextFieldInput size="2" placeholder="Local datetime" type="datetime-local" />
+                    <TextFieldInput size="3" placeholder="Local datetime" type="datetime-local" />
+                  </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type month
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Month" type="month" />
+                    <TextFieldInput size="2" placeholder="Month" type="month" />
+                    <TextFieldInput size="3" placeholder="Month" type="month" />
+                  </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type number
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Number" type="number" />
+                    <TextFieldInput size="2" placeholder="Number" type="number" />
+                    <TextFieldInput size="3" placeholder="Number" type="number" />
+                  </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type search
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Search" type="search" />
+                    <TextFieldInput size="2" placeholder="Search" type="search" />
+                    <TextFieldInput size="3" placeholder="Search" type="search" />
+                  </Flex>
+
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading size="3" mb="2">
+                      Type time
+                    </Heading>
+
+                    <TextFieldInput size="1" placeholder="Time" type="time" />
+                    <TextFieldInput size="2" placeholder="Time" type="time" />
+                    <TextFieldInput size="3" placeholder="Time" type="time" />
+                  </Flex>
                 </Grid>
               </Section>
             </Container>

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -91,9 +91,11 @@
   - Add `radius` prop
   - Add `resize` prop
   - Fix an issue when Grammarly extension would break the component styles
+  - Rework the internal HTML structure and styles. Make sure that your code works as expected if you were relying on any of the implementation quirks to override styles or behaviour.
 - `TextField`
   - Fix an issue with some input `type`s not supporting `getSelectionRange`
   - Fix an issue when Grammarly extension would break the component styles
+  - Rework the internal HTML structure and styles. Make sure that your code works as expected if you were relying on any of the implementation quirks to override styles or behaviour.
 - `Theme`
   - Set `min-height: 100vh` on the root `Theme` component
   - Fix an issue when in certain situations, `hasBackground` prop value would have no effect

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -68,6 +68,8 @@
   - Add `gapX` and `gapY` props
 - `Popover`, `HoverCard`, `Tooltip`
   - Add `position: relative` to support absolutely positioned children.
+- `Select`
+  - Make sure that Trigger font weight is not inherited, e.g. from a wrapping `<label>` element
 - `Separator`
   - Allow responsive values for the `orientation` prop
 - `ScrollArea`
@@ -91,10 +93,12 @@
   - Add `radius` prop
   - Add `resize` prop
   - Fix an issue when Grammarly extension would break the component styles
+  - Make sure that the font weight is not inherited, e.g. from a wrapping `<label>` element
   - Rework the internal HTML structure and styles. Make sure that your code works as expected if you were relying on any of the implementation quirks to override styles or behaviour.
 - `TextField`
   - Fix an issue with some input `type`s not supporting `getSelectionRange`
   - Fix an issue when Grammarly extension would break the component styles
+  - Make sure that the font weight is not inherited, e.g. from a wrapping `<label>` element
   - Rework the internal HTML structure and styles. Make sure that your code works as expected if you were relying on any of the implementation quirks to override styles or behaviour.
 - `Theme`
   - Set `min-height: 100vh` on the root `Theme` component

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -7,6 +7,9 @@
   line-height: 1;
   user-select: none;
   cursor: default;
+
+  /* Make sure that the height is not stretched in a Flex/Grid layout */
+  height: fit-content;
 }
 
 /***************************************************************************************************

--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -27,6 +27,8 @@
   }
   &:where(.rt-variant-ghost) {
     box-sizing: content-box;
+
+    /* Make sure that the height is not stretched in a Flex/Grid layout */
     height: fit-content;
   }
 }

--- a/packages/radix-ui-themes/src/components/base-menu.css
+++ b/packages/radix-ui-themes/src/components/base-menu.css
@@ -27,7 +27,7 @@
 .rt-BaseMenuItem {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--space-2);
   height: var(--base-menu-item-height);
   padding-left: var(--base-menu-item-padding-left);
   padding-right: var(--base-menu-item-padding-right);
@@ -49,7 +49,8 @@
 .rt-BaseMenuShortcut {
   display: flex;
   align-items: center;
-  margin-left: var(--space-5);
+  margin-left: auto;
+  padding-left: var(--space-4);
 }
 
 .rt-BaseMenuSubTriggerIcon {

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -3,7 +3,6 @@
 
 .rt-Code {
   --code-variant-font-size-adjust: calc(var(--code-font-size-adjust) * 0.95);
-  box-sizing: border-box;
   font-family: var(--code-font-family);
   font-size: calc(var(--code-variant-font-size-adjust) * 1em);
   font-style: var(--code-font-style);
@@ -13,6 +12,15 @@
     var(--code-letter-spacing) + var(--letter-spacing, var(--default-letter-spacing))
   );
   border-radius: calc((0.5px + 0.2em) * var(--radius-factor));
+
+  box-sizing: border-box;
+  padding-top: var(--code-padding-top);
+  padding-left: var(--code-padding-left);
+  padding-bottom: var(--code-padding-bottom);
+  padding-right: var(--code-padding-right);
+
+  /* Make sure that the height is not stretched in a Flex/Grid layout */
+  height: fit-content;
 
   & :where(&) {
     font-size: inherit;
@@ -85,6 +93,7 @@
 
 .rt-Code:where(.rt-variant-ghost) {
   --code-variant-font-size-adjust: var(--code-font-size-adjust);
+  padding: 0;
 
   &:where([data-accent-color]) {
     color: var(--accent-a11);
@@ -99,7 +108,6 @@
 /* solid */
 
 .rt-Code:where(.rt-variant-solid) {
-  padding: var(--code-padding-top) 0.25em var(--code-padding-bottom);
   background-color: var(--accent-a9);
   color: var(--accent-9-contrast);
 
@@ -133,7 +141,6 @@
 /* soft */
 
 .rt-Code:where(.rt-variant-soft) {
-  padding: var(--code-padding-top) 0.25em var(--code-padding-bottom);
   background-color: var(--accent-a3);
   color: var(--accent-a11);
 
@@ -155,7 +162,6 @@
 /* outline */
 
 .rt-Code:where(.rt-variant-outline) {
-  padding: var(--code-padding-top) 0.25em var(--code-padding-bottom);
   box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a8);
   color: var(--accent-a11);
 

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -79,8 +79,8 @@ const ContextMenuContent = React.forwardRef<ContextMenuContentElement, ContextMe
               <div className={classNames('rt-BaseMenuViewport', 'rt-ContextMenuViewport')}>
                 <ContextMenuContentContext.Provider
                   value={React.useMemo(
-                    () => ({ size, variant, color, highContrast }),
-                    [size, variant, color, highContrast]
+                    () => ({ size, variant, color: resolvedColor, highContrast }),
+                    [size, variant, resolvedColor, highContrast]
                   )}
                 >
                   {children}

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -80,8 +80,8 @@ const DropdownMenuContent = React.forwardRef<DropdownMenuContentElement, Dropdow
               <div className={classNames('rt-BaseMenuViewport', 'rt-DropdownMenuViewport')}>
                 <DropdownMenuContentContext.Provider
                   value={React.useMemo(
-                    () => ({ size, variant, color, highContrast }),
-                    [size, variant, color, highContrast]
+                    () => ({ size, variant, color: resolvedColor, highContrast }),
+                    [size, variant, resolvedColor, highContrast]
                   )}
                 >
                   {children}

--- a/packages/radix-ui-themes/src/components/kbd.css
+++ b/packages/radix-ui-themes/src/components/kbd.css
@@ -48,6 +48,9 @@
   border-radius: calc(var(--radius-factor) * 0.35em);
   letter-spacing: var(--letter-spacing, var(--default-letter-spacing));
 
+  /* Make sure that the height is not stretched in a Flex/Grid layout */
+  height: fit-content;
+
   color: var(--gray-12);
   background-color: var(--gray-1);
   box-shadow: var(--kbd-box-shadow);

--- a/packages/radix-ui-themes/src/components/progress.css
+++ b/packages/radix-ui-themes/src/components/progress.css
@@ -131,7 +131,7 @@
   background-color: var(--gray-a3);
 
   &::after {
-    box-shadow: inset 0 0 0 1px var(--gray-a5);
+    box-shadow: inset 0 0 0 1px var(--gray-a4);
   }
 
   & :where(.rt-ProgressIndicator) {

--- a/packages/radix-ui-themes/src/components/reset.css
+++ b/packages/radix-ui-themes/src/components/reset.css
@@ -33,7 +33,11 @@
   /*                                     */
   /* * * * * * * * * * * * * * * * * * * */
 
-  &:where(a, button, input, textarea, select) {
+  &:where(a) {
+    all: unset;
+    -webkit-tap-highlight-color: transparent;
+  }
+  &:where(button, input, textarea, select) {
     all: unset;
     display: inline-block;
     -webkit-tap-highlight-color: transparent;

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -7,6 +7,9 @@
   vertical-align: top;
   line-height: var(--height);
 
+  /* Make sure that font weight is not inherited, e.g. from a wrapping <label> */
+  font-weight: var(--font-weight-regular);
+
   &:where(:focus-visible) {
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -3,6 +3,9 @@
   flex-direction: column;
   box-sizing: border-box;
 
+  /* Make sure that font weight is not inherited, e.g. from a wrapping <label> */
+  font-weight: var(--font-weight-regular);
+
   /* Allows the `resize` property to work on the div */
   overflow: hidden;
 

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -2,10 +2,8 @@
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  position: relative;
-  z-index: 0;
 
-  /* Allows `resize` property to work on the div */
+  /* Allows the `resize` property to work on the div */
   overflow: hidden;
 
   &:where(:focus-within) {
@@ -18,21 +16,9 @@
   border-radius: inherit;
   resize: none;
 
-  position: relative;
   display: block;
   width: 100%;
   flex-grow: 1;
-  z-index: 1;
-
-  /* Clip text to inner shadow */
-  border: var(--text-area-border-width) solid transparent;
-  padding: var(--text-area-padding-y) var(--text-area-padding-x);
-
-  &:where(:focus) {
-    outline: 1px solid;
-    outline-color: inherit;
-    outline-offset: -1px;
-  }
 
   /* scrollbar */
   & {
@@ -67,19 +53,19 @@
   }
 }
 
-.rt-TextAreaChrome {
-  position: absolute;
-  border-radius: inherit;
-  box-sizing: border-box;
-  z-index: 0;
-  inset: 0;
-}
-
 /***************************************************************************************************
  *                                                                                                 *
  * SIZES                                                                                           *
  *                                                                                                 *
  ***************************************************************************************************/
+
+.rt-TextAreaRoot {
+  box-sizing: border-box;
+  padding: var(--text-area-border-width);
+}
+.rt-TextAreaInput {
+  padding: var(--text-area-padding-y) var(--text-area-padding-x);
+}
 
 @breakpoints {
   .rt-TextAreaRoot {
@@ -88,6 +74,7 @@
       border-radius: var(--radius-2);
 
       & :where(.rt-TextAreaInput) {
+        /* Clip text to border */
         --text-area-padding-y: calc(var(--space-1) - var(--text-area-border-width));
         --text-area-padding-x: calc(var(--space-1) * 1.5 - var(--text-area-border-width));
         font-size: var(--font-size-1);
@@ -100,6 +87,7 @@
       border-radius: var(--radius-2);
 
       & :where(.rt-TextAreaInput) {
+        /* Clip text to border */
         --text-area-padding-y: calc(var(--space-1) * 1.5 - var(--text-area-border-width));
         --text-area-padding-x: calc(var(--space-2) - var(--text-area-border-width));
         font-size: var(--font-size-2);
@@ -112,6 +100,7 @@
       border-radius: var(--radius-3);
 
       & :where(.rt-TextAreaInput) {
+        /* Clip text to border */
         --text-area-padding-y: calc(var(--space-2) - var(--text-area-border-width));
         --text-area-padding-x: calc(var(--space-3) - var(--text-area-border-width));
         font-size: var(--font-size-3);
@@ -130,83 +119,68 @@
 
 /* surface */
 .rt-TextAreaRoot:where(.rt-variant-surface) {
+  --text-area-border-width: 1px;
+
+  /* Blend inner shadow with page background */
+  background-clip: content-box;
+  background-color: var(--color-surface);
+  box-shadow: inset 0 0 0 var(--text-area-border-width) var(--gray-a7);
+  color: var(--gray-12);
+
   & :where(.rt-TextAreaInput) {
-    --text-area-border-width: 1px;
-    color: var(--gray-12);
-
-    & ~ :where(.rt-TextAreaChrome) {
-      box-shadow: inset 0 0 0 1px var(--gray-a7);
-      background-color: var(--color-surface);
-
-      /* Blend inner shadow with page background */
-      padding: 1px;
-      background-clip: content-box;
-    }
     &::placeholder {
       color: var(--gray-a10);
-      /* Firefox */
-      opacity: 1;
     }
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
-      ~ :where(.rt-TextAreaChrome) {
-      background-color: var(--focus-a3);
-      box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
-    }
-    &:where(:disabled, :read-only) {
-      & ~ :where(.rt-TextAreaChrome) {
-        /* Blend with grey */
-        background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-      }
-    }
+  }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    background-color: var(--focus-a3);
+    box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
+  }
+
+  &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
+    /* Blend with grey */
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
   }
 }
 
 /* classic */
 .rt-TextAreaRoot:where(.rt-variant-classic) {
+  --text-area-border-width: 1px;
+
+  /* Blend inner shadow with page background */
+  background-clip: content-box;
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-1);
+  color: var(--gray-12);
+
   & :where(.rt-TextAreaInput) {
-    --text-area-border-width: 1px;
-    color: var(--gray-12);
-
-    & ~ :where(.rt-TextAreaChrome) {
-      background-color: var(--color-surface);
-      box-shadow: var(--shadow-1);
-
-      /* Blend inner shadow with page background */
-      padding: 1px;
-      background-clip: content-box;
-    }
     &::placeholder {
       color: var(--gray-a10);
-      /* Firefox */
-      opacity: 1;
     }
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
-      ~ :where(.rt-TextAreaChrome) {
-      background-color: var(--focus-a3);
-      box-shadow: inset 0 0 0 1px var(--focus-a3), var(--shadow-1);
-    }
-    &:where(:disabled, :read-only) {
-      & ~ :where(.rt-TextAreaChrome) {
-        /* Blend with grey */
-        background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-      }
-    }
+  }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    background-color: var(--focus-a3);
+    box-shadow: inset 0 0 0 1px var(--focus-a3),  var(--shadow-1);
+  }
+
+  &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
+    /* Blend with grey */
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
   }
 }
 
 /* soft */
 .rt-TextAreaRoot:where(.rt-variant-soft) {
-  &:where(:focus-within) {
-    /* Use gray outline when component color is gray */
-    outline-color: var(--accent-8);
-  }
-  & :where(.rt-TextAreaInput) {
-    --text-area-border-width: 0px;
-    color: var(--accent-12);
+  --text-area-border-width: 0px;
 
-    & ~ :where(.rt-TextAreaChrome) {
-      background-color: var(--accent-a3);
-    }
+  background-color: var(--accent-a3);
+  color: var(--accent-12);
+
+  & :where(.rt-TextAreaInput) {
     &::selection {
       /* Use gray selection when component color is gray */
       background-color: var(--accent-a5);
@@ -215,16 +189,20 @@
       color: var(--accent-12);
       opacity: 0.65;
     }
-    /* Use gray autofill color when component color is gray */
-    &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only))
-      ~ :where(.rt-TextAreaChrome) {
-      background-color: var(--accent-a4);
-    }
-    &:where(:disabled, :read-only) {
-      & ~ :where(.rt-TextAreaChrome) {
-        background-color: var(--gray-a4);
-      }
-    }
+  }
+
+  &:where(:focus-within) {
+    /* Use gray outline when component color is gray */
+    outline-color: var(--accent-8);
+  }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    background-color: var(--accent-a4);
+  }
+
+  &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
+    background-color: var(--gray-a4);
   }
 }
 
@@ -235,6 +213,7 @@
     color: var(--gray-a11);
     /* Safari */
     -webkit-text-fill-color: var(--gray-a11);
+
     &::placeholder {
       opacity: 0.5;
     }
@@ -244,7 +223,7 @@
     &::selection {
       background-color: var(--gray-a5);
     }
-    .rt-TextAreaRoot:where(:has(&:focus)) {
+    .rt-TextAreaRoot:where(:focus-within) {
       outline-color: var(--gray-8);
     }
   }

--- a/packages/radix-ui-themes/src/components/text-area.tsx
+++ b/packages/radix-ui-themes/src/components/text-area.tsx
@@ -25,7 +25,6 @@ const TextArea = React.forwardRef<TextAreaElement, TextAreaProps>((props, forwar
       style={style}
     >
       <textarea className="rt-reset rt-TextAreaInput" ref={forwardedRef} {...textAreaProps} />
-      <div className="rt-TextAreaChrome" />
     </div>
   );
 });

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -24,7 +24,9 @@
 }
 
 .rt-TextFieldInput {
+  /* Flex layout edge cases — make sure the input can grow, but won't break out of the container */
   flex-grow: 1;
+  min-width: 0;
 
   /* Fix date inputs alignment in Chrome and Safari */
   display: flex;

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -1,36 +1,94 @@
 .rt-TextFieldRoot {
   display: flex;
-  box-sizing: border-box;
-  position: relative;
-  z-index: 0;
-}
+  align-items: stretch;
 
-.rt-TextFieldInput {
-  display: block;
-  width: 100%;
-  position: relative;
-  z-index: 1;
+  @supports selector(:has(*)) {
+    &:where(:has(.rt-TextFieldInput:focus)) {
+      outline: 2px solid var(--text-field-focus-color);
+      outline-offset: -1px;
+    }
+  }
+  @supports not selector(:has(*)) {
+    &:where(:focus-within) {
+      outline: 2px solid var(--text-field-focus-color);
+      outline-offset: -1px;
+    }
+  }
 
-  /* Clip text to the inner shadow */
-  border: var(--text-field-border-width) solid transparent;
-
-  &:where(:autofill, [data-com-onepassword-filled]) {
-    /* Reliably removes native autofill colors */
-    background-clip: text;
-    -webkit-text-fill-color: var(--gray-12);
+  &::selection {
+    background-color: var(--text-field-selection-color);
   }
 }
 
-.rt-TextFieldChrome {
-  position: absolute;
-  box-sizing: border-box;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
+.rt-TextFieldInput {
+  flex-grow: 1;
 
-  :where(.rt-TextFieldInput:focus) ~ & {
-    outline: 2px solid var(--focus-8);
-    outline-offset: -1px;
+  /* Fix date inputs alignment in Chrome and Safari */
+  display: flex;
+  align-items: center;
+
+  /*
+   * Hide type="number" input stepper because it's small, ugly, hard to use, and if
+   * needed, a nicer one can be easily implemented with own buttons in the Slot part.
+   */
+  &:where(type='number') {
+    -moz-appearance: textfield;
+  }
+  &::-webkit-inner-spin-button {
+    appearance: none;
+  }
+
+  /* Remove the native cancel button */
+  &::-webkit-search-cancel-button {
+    appearance: none;
+  }
+
+  &::selection {
+    background-color: var(--text-field-selection-color);
+  }
+
+  /*
+   * Style the date inputs:
+   * https://codepen.io/andresdamelio/pen/KKbvdYb
+   */
+
+  /* Chrome’s calendar icon */
+  &::-webkit-calendar-picker-indicator {
+    padding: calc(var(--text-field-padding) - 2px);
+    margin: calc((var(--text-field-padding) - 2px) * -1);
+    margin-left: var(--space-1);
+    border-radius: var(--text-field-border-radius);
+  }
+  &::-webkit-calendar-picker-indicator:where(:hover) {
+    background-color: var(--gray-a3);
+  }
+  &::-webkit-calendar-picker-indicator:where(:focus-visible) {
+    outline: 2px solid var(--text-field-focus-color);
+  }
+
+  /* Remove focus ring from date fields and use the selection color */
+  &::-webkit-datetime-edit-ampm-field,
+  &::-webkit-datetime-edit-day-field,
+  &::-webkit-datetime-edit-hour-field,
+  &::-webkit-datetime-edit-millisecond-field,
+  &::-webkit-datetime-edit-minute-field,
+  &::-webkit-datetime-edit-month-field,
+  &::-webkit-datetime-edit-second-field,
+  &::-webkit-datetime-edit-week-field,
+  &::-webkit-datetime-edit-year-field {
+    &:where(:focus) {
+      background-color: var(--text-field-selection-color);
+      color: inherit;
+      outline: none;
+    }
+  }
+
+  @supports selector(:has(*)) {
+    &:where(:autofill, [data-com-onepassword-filled]) {
+      /* Reliably removes native autofill colors */
+      background-clip: text;
+      -webkit-text-fill-color: var(--gray-12);
+    }
   }
 }
 
@@ -38,8 +96,6 @@
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  position: relative;
-  z-index: 1;
   color: var(--gray-a11);
   cursor: text;
 
@@ -49,6 +105,12 @@
   &:where(:empty) {
     display: none;
   }
+  &:where(:first-child) {
+    margin-left: calc(var(--text-field-border-width) * -1);
+  }
+  &:where(:last-child) {
+    margin-right: calc(var(--text-field-border-width) * -1);
+  }
 }
 
 /***************************************************************************************************
@@ -57,84 +119,125 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-@breakpoints {
-  .rt-TextFieldSlot {
-    &:where(.rt-r-size-1) {
-      gap: var(--space-2);
-      padding-left: var(--space-1);
-      padding-right: var(--space-1);
-    }
-    &:where(.rt-r-size-2) {
-      gap: var(--space-2);
-      padding-left: var(--space-2);
-      padding-right: var(--space-2);
-    }
-    &:where(.rt-r-size-3) {
-      gap: var(--space-3);
-      padding-left: var(--space-3);
-      padding-right: var(--space-3);
-    }
+.rt-TextFieldRoot {
+  box-sizing: border-box;
+  padding: var(--text-field-border-width);
+  border-radius: var(--text-field-border-radius);
+
+  & > :where(.rt-TextFieldInput:first-child) {
+    /* Equivalent to padding-left, but doesn't cut off long values when cursor is at the end. */
+    text-indent: var(--text-field-padding);
   }
-  .rt-TextFieldInput {
+
+  /* prettier-ignore */
+  & :where(.rt-TextFieldInput:where(
+    [type="date"], [type="datetime-local"], [type="time"], [type="week"], [type="month"])
+  ) {
+    padding-left: var(--text-field-padding);
+    padding-right: var(--text-field-padding);
+    /* Safari is buggy with text-indent for these input types */
+    text-indent: 0;
+  }
+}
+.rt-TextFieldInput {
+  /* Clip text to the border radius of the Root */
+  border-radius: calc(var(--text-field-border-radius) - var(--text-field-border-width));
+
+  /* Remove border-radius on the left if it's not a first child */
+  .rt-TextFieldRoot > :where(&:not(:first-child)) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  /* Remove border-radius on the right if there’s a slot there */
+  &:where(:has(~ .rt-TextFieldSlot)) {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+@breakpoints {
+  .rt-TextFieldRoot {
     &:where(.rt-r-size-1) {
+      --text-field-padding: calc(var(--space-1) * 1.5 - var(--text-field-border-width));
+      --text-field-border-radius: max(var(--radius-2), var(--radius-full));
       height: var(--space-5);
       font-size: var(--font-size-1);
       letter-spacing: var(--letter-spacing-1);
 
-      &:where(:first-child) {
-        /* Equivalent to padding-left, but doesn't cut off long values when cursor is at the end. */
-        text-indent: calc(var(--space-1) * 1.5 - var(--text-field-border-width));
-        /* Clip text to the visible border radius */
-        border-radius: max(var(--radius-2), var(--radius-full));
+      & :where(.rt-TextFieldSlot) {
+        gap: var(--space-2);
+        padding-left: var(--space-1);
+        padding-right: var(--space-1);
       }
 
-      & ~ :where(.rt-TextFieldChrome) {
-        border-radius: max(var(--radius-2), var(--radius-full));
+      & :where(.rt-TextFieldInput) {
+        /* Reset size 2 padding bottom */
+        padding-bottom: 0px;
+
+        /* Safari credentials autofill icon */
+        &::-webkit-textfield-decoration-container {
+          padding-right: 0px;
+          margin-right: -2px;
+        }
+      }
+
+      /* Safari credentials autofill icon */
+      input::-webkit-textfield-decoration-container {
+        padding-right: 0px;
       }
     }
+
     &:where(.rt-r-size-2) {
+      --text-field-padding: calc(var(--space-2) - var(--text-field-border-width));
+      --text-field-border-radius: max(var(--radius-2), var(--radius-full));
       height: var(--space-6);
       font-size: var(--font-size-2);
       letter-spacing: var(--letter-spacing-2);
 
-      /* Avoid 1px baseline jitter when layout around the text field is subpixel-sized (e.g. vh units). */
-      /* Works because as of Nov 2023, Chrome computes input text bounding box height as 16.5px on @2x screens. */
-      padding-bottom: 0.5px;
+      & :where(.rt-TextFieldInput) {
+        /* Avoid 1px baseline jitter when layout around the text field is subpixel-sized (e.g. vh units). */
+        /* Works because as of Nov 2023, Chrome computes input text bounding box height as 16.5px on @2x screens. */
+        padding-bottom: 0.5px;
 
-      &:where(:first-child) {
-        /* Equivalent to padding-left, but doesn't cut off long values when cursor is at the end */
-        text-indent: calc(var(--space-2) - var(--text-field-border-width));
-        /* Clip text to the visible border radius */
-        border-radius: max(var(--radius-2), var(--radius-full));
+        /* Safari credentials autofill icon */
+        &::-webkit-textfield-decoration-container {
+          padding-right: 2px;
+          margin-right: 0px;
+        }
       }
 
-      & ~ :where(.rt-TextFieldChrome) {
-        border-radius: max(var(--radius-2), var(--radius-full));
+      & :where(.rt-TextFieldSlot) {
+        gap: var(--space-2);
+        padding-left: var(--space-2);
+        padding-right: var(--space-2);
       }
     }
+
     &:where(.rt-r-size-3) {
+      --text-field-padding: calc(var(--space-3) - var(--text-field-border-width));
+      --text-field-border-radius: max(var(--radius-3), var(--radius-full));
       height: var(--space-7);
       font-size: var(--font-size-3);
       letter-spacing: var(--letter-spacing-3);
 
-      &:where(:first-child) {
-        /* Equivalent to padding-left, but doesn't cut off long values when cursor is at the end */
-        text-indent: calc(var(--space-3) - var(--text-field-border-width));
-        /* Clip text to the visible border radius */
-        border-radius: max(var(--radius-3), var(--radius-full));
+      & :where(.rt-TextFieldInput) {
+        /* Reset size 2 padding bottom */
+        padding-bottom: 0px;
+
+        /* Safari credentials autofill icon */
+        &::-webkit-textfield-decoration-container {
+          padding-right: 5px;
+          margin-right: 0px;
+        }
       }
 
-      & ~ :where(.rt-TextFieldChrome) {
-        border-radius: max(var(--radius-3), var(--radius-full));
+      & :where(.rt-TextFieldSlot) {
+        gap: var(--space-3);
+        padding-left: var(--space-3);
+        padding-right: var(--space-3);
       }
     }
   }
-}
-
-/* As an enhancement, remove border-radius on the right if there’s a slot */
-.rt-TextFieldInput:where(:has(~ .rt-TextFieldSlot)) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
 }
 
 /***************************************************************************************************
@@ -145,100 +248,91 @@
 
 /* surface */
 
-.rt-TextFieldInput:where(.rt-variant-surface) {
+.rt-TextFieldRoot:where(.rt-variant-surface) {
+  --text-field-selection-color: var(--focus-a5);
+  --text-field-focus-color: var(--focus-8);
   --text-field-border-width: 1px;
+
+  /* Blend inner shadow with page background */
+  background-clip: content-box;
+  background-color: var(--color-surface);
+  box-shadow: inset 0 0 0 var(--text-field-border-width) var(--gray-a7);
   color: var(--gray-12);
 
-  & ~ :where(.rt-TextFieldChrome) {
-    background-color: var(--color-surface);
-    box-shadow: inset 0 0 0 1px var(--gray-a7);
-    /* Blend inner shadow with page background */
-    padding: 1px;
-    background-clip: content-box;
-  }
-  &::placeholder {
-    color: var(--gray-a10);
-    /* Firefox */
-    opacity: 1;
-  }
-  &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-    & ~ :where(.rt-TextFieldChrome) {
-      background-color: var(--focus-a3);
-      box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
+  & :where(.rt-TextFieldInput) {
+    &::placeholder {
+      color: var(--gray-a10);
     }
   }
-  &:where(:disabled, :read-only) {
-    & ~ :where(.rt-TextFieldChrome) {
-      /* Blend with grey */
-      background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-    }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    background-color: var(--focus-a3);
+    box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
+  }
+
+  &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
+    /* Blend with grey */
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
   }
 }
 
 /* classic */
 
-.rt-TextFieldInput:where(.rt-variant-classic) {
+.rt-TextFieldRoot:where(.rt-variant-classic) {
+  --text-field-selection-color: var(--focus-a5);
+  --text-field-focus-color: var(--focus-8);
   --text-field-border-width: 1px;
+
+  /* Blend inner shadow with page background */
+  background-clip: content-box;
+  background-color: var(--color-surface);
+  box-shadow: var(--shadow-1);
   color: var(--gray-12);
 
-  & ~ :where(.rt-TextFieldChrome) {
-    background-color: var(--color-surface);
-    box-shadow: var(--shadow-1);
-    /* Blend inner shadow with page background */
-    padding: 1px;
-    background-clip: content-box;
-  }
-  &::placeholder {
-    color: var(--gray-a10);
-    /* Firefox */
-    opacity: 1;
-  }
-  &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-    & ~ :where(.rt-TextFieldChrome) {
-      background-color: var(--focus-a3);
-      box-shadow: inset 0 0 0 1px var(--focus-a3), var(--shadow-1);
+  & :where(.rt-TextFieldInput) {
+    &::placeholder {
+      color: var(--gray-a10);
     }
   }
-  &:where(:disabled, :read-only) {
-    & ~ :where(.rt-TextFieldChrome) {
-      /* Blend with grey */
-      background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-    }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    background-color: var(--focus-a3);
+    box-shadow: inset 0 0 0 1px var(--focus-a3), var(--shadow-1);
+  }
+
+  &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
+    /* Blend with grey */
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
   }
 }
 
 /* soft */
-.rt-TextFieldInput:where(.rt-variant-soft) {
+
+.rt-TextFieldRoot:where(.rt-variant-soft) {
+  --text-field-selection-color: var(--accent-a5);
+  --text-field-focus-color: var(--accent-8);
   --text-field-border-width: 0px;
+
+  background-color: var(--accent-a3);
   color: var(--accent-12);
 
-  & ~ :where(.rt-TextFieldChrome) {
-    background-color: var(--accent-a3);
-  }
-  &::placeholder {
-    color: var(--accent-12);
-    opacity: 0.6;
-  }
-  &:where(:autofill, [data-com-onepassword-filled]):where(:not(:disabled, :read-only)) {
-    & ~ :where(.rt-TextFieldChrome) {
-      /* Use gray autofill color when component color is gray */
-      background-color: var(--accent-a4);
+  & :where(.rt-TextFieldInput) {
+    &::placeholder {
+      color: var(--accent-12);
+      opacity: 0.6;
     }
   }
-  &:where(:focus) {
-    & ~ :where(.rt-TextFieldChrome) {
-      /* Use gray outline when component color is gray */
-      outline-color: var(--accent-8);
-    }
+
+  /* prettier-ignore */
+  &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
+    /* Use gray autofill color when component color is gray */
+    background-color: var(--accent-a4);
   }
-  &:where(:disabled, :read-only) {
-    & ~ :where(.rt-TextFieldChrome) {
-      background-color: var(--gray-a4);
-    }
-  }
-  &::selection {
-    /* Use gray selection when component color is gray */
-    background-color: var(--accent-a5);
+
+  &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
+    background-color: var(--gray-a4);
   }
 }
 
@@ -251,19 +345,16 @@
     /* Safari */
     -webkit-text-fill-color: var(--gray-a11);
 
-    &:where(:focus) ~ :where(.rt-TextFieldChrome) {
-      outline: 2px solid var(--gray-8);
-    }
     &::placeholder {
       opacity: 0.5;
     }
     &:where(:placeholder-shown) {
       cursor: var(--cursor-disabled);
     }
-    &::selection {
-      background-color: var(--gray-a5);
+    .rt-TextFieldRoot:where(:has(&)) {
+      --text-field-selection-color: var(--gray-a5);
+      --text-field-focus-color: var(--gray-8);
     }
-
     /* Cursor in slots, as an enhancement */
     .rt-TextFieldRoot:where(:has(&:placeholder-shown)) :where(.rt-TextFieldSlot) {
       cursor: var(--cursor-disabled);

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -24,9 +24,12 @@
 }
 
 .rt-TextFieldInput {
-  /* Flex layout edge cases — make sure the input can grow, but won't break out of the container */
-  flex-grow: 1;
-  min-width: 0;
+  /*
+   * Flex layout edge case: when the parent container of TextFieldRoot
+   * is smaller than the intrinsic width of TextFieldInput with all the slots,
+   * this actually causes the input to shrink the available width.
+   */
+  width: 100%;
 
   /* Fix date inputs alignment in Chrome and Safari */
   display: flex;

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -2,6 +2,9 @@
   display: flex;
   align-items: stretch;
 
+  /* Make sure that font weight is not inherited, e.g. from a wrapping <label> */
+  font-weight: var(--font-weight-regular);
+
   @supports selector(:has(*)) {
     &:where(:has(.rt-TextFieldInput:focus)) {
       outline: 2px solid var(--text-field-focus-color);

--- a/packages/radix-ui-themes/src/styles/tokens/typography.css
+++ b/packages/radix-ui-themes/src/styles/tokens/typography.css
@@ -76,6 +76,8 @@
   --code-letter-spacing: -0.007em;
   --code-padding-top: 0.1em;
   --code-padding-bottom: 0.1em;
+  --code-padding-left: 0.25em;
+  --code-padding-right: 0.25em;
 
   /* Strong */
 


### PR DESCRIPTION
- Make sure inline elements like Badge and Code that rely on padding for their height don't stretch vertically in Flex/Grid layouts, similarly to how fixed-height elements work
- Fix `a` reset regression when links would get an unintended `inline-block` style by default
- Rework Text Field and Text Area
  - Make sure that the font weight is not inherited, e.g. from a wrapping `<label>` element
  - Add styles for inputs of different types, like date and search
  - Got rid of the internal Chrome part given [good support](https://caniuse.com/css-has) for `:has`, which simplifies greatly our implementation and allows the `style` prop to work more predictably.
  - Older browser that don't support `:has` will render the disabled and autofilled styles as regular state; otherwise these components are still going to be fully functional.