### PR TITLE
Support type=color on TextFieldRoot

### DIFF
--- a/packages/radix-ui-themes/src/components/text-field.tsx
+++ b/packages/radix-ui-themes/src/components/text-field.tsx
@@ -13,6 +13,7 @@ import { composeRefs } from '@radix-ui/react-compose-refs';
 type TextFieldRootElement = React.ElementRef<'input'>;
 type TextFieldRootOwnProps = GetPropDefTypes<typeof textFieldRootPropDefs> & {
   type?:
+    | 'color'
     | 'date'
     | 'datetime-local'
     | 'email'


### PR DESCRIPTION
## Description

When using TextFieldRoot with [getInputProps](https://conform.guide/api/react/getInputProps) from [@conform-to/react](https://conform.guide), you get a TypeScript error as the props returned from getInputProps can return type='color'.

I think it's reasonable to allow [type=color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color) to be set on a Radix TextInput, so fixing this by adjusting types to allow for this.


## Testing steps

The following should not produce a TypeScript error:

```tsx
import { getInputProps, useForm } from "@conform-to/react";
import { TextFieldRoot } from "@radix-ui/themes";

function MyComponent() {
  const [form, fields] = useForm({});

  return (
    <TextFieldRoot
      {...getInputProps(fields.name, { type: "text" })}
    ></TextFieldRoot>
  );
}

```

