### PR TITLE
Improve Data List alignment with flexbox children

### DIFF
--- a/apps/playground/app/test-data-list/page.tsx
+++ b/apps/playground/app/test-data-list/page.tsx
@@ -164,9 +164,23 @@ export default function DataListPage() {
                     <DataListItem align="center">
                       <DataListLabel>Authentication methods</DataListLabel>
                       <DataListValue>
-                        <Flex gap="2">
+                        <Flex gap="2" align="center">
                           <StarFilledIcon />
                           <StarFilledIcon />
+                        </Flex>
+                      </DataListValue>
+                    </DataListItem>
+
+                    <DataListItem>
+                      <DataListLabel>Accent</DataListLabel>
+                      <DataListValue>
+                        <Flex gap="2" align="center">
+                          <Box
+                            width="16px"
+                            height="16px"
+                            style={{ backgroundColor: 'royalblue' }}
+                          />
+                          <Text>Blue</Text>
                         </Flex>
                       </DataListValue>
                     </DataListItem>

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -1,6 +1,5 @@
 .rt-DataListLabel {
   display: flex;
-  gap: var(--space-2);
   color: var(--gray-a11);
 
   &:where([data-accent-color]) {
@@ -14,7 +13,7 @@
 
 .rt-DataListValue {
   display: flex;
-  gap: var(--space-2);
+  margin: 0;
 
   /* Ensure value can be truncated */
   min-width: 0px;
@@ -139,6 +138,16 @@
 /*              Alignment              */
 /*                                     */
 /* * * * * * * * * * * * * * * * * * * */
+
+.rt-DataListValue {
+  &::before {
+    /*
+     * Zero-width joiner to establish a baseline.
+     * Allows Flex children with text to align automatically.
+     */
+    content: '‍';
+  }
+}
 
 @breakpoints {
   /*

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -69,11 +69,7 @@ type DataListValueElement = React.ElementRef<'dd'>;
 interface DataListValueProps extends ComponentPropsWithoutColor<'dd'> {}
 const DataListValue = React.forwardRef<DataListValueElement, DataListValueProps>(
   ({ children, className, ...props }, forwardedRef) => (
-    <dd
-      {...props}
-      ref={forwardedRef}
-      className={classNames(className, 'rt-reset', 'rt-DataListValue')}
-    >
+    <dd {...props} ref={forwardedRef} className={classNames(className, 'rt-DataListValue')}>
       {children}
     </dd>
   )


### PR DESCRIPTION
Covering a case when flex children with text would would not be aligned properly:

<img width="346" alt="image" src="https://github.com/radix-ui/themes/assets/8441036/354d13f9-60c0-43ad-8132-193468e4db6c">
