### PR TITLE
Recover textarea pre-wrap in Firefox

### DIFF
--- a/packages/radix-ui-themes/src/components/reset.css
+++ b/packages/radix-ui-themes/src/components/reset.css
@@ -95,6 +95,9 @@
 
     /* Make sure parent <label> doesn't change the text cursor */
     cursor: text;
+
+    /* Recover textarea pre-wrap in Firefox */
+    white-space: pre-wrap;
   }
   &:where(:focus) {
     outline: none;


### PR DESCRIPTION
Resolves #429 