### PR TITLE
Add width props to portalled components

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -247,7 +247,7 @@ export default function Sink() {
                             <DialogTrigger>
                               <Button variant="solid">Open</Button>
                             </DialogTrigger>
-                            <DialogContent asChild style={{ maxWidth: 450 }}>
+                            <DialogContent asChild maxWidth="450px">
                               <Flex direction="column" gap="3">
                                 <InfoCircledIcon
                                   style={{ position: 'absolute', top: '24px', right: '20px' }}
@@ -280,7 +280,7 @@ export default function Sink() {
                             <HoverCardTrigger>
                               <Link>A fancy link</Link>
                             </HoverCardTrigger>
-                            <HoverCardContent style={{ width: 200 }}>
+                            <HoverCardContent width="200px">
                               <Text as="p" size="2">
                                 Jan Tschichold was a German calligrapher, typographer and book
                                 designer. He played a significant role in the development of graphic
@@ -298,12 +298,7 @@ export default function Sink() {
                               </Button>
                             </Tooltip>
 
-                            <Tooltip
-                              content="The goal of typography is to relate font size, line height, and line width in a
-                    proportional way that maximizes beauty and makes reading easier and more
-                    pleasant."
-                              style={{ maxWidth: 200 }}
-                            >
+                            <Tooltip content="The goal of typography is to relate font size, line height, and line width in a proportional way that maximizes beauty and makes reading easier and more pleasant.">
                               <Button variant="solid" size="1">
                                 Multiline
                               </Button>
@@ -316,7 +311,7 @@ export default function Sink() {
                             <AlertDialogTrigger>
                               <Button variant="solid">Open</Button>
                             </AlertDialogTrigger>
-                            <AlertDialogContent style={{ maxWidth: 450 }}>
+                            <AlertDialogContent maxWidth="450px">
                               <Flex direction="column" gap="3">
                                 <AlertDialogTitle>Revoke setup link</AlertDialogTitle>
                                 <AlertDialogDescription>
@@ -345,7 +340,7 @@ export default function Sink() {
                             <PopoverTrigger>
                               <Button variant="solid">Popover</Button>
                             </PopoverTrigger>
-                            <PopoverContent style={{ width: 200 }}>
+                            <PopoverContent width="200px">
                               <Text as="p" size="2" mb="2">
                                 Jan Tschichold was a German calligrapher, typographer and book
                                 designer. He played a significant role in the development of graphic
@@ -6096,7 +6091,7 @@ type RightClickAreaProps = React.ComponentProps<typeof Grid> & {
 function RightClickArea({ size = '2', ...props }: RightClickAreaProps) {
   return (
     <Grid
-      height={size === '2' ? '8' : '6'}
+      height={size === '2' ? '48px' : '32px'}
       px="3"
       {...props}
       style={{

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -79,7 +79,10 @@
       - `Link`
 - `AlertDialog`, `Dialog`
   - Add `position: relative` to support absolutely positioned children.
-  - Rework the scroll container so that it displays scrollbars on the viewport rather than confined to the dialog content
+  - Add `width`, `minWidth`, `maxWidth` props to the Content part.
+  - Set `maxWidth="600px"` by default on the Content part.
+    - **[Upgrade guide]** This slightly larger than the previous `580px` value. If you use dialogs that need a different width, override `maxWidth` with your own value.
+  - Rework the scroll container so that it displays scrollbars on the viewport rather than confined to the dialog Content part. Make sure that your code works as expected if you were relying on any of the implementation quirks to override styles or behaviour.
 - `Blockquote`, `Code`, `Em`, `Heading`, `Quote`, `Link`, `Strong`, `Text`
   - Add new `wrap` and `truncate` props that control whether the text wraps and whether it is truncated with ellipsis
 - `Card`
@@ -105,8 +108,11 @@
   - Add new `loading` prop
 - `Flex`
   - Add `gapX` and `gapY` props
-- `Popover`, `HoverCard`, `Tooltip`
+- `Popover`, `HoverCard`
   - Add `position: relative` to support absolutely positioned children.
+  - Add `width`, `minWidth`, `maxWidth`, `height`, `minHeight`, `maxHeight` props to the Content part.
+  - Set `maxWidth="480px"` by default on the Content part.
+    - **[Upgrade guide]** If you use popovers and hover cards that need a wider width, override `maxWidth` with your own value.
 - `RadioGroup`
   - [**Breaking**] Rework the internal HTML structure and styles. This component is now designed to display an optional text label when passing `children` to the `Item` part, and the `Root` part now provides flex column styles and spacing.
 - `Section`
@@ -163,6 +169,9 @@
     - `suppressHydrationWarning` on `html` is no longer needed (unless required by other libraries, like `next-themes`)
   - Document all Theme props with JSDoc
 - `Tooltip`
+  - Add `width`, `minWidth`, `maxWidth` props.
+  - Set `maxWidth="200px"` by default on the tooltip content
+    - **[Upgrade guide]** If you use tooltips that need to be wider, override `maxWidth` with your own value.
   - Change the default delay duration to 200ms
 
 ## 2.0.3

--- a/packages/radix-ui-themes/src/components/alert-dialog.props.ts
+++ b/packages/radix-ui-themes/src/components/alert-dialog.props.ts
@@ -1,1 +1,2 @@
 export { dialogContentPropDefs as alertDialogContentPropDefs } from './dialog.props.js';
+export type { DialogContentOwnProps as AlertDialogContentOwnProps } from './dialog.props.js';

--- a/packages/radix-ui-themes/src/components/alert-dialog.tsx
+++ b/packages/radix-ui-themes/src/components/alert-dialog.tsx
@@ -10,7 +10,7 @@ import { Text } from './text.js';
 import { Theme } from './theme.js';
 
 import type { ComponentPropsAs, ComponentPropsWithoutColor } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { AlertDialogContentOwnProps } from '../props/index.js';
 
 interface AlertDialogRootProps
   extends ComponentPropsWithoutColor<typeof AlertDialogPrimitive.Root> {}
@@ -32,7 +32,6 @@ const AlertDialogTrigger = React.forwardRef<AlertDialogTriggerElement, AlertDial
 AlertDialogTrigger.displayName = 'AlertDialogTrigger';
 
 type AlertDialogContentElement = React.ElementRef<typeof AlertDialogPrimitive.Content>;
-type AlertDialogContentOwnProps = GetPropDefTypes<typeof alertDialogContentPropDefs>;
 interface AlertDialogContentProps
   extends ComponentPropsWithoutColor<typeof AlertDialogPrimitive.Content>,
     AlertDialogContentOwnProps {

--- a/packages/radix-ui-themes/src/components/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/base-dialog.css
@@ -29,7 +29,6 @@
 .rt-BaseDialogContent {
   margin: auto;
   width: 100%;
-  max-width: 580px;
   z-index: 1;
   position: relative;
   box-sizing: border-box;

--- a/packages/radix-ui-themes/src/components/dialog.props.ts
+++ b/packages/radix-ui-themes/src/components/dialog.props.ts
@@ -14,7 +14,7 @@ const dialogContentPropDefs = {
   },
   width: widthPropDefs.width,
   minWidth: widthPropDefs.minWidth,
-  maxWidth: { ...widthPropDefs.maxWidth, default: '600px' } as const,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '600px' },
 } satisfies {
   size: PropDef<(typeof contentSizes)[number]>;
   width: PropDef<string>;

--- a/packages/radix-ui-themes/src/components/dialog.props.ts
+++ b/packages/radix-ui-themes/src/components/dialog.props.ts
@@ -1,5 +1,5 @@
-import { asChildProp } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildProp, widthPropDefs } from '../props/index.js';
+import type { GetPropDefTypes, PropDef } from '../props/index.js';
 
 const contentSizes = ['1', '2', '3', '4'] as const;
 
@@ -12,8 +12,19 @@ const dialogContentPropDefs = {
     default: '3',
     responsive: true,
   },
+  width: widthPropDefs.width,
+  minWidth: widthPropDefs.minWidth,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '600px' } as const,
 } satisfies {
   size: PropDef<(typeof contentSizes)[number]>;
+  width: PropDef<string>;
+  minWidth: PropDef<string>;
+  maxWidth: PropDef<string>;
 };
 
+type DialogContentOwnProps = GetPropDefTypes<
+  typeof dialogContentPropDefs & typeof asChildProp & typeof widthPropDefs
+>;
+
 export { dialogContentPropDefs };
+export type { DialogContentOwnProps };

--- a/packages/radix-ui-themes/src/components/dialog.tsx
+++ b/packages/radix-ui-themes/src/components/dialog.tsx
@@ -10,7 +10,7 @@ import { Text } from './text.js';
 import { Theme } from './theme.js';
 
 import type { ComponentPropsAs, ComponentPropsWithoutColor } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { DialogContentOwnProps } from '../props/index.js';
 
 interface DialogRootProps
   extends Omit<ComponentPropsWithoutColor<typeof DialogPrimitive.Root>, 'modal'> {}
@@ -30,7 +30,6 @@ const DialogTrigger = React.forwardRef<DialogTriggerElement, DialogTriggerProps>
 DialogTrigger.displayName = 'DialogTrigger';
 
 type DialogContentElement = React.ElementRef<typeof DialogPrimitive.Content>;
-type DialogContentOwnProps = GetPropDefTypes<typeof dialogContentPropDefs>;
 interface DialogContentProps
   extends ComponentPropsWithoutColor<typeof DialogPrimitive.Content>,
     DialogContentOwnProps {

--- a/packages/radix-ui-themes/src/components/hover-card.props.ts
+++ b/packages/radix-ui-themes/src/components/hover-card.props.ts
@@ -1,5 +1,5 @@
-import { asChildProp } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildProp, heightPropDefs, widthPropDefs } from '../props/index.js';
+import type { GetPropDefTypes, PropDef } from '../props/index.js';
 
 const contentSizes = ['1', '2', '3'] as const;
 
@@ -12,8 +12,23 @@ const hoverCardContentPropDefs = {
     default: '2',
     responsive: true,
   },
+  width: widthPropDefs.width,
+  minWidth: widthPropDefs.minWidth,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' } as const,
+  ...heightPropDefs,
 } satisfies {
+  width: PropDef<string>;
+  minWidth: PropDef<string>;
+  maxWidth: PropDef<string>;
   size: PropDef<(typeof contentSizes)[number]>;
 };
 
+type HoverCardContentOwnProps = GetPropDefTypes<
+  typeof hoverCardContentPropDefs &
+    typeof asChildProp &
+    typeof widthPropDefs &
+    typeof heightPropDefs
+>;
+
 export { hoverCardContentPropDefs };
+export type { HoverCardContentOwnProps };

--- a/packages/radix-ui-themes/src/components/hover-card.props.ts
+++ b/packages/radix-ui-themes/src/components/hover-card.props.ts
@@ -14,7 +14,7 @@ const hoverCardContentPropDefs = {
   },
   width: widthPropDefs.width,
   minWidth: widthPropDefs.minWidth,
-  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' } as const,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' },
   ...heightPropDefs,
 } satisfies {
   width: PropDef<string>;

--- a/packages/radix-ui-themes/src/components/hover-card.tsx
+++ b/packages/radix-ui-themes/src/components/hover-card.tsx
@@ -8,7 +8,7 @@ import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Theme } from './theme.js';
 
 import type { ComponentPropsWithoutColor } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { HoverCardContentOwnProps } from '../props/index.js';
 
 interface HoverCardRootProps extends ComponentPropsWithoutColor<typeof HoverCardPrimitive.Root> {}
 const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => (
@@ -34,7 +34,6 @@ const HoverCardTrigger = React.forwardRef<HoverCardTriggerElement, HoverCardTrig
 HoverCardTrigger.displayName = 'HoverCardTrigger';
 
 type HoverCardContentElement = React.ElementRef<typeof HoverCardPrimitive.Content>;
-type HoverCardContentOwnProps = GetPropDefTypes<typeof hoverCardContentPropDefs>;
 interface HoverCardContentProps
   extends ComponentPropsWithoutColor<typeof HoverCardPrimitive.Content>,
     HoverCardContentOwnProps {

--- a/packages/radix-ui-themes/src/components/popover.props.ts
+++ b/packages/radix-ui-themes/src/components/popover.props.ts
@@ -14,7 +14,7 @@ const popoverContentPropDefs = {
   },
   width: widthPropDefs.width,
   minWidth: widthPropDefs.minWidth,
-  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' } as const,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' },
   ...heightPropDefs,
 } satisfies {
   width: PropDef<string>;

--- a/packages/radix-ui-themes/src/components/popover.props.ts
+++ b/packages/radix-ui-themes/src/components/popover.props.ts
@@ -1,5 +1,5 @@
-import { asChildProp } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildProp, heightPropDefs, widthPropDefs } from '../props/index.js';
+import type { GetPropDefTypes, PropDef } from '../props/index.js';
 
 const contentSizes = ['1', '2', '3', '4'] as const;
 
@@ -12,8 +12,20 @@ const popoverContentPropDefs = {
     default: '2',
     responsive: true,
   },
+  width: widthPropDefs.width,
+  minWidth: widthPropDefs.minWidth,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '480px' } as const,
+  ...heightPropDefs,
 } satisfies {
+  width: PropDef<string>;
+  minWidth: PropDef<string>;
+  maxWidth: PropDef<string>;
   size: PropDef<(typeof contentSizes)[number]>;
 };
 
+type PopoverContentOwnProps = GetPropDefTypes<
+  typeof popoverContentPropDefs & typeof asChildProp & typeof widthPropDefs & typeof heightPropDefs
+>;
+
 export { popoverContentPropDefs };
+export type { PopoverContentOwnProps };

--- a/packages/radix-ui-themes/src/components/popover.tsx
+++ b/packages/radix-ui-themes/src/components/popover.tsx
@@ -8,7 +8,7 @@ import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Theme } from './theme.js';
 
 import type { ComponentPropsWithoutColor } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { PopoverContentOwnProps } from '../props/index.js';
 
 interface PopoverRootProps extends ComponentPropsWithoutColor<typeof PopoverPrimitive.Root> {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => (
@@ -29,7 +29,6 @@ const PopoverTrigger = React.forwardRef<PopoverTriggerElement, PopoverTriggerPro
 PopoverTrigger.displayName = 'PopoverTrigger';
 
 type PopoverContentElement = React.ElementRef<typeof PopoverPrimitive.Content>;
-type PopoverContentOwnProps = GetPropDefTypes<typeof popoverContentPropDefs>;
 interface PopoverContentProps
   extends ComponentPropsWithoutColor<typeof PopoverPrimitive.Content>,
     PopoverContentOwnProps {

--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -5,9 +5,11 @@ import classNames from 'classnames';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
 import { segmentedControlRootPropDefs } from './segmented-control.props.js';
+import { extractProps } from '../helpers/index.js';
+import { marginPropDefs } from '../props/index.js';
 
-import { extractProps, type ComponentPropsWithoutColor } from '../helpers/index.js';
-import { marginPropDefs, type GetPropDefTypes, type MarginProps } from '../props/index.js';
+import type { ComponentPropsWithoutColor } from '../helpers/index.js';
+import type { GetPropDefTypes, MarginProps } from '../props/index.js';
 
 type SegmentedControlRootOwnProps = GetPropDefTypes<typeof segmentedControlRootPropDefs>;
 

--- a/packages/radix-ui-themes/src/components/tooltip.css
+++ b/packages/radix-ui-themes/src/components/tooltip.css
@@ -3,7 +3,6 @@
   padding: var(--space-1) var(--space-2);
   background-color: var(--gray-12);
   border-radius: var(--radius-2);
-  position: relative;
 
   transform-origin: var(--radix-tooltip-content-transform-origin);
 

--- a/packages/radix-ui-themes/src/components/tooltip.props.ts
+++ b/packages/radix-ui-themes/src/components/tooltip.props.ts
@@ -1,9 +1,19 @@
-import type { PropDef } from '../props/index.js';
+import { widthPropDefs } from '../props/index.js';
+import type { GetPropDefTypes, PropDef } from '../props/index.js';
 
 const tooltipPropDefs = {
   content: { type: 'ReactNode', default: undefined, required: true },
+  width: widthPropDefs.width,
+  minWidth: widthPropDefs.minWidth,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '200px' } as const,
 } satisfies {
+  width: PropDef<string>;
+  minWidth: PropDef<string>;
+  maxWidth: PropDef<string>;
   content: PropDef<React.ReactNode>;
 };
 
+type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs & typeof widthPropDefs>;
+
 export { tooltipPropDefs };
+export type { TooltipOwnProps };

--- a/packages/radix-ui-themes/src/components/tooltip.props.ts
+++ b/packages/radix-ui-themes/src/components/tooltip.props.ts
@@ -5,7 +5,7 @@ const tooltipPropDefs = {
   content: { type: 'ReactNode', default: undefined, required: true },
   width: widthPropDefs.width,
   minWidth: widthPropDefs.minWidth,
-  maxWidth: { ...widthPropDefs.maxWidth, default: '200px' } as const,
+  maxWidth: { ...widthPropDefs.maxWidth, default: '200px' },
 } satisfies {
   width: PropDef<string>;
   minWidth: PropDef<string>;

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -8,7 +8,7 @@ import { tooltipPropDefs } from './tooltip.props.js';
 import { Theme } from './theme.js';
 
 import type { GetPropDefTypes } from '../props/index.js';
-import type { ComponentPropsWithoutColor } from '../helpers/index.js';
+import { extractProps, type ComponentPropsWithoutColor } from '../helpers/index.js';
 
 type TooltipElement = React.ElementRef<typeof TooltipPrimitive.Content>;
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;
@@ -33,7 +33,7 @@ const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, forwarded
     container,
     forceMount,
     ...tooltipContentProps
-  } = props;
+  } = extractProps(props, tooltipPropDefs);
   const rootProps = { open, defaultOpen, onOpenChange, delayDuration, disableHoverableContent };
   return (
     <TooltipPrimitive.Root {...rootProps}>

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -4,11 +4,12 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { Text } from './text.js';
-import { tooltipPropDefs } from './tooltip.props.js';
 import { Theme } from './theme.js';
+import { extractProps } from '../helpers/index.js';
+import { tooltipPropDefs } from './tooltip.props.js';
 
 import type { GetPropDefTypes } from '../props/index.js';
-import { extractProps, type ComponentPropsWithoutColor } from '../helpers/index.js';
+import type { ComponentPropsWithoutColor } from '../helpers/index.js';
 
 type TooltipElement = React.ElementRef<typeof TooltipPrimitive.Content>;
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;

--- a/packages/radix-ui-themes/src/props/height.props.ts
+++ b/packages/radix-ui-themes/src/props/height.props.ts
@@ -1,6 +1,17 @@
 import { GetPropDefTypes, PropDef } from './prop-def.js';
 
 const heightPropDefs = {
+  /**
+   * Sets the CSS **height** property.
+   * Supports CSS strings and responsive objects.
+   *
+   * @example
+   * height="100px"
+   * height={{ md: '100vh', xl: '600px' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/height
+   */
   height: {
     type: 'string',
     className: 'rt-r-h',
@@ -8,6 +19,17 @@ const heightPropDefs = {
     default: undefined,
     responsive: true,
   },
+  /**
+   * Sets the CSS **min-height** property.
+   * Supports CSS strings and responsive objects.
+   *
+   * @example
+   * minHeight="100px"
+   * minHeight={{ md: '100vh', xl: '600px' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/min-height
+   */
   minHeight: {
     type: 'string',
     className: 'rt-r-min-h',
@@ -15,6 +37,17 @@ const heightPropDefs = {
     default: undefined,
     responsive: true,
   },
+  /**
+   * Sets the CSS **max-height** property.
+   * Supports CSS strings and responsive objects.
+   *
+   * @example
+   * maxHeight="100px"
+   * maxHeight={{ md: '100vh', xl: '600px' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/max-height
+   */
   maxHeight: {
     type: 'string',
     className: 'rt-r-max-h',

--- a/packages/radix-ui-themes/src/props/prop-def.ts
+++ b/packages/radix-ui-themes/src/props/prop-def.ts
@@ -68,8 +68,8 @@ type PropDef<T = any> = RegularPropDef<T> | ResponsivePropDef<T>;
 
 // prettier-ignore
 type GetPropDefType<Def> =
-    Def extends StringPropDef ? (Def extends ResponsivePropDef ? Responsive<string> : string)
-  : Def extends BooleanPropDef ? (Def extends ResponsivePropDef ? Responsive<boolean> : boolean)
+    Def extends BooleanPropDef ? (Def extends ResponsivePropDef ? Responsive<boolean> : boolean)
+  : Def extends StringPropDef ? (Def extends ResponsivePropDef ? Responsive<string> : string)
   : Def extends ReactNodePropDef ? (Def extends ResponsivePropDef ? Responsive<React.ReactNode> : React.ReactNode)
   : Def extends EnumOrStringPropDef<infer Type> ?
     Def extends ResponsivePropDef<infer Type extends string> ? Responsive<Union<string, Type>> : Type

--- a/packages/radix-ui-themes/src/props/prop-def.ts
+++ b/packages/radix-ui-themes/src/props/prop-def.ts
@@ -68,10 +68,11 @@ type PropDef<T = any> = RegularPropDef<T> | ResponsivePropDef<T>;
 
 // prettier-ignore
 type GetPropDefType<Def> =
-	  Def extends BooleanPropDef ? (Def extends ResponsivePropDef ? Responsive<boolean> : boolean)
-  : Def extends StringPropDef ? (Def extends ResponsivePropDef ? Responsive<string> : string)
+    Def extends StringPropDef ? (Def extends ResponsivePropDef ? Responsive<string> : string)
+  : Def extends BooleanPropDef ? (Def extends ResponsivePropDef ? Responsive<boolean> : boolean)
   : Def extends ReactNodePropDef ? (Def extends ResponsivePropDef ? Responsive<React.ReactNode> : React.ReactNode)
-  : Def extends EnumOrStringPropDef<infer Type> ? (Def extends ResponsivePropDef<infer Type extends string> ? Responsive<Union<string, Type>> : Type)
+  : Def extends EnumOrStringPropDef<infer Type> ?
+    Def extends ResponsivePropDef<infer Type extends string> ? Responsive<Union<string, Type>> : Type
   : Def extends EnumPropDef<infer Type> ? (Def extends ResponsivePropDef<infer Type> ? Responsive<Type> : Type)
   : never;
 

--- a/packages/radix-ui-themes/src/props/width.props.ts
+++ b/packages/radix-ui-themes/src/props/width.props.ts
@@ -16,7 +16,6 @@ const widthPropDefs = {
     type: 'string',
     className: 'rt-r-w',
     customProperties: ['--width'],
-    default: undefined,
     responsive: true,
   },
   /**
@@ -34,7 +33,6 @@ const widthPropDefs = {
     type: 'string',
     className: 'rt-r-min-w',
     customProperties: ['--min-width'],
-    default: undefined,
     responsive: true,
   },
   /**
@@ -52,7 +50,6 @@ const widthPropDefs = {
     type: 'string',
     className: 'rt-r-max-w',
     customProperties: ['--max-width'],
-    default: undefined,
     responsive: true,
   },
 } satisfies {


### PR DESCRIPTION
`AlertDialog`, `Dialog`
- Add `width`, `minWidth`, `maxWidth` props to the Content part.
- Set `maxWidth="600px"` by default on the Content part.
  - **[Upgrade guide]** This slightly larger than the previous `580px` value. If you use dialogs that need a different width, override `maxWidth` with your own value.

***

`Popover`, `HoverCard`
- Add `width`, `minWidth`, `maxWidth`, `height`, `minHeight`, `maxHeight` props to the Content part.
- Set `maxWidth="480px"` by default on the Content part.
  - **[Upgrade guide]** If you use popovers and hover cards that need a wider width, override `maxWidth` with your own value.

***

`Tooltip`
- Add `width`, `minWidth`, `maxWidth` props.
- Set `maxWidth="200px"` by default on the tooltip content
  - **[Upgrade guide]** If you use tooltips that need to be wider, override `maxWidth` with your own value.