### PR TITLE
Fix `SegmentedControl` controlled behaviour

### DIFF
--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -31,6 +31,7 @@ const SegmentedControlRoot = React.forwardRef<HTMLDivElement, SegmentedControlRo
       value: valueProp,
       defaultValue: defaultValueProp,
       onValueChange: onValueChangeProp,
+      ...rootProps
     } = extractProps(props, segmentedControlRootPropDefs, marginPropDefs);
 
     const [value, setValue] = useControllableState({
@@ -49,7 +50,7 @@ const SegmentedControlRoot = React.forwardRef<HTMLDivElement, SegmentedControlRo
             setValue(value);
           }
         }}
-        {...props}
+        {...rootProps}
         type="single"
         value={value}
         asChild={false}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

When providing `onValueChange` to `SegmentedControl.Root`, the value would clear when interacting with the currently active element.

This is due to the handler being overridden by spreading the original `props` object, wiping out the inline conditional.


## Testing steps

Pass `onValueChange` to `SegmentedControl.Root`.

Before:

https://github.com/radix-ui/themes/assets/11708259/b6629f6e-087d-42f4-97d8-c13414f63122

After:

https://github.com/radix-ui/themes/assets/11708259/2826721b-8895-4a13-88a2-e5e91ecf28b0



## Relates issues / PRs

<!-- List out related issues and PR links -->
