### PR TITLE
Add missing props

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -76,6 +76,8 @@
 - `AlertDialog`, `Dialog`
   - Add `position: relative` to support absolutely positioned children.
   - Rework the scroll container so that it displays scrollbars on the viewport rather than confined to the dialog content
+- `Blockquote`, `Code`, `Em`, `Heading`, `Quote`, `Link`, `Strong`, `Text`
+  - Add new `wrap` and `truncate` props that control whether the text wraps and whether it is truncated with ellipsis
 - `Code`
   - `variant="ghost"` color now works similarly to Text, inheriting the color unless set explicitly using the `color` prop
 - `Container`
@@ -107,19 +109,19 @@
   - Fix an issue when Scroll Area would be unable to stretch to 100% height when informed by the parent’s auto height
 - `Slider`
   - Change the size of the bounding box to match the size of the Slider track
+  - Fix an overzealous focus outline in Safari
 - `Table`
   - Add new `layout` prop to control the `table-layout` style property
   - Align `width` prop type signature and implementation on the `TableCell` part with the reworked `width` prop on the layout components
   - Add `minWidth` and `maxWidth` props to the `TableCell` part
 - `Tabs`:
   - Add `color` and `highContrast` props to `TabsList`
+  - Add margin props `TabsList` and `TabsContent`
   - Renamed the letter/word spacing CSS variables in `.radix-themes` so that it supports both `Tabs` and `TabNav` components. Note that this is a backwards compatible change, as the old variables are still supported.
     - `--tabs-trigger-active-letter-spacing` -> `--tab-active-letter-spacing`
     - `--tabs-trigger-active-word-spacing` -> `--tab-active-word-spacing`
     - `--tabs-trigger-inactive-letter-spacing` -> `--tab-inactive-letter-spacing`
     - `--tabs-trigger-inactive-word-spacing` -> `--tab-inactive-word-spacing`
-- `Text`, `Heading`, `Link`
-  - Add new `wrap` and `truncate` props
 - `TextArea`
   - Add `radius` prop
   - Add `resize` prop

--- a/packages/radix-ui-themes/src/components/blockquote.props.ts
+++ b/packages/radix-ui-themes/src/components/blockquote.props.ts
@@ -1,18 +1,38 @@
-import { asChildProp } from '../props/as-child.prop.js';
-import { textPropDefs } from './text.props.js';
+import {
+  asChildProp,
+  highContrastProp,
+  inheritedColorProp,
+  textWrapProp,
+  truncateProp,
+  weightProp,
+} from '../props/index.js';
+
+import type { PropDef } from '../props/index.js';
+
+const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 
 const blockquotePropDefs = {
   asChild: asChildProp,
-  size: textPropDefs.size,
-  weight: textPropDefs.weight,
-  color: textPropDefs.color,
-  highContrast: textPropDefs.highContrast,
+  size: {
+    type: 'enum',
+    className: 'rt-r-size',
+    values: sizes,
+    default: undefined,
+    responsive: true,
+  },
+  weight: weightProp,
+  color: inheritedColorProp,
+  highContrast: highContrastProp,
+  truncate: truncateProp,
+  wrap: textWrapProp,
 } satisfies {
   asChild: typeof asChildProp;
-  size: typeof textPropDefs.size;
-  weight: typeof textPropDefs.weight;
-  color: typeof textPropDefs.color;
-  highContrast: typeof textPropDefs.highContrast;
+  size: PropDef<(typeof sizes)[number]>;
+  weight: typeof weightProp;
+  color: typeof inheritedColorProp;
+  highContrast: typeof highContrastProp;
+  truncate: typeof truncateProp;
+  wrap: typeof textWrapProp;
 };
 
 export { blockquotePropDefs };

--- a/packages/radix-ui-themes/src/components/code.props.ts
+++ b/packages/radix-ui-themes/src/components/code.props.ts
@@ -1,6 +1,13 @@
-import { weightProp, colorProp, highContrastProp } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import {
+  weightProp,
+  colorProp,
+  highContrastProp,
+  textWrapProp,
+  truncateProp,
+} from '../props/index.js';
 import { asChildProp } from '../props/as-child.prop.js';
