### PR TITLE
Minimize usage of default utility classes values

### DIFF
--- a/packages/radix-ui-themes/src/components/base-tab-list.css
+++ b/packages/radix-ui-themes/src/components/base-tab-list.css
@@ -1,5 +1,6 @@
 .rt-BaseTabList {
   display: flex;
+  justify-content: flex-start;
   overflow-x: auto;
   white-space: nowrap;
 

--- a/packages/radix-ui-themes/src/components/base-tab-list.props.ts
+++ b/packages/radix-ui-themes/src/components/base-tab-list.props.ts
@@ -18,7 +18,7 @@ const baseTabListPropDefs = {
     type: 'enum',
     className: 'rt-r-jc',
     values: justifyValues,
-    default: 'start',
+    default: undefined,
     responsive: true,
   },
   ...colorPropDef,

--- a/packages/radix-ui-themes/src/components/container.css
+++ b/packages/radix-ui-themes/src/components/container.css
@@ -7,6 +7,7 @@
 
 .rt-Container {
   display: flex;
+  box-sizing: border-box;
   flex-direction: column;
   align-items: center;
   flex-shrink: 0;

--- a/packages/radix-ui-themes/src/components/container.tsx
+++ b/packages/radix-ui-themes/src/components/container.tsx
@@ -15,7 +15,7 @@ interface ContainerProps
     LayoutProps,
     ContainerOwnProps {}
 const Container = React.forwardRef<ContainerElement, ContainerProps>(
-  ({ width, minWidth, maxWidth, ...props }, forwardedRef) => {
+  ({ width, minWidth, maxWidth, height, minHeight, maxHeight, ...props }, forwardedRef) => {
     const { asChild, children, className, ...containerProps } = extractProps(
       props,
       containerPropDefs,
@@ -24,7 +24,7 @@ const Container = React.forwardRef<ContainerElement, ContainerProps>(
     );
 
     const { className: innerClassName, style: innerStyle } = extractProps(
-      { width, minWidth, maxWidth },
+      { width, minWidth, maxWidth, height, minHeight, maxHeight },
       widthPropDefs,
       heightPropDefs
     );

--- a/packages/radix-ui-themes/src/components/flex.props.ts
+++ b/packages/radix-ui-themes/src/components/flex.props.ts
@@ -33,7 +33,7 @@ const flexPropDefs = {
     type: 'enum',
     className: 'rt-r-display',
     values: displayValues,
-    default: 'flex',
+    default: undefined,
     responsive: true,
   },
   /**
@@ -88,7 +88,7 @@ const flexPropDefs = {
     className: 'rt-r-jc',
     values: justifyValues,
     parseValue: parseJustifyValue,
-    default: 'start',
+    default: undefined,
     responsive: true,
   },
   /**

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -3,6 +3,7 @@
   --leading-trim-end: var(--heading-leading-trim-end);
   font-family: var(--heading-font-family);
   font-style: var(--heading-font-style);
+  font-weight: var(--font-weight-bold);
   line-height: var(--line-height);
 
   :where(&) {

--- a/packages/radix-ui-themes/src/components/heading.props.ts
+++ b/packages/radix-ui-themes/src/components/heading.props.ts
@@ -12,7 +12,6 @@ import type { PropDef } from '../props/index.js';
 
 const as = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
-const weights = weightPropDef.weight.values;
 
 const headingPropDefs = {
   as: { type: 'enum', values: as, default: 'h1' },
@@ -24,7 +23,7 @@ const headingPropDefs = {
     default: '6',
     responsive: true,
   },
-  weight: { ...weightPropDef.weight, default: 'bold' },
+  ...weightPropDef,
   ...textAlignPropDef,
   ...leadingTrimPropDef,
   ...truncatePropDef,
@@ -34,7 +33,6 @@ const headingPropDefs = {
 } satisfies {
   as: PropDef<(typeof as)[number]>;
   size: PropDef<(typeof sizes)[number]>;
-  weight: PropDef<(typeof weights)[number]>;
 };
 
 export { headingPropDefs };

--- a/packages/radix-ui-themes/src/components/inset.css
+++ b/packages/radix-ui-themes/src/components/inset.css
@@ -1,4 +1,6 @@
 .rt-Inset {
+  box-sizing: border-box;
+
   /* We reset the defined margin variables to avoid inheriting them from a higher component */
   /* If a margin IS defined on the component itself, the utility class will win and reset it */
   --margin-top: 0px;

--- a/packages/radix-ui-themes/src/components/link.props.ts
+++ b/packages/radix-ui-themes/src/components/link.props.ts
@@ -30,7 +30,6 @@ const linkPropDefs = {
   ...highContrastPropDef,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
-
   underline: PropDef<(typeof underline)[number]>;
 };
 

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -114,6 +114,7 @@
 }
 
 .rt-TextFieldSlot {
+  box-sizing: border-box;
   flex-shrink: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
- Resolves an edge case when utility classes CSS is imported on top of custom styles and take over the custom styles unexpectedly when building on top of certain components
- Add missing box-sizing to components that have padding props on them