### PR TITLE
Add a wildcard export

### DIFF
--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -37,26 +37,7 @@
         "default": "./dist/esm/props/index.js"
       }
     },
-    "./tokens.css": {
-      "import": "./tokens.css",
-      "require": "./tokens.css",
-      "default": "./tokens.css"
-    },
-    "./components.css": {
-      "import": "./components.css",
-      "require": "./components.css",
-      "default": "./components.css"
-    },
-    "./utilities.css": {
-      "import": "./utilities.css",
-      "require": "./utilities.css",
-      "default": "./utilities.css"
-    },
-    "./styles.css": {
-      "import": "./styles.css",
-      "require": "./styles.css",
-      "default": "./styles.css"
-    }
+    "./*": "./*"
   },
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Adding a wildcard export so that Next.js is able to resolve direct imports from the `dist` folder
https://work-os.slack.com/archives/C066T3GNG4Q/p1708683018800289