### PR TITLE
:bug: Fixed an unnecessary comma causing SassError.

### DIFF
--- a/packages/radix-ui-themes/src/components/reset.css
+++ b/packages/radix-ui-themes/src/components/reset.css
@@ -51,7 +51,7 @@
       [type='checkbox'],
       [type='color'],
       [type='radio'],
-      [type='range'],
+      [type='range']
     ) {
     all: unset;
     display: inline-block;


### PR DESCRIPTION
## Description

Fixed an unnecessary comma causing SassError when import radix styles in main `.scss` file.

## Testing steps

1. `@import '@radix-ui/themes/styles.css';` in main `.scss` file.
2. Run dev, will see the error: `SassError: expected selector.`

## Relates issues / PRs

Resolved #410 
