### PR TITLE
Require .js extension

### DIFF
--- a/packages/radix-ui-themes/.eslintrc.cjs
+++ b/packages/radix-ui-themes/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
-  extends: ['custom'],
+  extends: ['custom', 'plugin:require-extensions/recommended'],
+  plugins: ['require-extensions'],
 };

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -129,6 +129,7 @@
     "esbuild": "^0.20.0",
     "eslint": "^8.15.0",
     "eslint-config-custom": "*",
+    "eslint-plugin-require-extensions": "^0.1.3",
     "postcss": "^8.4.33",
     "postcss-cli": "^11.0.0",
     "postcss-combine-duplicated-selectors": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,6 +1914,11 @@ eslint-plugin-react@^7.33.2:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.8"
 
+eslint-plugin-require-extensions@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz#394aeab433f996797a6ceba0a3f75640d4846bc8"
+  integrity sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==
+
 eslint-plugin-turbo@1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-turbo/-/eslint-plugin-turbo-1.12.2.tgz#610327a35933a9f29cc6ce546e21ff3f3867b36a"


### PR DESCRIPTION
Add an ESLint plugin that makes sure all the imports in the Radix Themes package have a `.js` extension.

This is auto-fixable as well:

<img width="688" alt="image" src="https://github.com/radix-ui/themes/assets/8441036/c8a8e39a-9c71-4f0f-9a38-72298c3070a9">