### PR TITLE
Fix auto high-contrast link color regression

### DIFF
--- a/packages/radix-ui-themes/src/components/index.css
+++ b/packages/radix-ui-themes/src/components/index.css
@@ -1,8 +1,12 @@
 @import './reset.css';
-/* Import Skeleton before other components so that its default border-radius doesn’t have a higher specificity */
-@import './skeleton.css';
 @import './animations.css';
 @import './layout.css';
+
+/* Import Skeleton before other components so that its default border-radius doesn’t have a higher specificity */
+@import './skeleton.css';
+
+/* Import Text before other components as it’s commonly extended */
+@import './text.css';
 
 @import './alert-dialog.css';
 @import './avatar.css';
@@ -45,7 +49,6 @@
 @import './tabs.css';
 @import './text-area.css';
 @import './text-field.css';
-@import './text.css';
 @import './theme-panel.css';
 @import './tooltip.css';
 


### PR DESCRIPTION
Fixes a regression from https://github.com/radix-ui/themes/pull/387 when links wouldn't become high-contrast automatically when used in colored text:

<img width="1213" alt="image" src="https://github.com/radix-ui/themes/assets/8441036/7fff42c9-18a6-4dc5-b4d8-0a3dcde71322">
