### PR TITLE
Fix input cursor when in `<label>`

### DIFF
--- a/packages/radix-ui-themes/src/components/reset.css
+++ b/packages/radix-ui-themes/src/components/reset.css
@@ -116,7 +116,6 @@
     border: none;
   }
   &:where(
-      iframe,
       textarea,
       input:not(
           [type='button'],
@@ -128,6 +127,17 @@
           [type='submit']
         )
     ) {
+    /* Make sure parent <label> doesn't change the cursor */
+    cursor: text;
+
+    @supports (width: -webkit-fill-available) {
+      width: -webkit-fill-available;
+    }
+    @supports (width: -moz-available) {
+      width: -moz-available;
+    }
+  }
+  &:where(iframe) {
     @supports (width: -webkit-fill-available) {
       width: -webkit-fill-available;
     }


### PR DESCRIPTION
Wrapping a `label` around a text field that uses `rt-reset` class would change the text field's cursor to `default` (inheriting from the label)