+
+import type { PropDef } from '../props/index.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const variants = ['solid', 'soft', 'outline', 'ghost'] as const;
@@ -18,6 +25,8 @@ const codePropDefs = {
   weight: weightProp,
   color: colorProp,
   highContrast: highContrastProp,
+  truncate: truncateProp,
+  wrap: textWrapProp,
 } satisfies {
   asChild: typeof asChildProp;
   size: PropDef<(typeof sizes)[number]>;
@@ -25,6 +34,8 @@ const codePropDefs = {
   weight: typeof weightProp;
   color: typeof colorProp;
   highContrast: typeof highContrastProp;
+  truncate: typeof truncateProp;
+  wrap: typeof textWrapProp;
 };
 
 export { codePropDefs };

--- a/packages/radix-ui-themes/src/components/em.props.ts
+++ b/packages/radix-ui-themes/src/components/em.props.ts
@@ -1,9 +1,13 @@
-import { asChildProp } from '../props/index.js';
+import { asChildProp, textWrapProp, truncateProp } from '../props/index.js';
 
 const emPropDefs = {
   asChild: asChildProp,
+  truncate: truncateProp,
+  wrap: textWrapProp,
 } satisfies {
   asChild: typeof asChildProp;
+  truncate: typeof truncateProp;
+  wrap: typeof textWrapProp;
 };
 
 export { emPropDefs };

--- a/packages/radix-ui-themes/src/components/quote.props.ts
+++ b/packages/radix-ui-themes/src/components/quote.props.ts
@@ -1,9 +1,13 @@
-import { asChildProp } from '../props/index.js';
+import { asChildProp, textWrapProp, truncateProp } from '../props/index.js';
 
 const quotePropDefs = {
   asChild: asChildProp,
+  truncate: truncateProp,
+  wrap: textWrapProp,
 } satisfies {
   asChild: typeof asChildProp;
+  truncate: typeof truncateProp;
+  wrap: typeof textWrapProp;
 };
 
 export { quotePropDefs };

--- a/packages/radix-ui-themes/src/components/reset.tsx
+++ b/packages/radix-ui-themes/src/components/reset.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { extractProps, requireReactElement } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
+import { requireReactElement } from '../helpers/index.js';
 
 import type { ComponentPropsWithoutColor } from '../helpers/index.js';
-import type { MarginProps } from '../props/index.js';
 
 type ResetElement = React.ElementRef<'div'>;
-interface ResetProps extends ComponentPropsWithoutColor<typeof Slot>, MarginProps {}
-const Reset = React.forwardRef<ResetElement, ResetProps>((props, forwardedRef) => {
-  const { className, children, ...resetProps } = extractProps(props, marginPropDefs);
-  return (
-    <Slot {...resetProps} ref={forwardedRef} className={classNames('rt-reset', className)}>
-      {requireReactElement(children)}
-    </Slot>
-  );
-});
+interface ResetProps extends ComponentPropsWithoutColor<typeof Slot> {}
+const Reset = React.forwardRef<ResetElement, ResetProps>(
+  ({ className, children, ...props }, forwardedRef) => {
+    return (
+      <Slot {...props} ref={forwardedRef} className={classNames('rt-reset', className)}>
+        {requireReactElement(children)}
+      </Slot>
+    );
+  }
+);
 Reset.displayName = 'Reset';
 
 export { Reset };

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -59,6 +59,9 @@
   width: var(--slider-thumb-size);
   height: var(--slider-thumb-size);
 
+  /* Safari */
+  outline: 0;
+
   &::before {
     content: '';
     position: absolute;

--- a/packages/radix-ui-themes/src/components/strong.props.ts
+++ b/packages/radix-ui-themes/src/components/strong.props.ts
@@ -1,9 +1,13 @@
-import { asChildProp } from '../props/index.js';
+import { asChildProp, textWrapProp, truncateProp } from '../props/index.js';
 
 const strongPropDefs = {
   asChild: asChildProp,
+  truncate: truncateProp,
+  wrap: textWrapProp,
 } satisfies {
   asChild: typeof asChildProp;
+  truncate: typeof truncateProp;
+  wrap: typeof textWrapProp;
 };
 
 export { strongPropDefs };

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -32,9 +32,10 @@ type TabsListElement = React.ElementRef<typeof TabsPrimitive.List>;
 type TabsListOwnProps = GetPropDefTypes<typeof tabsListPropDefs>;
 interface TabsListProps
   extends Omit<ComponentPropsWithoutColor<typeof TabsPrimitive.List>, 'asChild'>,
+    MarginProps,
     TabsListOwnProps {}
 const TabsList = React.forwardRef<TabsListElement, TabsListProps>((props, forwardedRef) => {
-  const { className, color, ...listProps } = extractProps(props, tabsListPropDefs);
+  const { className, color, ...listProps } = extractProps(props, tabsListPropDefs, marginPropDefs);
   return (
     <TabsPrimitive.List
       data-accent-color={color}
@@ -74,15 +75,19 @@ type TabsContentElement = React.ElementRef<typeof TabsPrimitive.Content>;
 type TabsContentOwnProps = GetPropDefTypes<typeof tabsContentPropDefs>;
 interface TabsContentProps
   extends ComponentPropsWithoutColor<typeof TabsPrimitive.Content>,
+    MarginProps,
     TabsContentOwnProps {}
 const TabsContent = React.forwardRef<TabsContentElement, TabsContentProps>(
-  ({ className, ...props }, forwardedRef) => (
-    <TabsPrimitive.Content
-      {...props}
-      ref={forwardedRef}
-      className={classNames('rt-TabsContent', className)}
-    />
-  )
+  (props, forwardedRef) => {
+    const { className, ...contentProps } = extractProps(props, marginPropDefs);
+    return (
+      <TabsPrimitive.Content
+        {...contentProps}
+        ref={forwardedRef}
+        className={classNames('rt-TabsContent', className)}
+      />
+    );
+  }
 );
 TabsContent.displayName = 'TabsContent';
 


### PR DESCRIPTION
- Add `wrap` and `truncate` props to all text formatting components except `Kbd`
- Add margin props to `TabsList` and `TabsContent`
- Remove margin props from `Reset`
- Fix Slider focus outline in Safari