### PR TITLE
Link: Fix overzealous automatic high-contrast colour

### DIFF
--- a/apps/playground/app/test-high-contrast/page.tsx
+++ b/apps/playground/app/test-high-contrast/page.tsx
@@ -616,6 +616,262 @@ export default function Test() {
 
                     <Flex direction="column" align="start" gap="4">
                       <Text color="gray" size="2">
+                        All wrapping components with {'color="indigo"'} and inline components with
+                        high contrast
+                      </Text>
+
+                      <Heading color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Heading>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link highContrast href="#">
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code highContrast variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link highContrast href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Code size="2" color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link highContrast href="#">
+                          prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link highContrast href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Code>
+
+                      <Callout.Root color="indigo">
+                        <Callout.Text>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code highContrast variant="ghost">
+                            kiwi bowls
+                          </Code>{' '}
+                          to a{' '}
+                          <Link highContrast href="#">
+                            zephyr
+                          </Link>
+                          .
+                        </Callout.Text>
+                      </Callout.Root>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
+                        All wrapping components with {'color="indigo"'} and inline components with{' '}
+                        {'color="indigo"'}
+                      </Text>
+
+                      <Heading color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Heading>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" href="#">
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Text color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Text>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Code color="indigo" variant="ghost">
+                          kiwi bowls
+                        </Code>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which prefers{' '}
+                        <Link color="indigo" href="#">
+                          <Code variant="ghost">kiwi bowls</Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Blockquote color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Blockquote>
+
+                      <Code size="2" color="indigo">
+                        Ambiguous voice of a heart which{' '}
+                        <Link color="indigo" href="#">
+                          prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>
+                        </Link>{' '}
+                        to a{' '}
+                        <Link color="indigo" href="#">
+                          zephyr
+                        </Link>
+                        .
+                      </Code>
+
+                      <Callout.Root color="indigo">
+                        <Callout.Text>
+                          Ambiguous voice of a heart which prefers{' '}
+                          <Code color="indigo" variant="ghost">
+                            kiwi bowls
+                          </Code>{' '}
+                          to a{' '}
+                          <Link color="indigo" href="#">
+                            zephyr
+                          </Link>
+                          .
+                        </Callout.Text>
+                      </Callout.Root>
+                    </Flex>
+
+                    <Flex direction="column" align="start" gap="4">
+                      <Text color="gray" size="2">
                         All wrapping components with high contrast
                       </Text>
 
@@ -746,134 +1002,6 @@ export default function Test() {
                         <Callout.Text>
                           Ambiguous voice of a heart which prefers{' '}
                           <Code variant="ghost">kiwi bowls</Code> to a <Link href="#">zephyr</Link>.
-                        </Callout.Text>
-                      </Callout.Root>
-                    </Flex>
-
-                    <Flex direction="column" align="start" gap="4">
-                      <Text color="gray" size="2">
-                        All wrapping components with {'color="indigo"'} and inline components with
-                        high contrast
-                      </Text>
-
-                      <Heading color="indigo">
-                        Ambiguous voice of a heart which prefers{' '}
-                        <Code highContrast variant="ghost">
-                          kiwi bowls
-                        </Code>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Heading>
-
-                      <Text color="indigo">
-                        Ambiguous voice of a heart which prefers{' '}
-                        <Code highContrast variant="ghost">
-                          kiwi bowls
-                        </Code>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Text>
-
-                      <Text color="indigo">
-                        Ambiguous voice of a heart which prefers{' '}
-                        <Link highContrast href="#">
-                          <Code highContrast variant="ghost">
-                            kiwi bowls
-                          </Code>
-                        </Link>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Text>
-
-                      <Text color="indigo">
-                        Ambiguous voice of a heart which{' '}
-                        <Link highContrast href="#">
-                          prefers{' '}
-                          <Code highContrast variant="ghost">
-                            kiwi bowls
-                          </Code>
-                        </Link>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Text>
-
-                      <Blockquote color="indigo">
-                        Ambiguous voice of a heart which prefers{' '}
-                        <Code highContrast variant="ghost">
-                          kiwi bowls
-                        </Code>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Blockquote>
-
-                      <Blockquote color="indigo">
-                        Ambiguous voice of a heart which prefers{' '}
-                        <Link highContrast href="#">
-                          <Code variant="ghost">kiwi bowls</Code>
-                        </Link>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Blockquote>
-
-                      <Blockquote color="indigo">
-                        Ambiguous voice of a heart which{' '}
-                        <Link highContrast href="#">
-                          prefers{' '}
-                          <Code highContrast variant="ghost">
-                            kiwi bowls
-                          </Code>
-                        </Link>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Blockquote>
-
-                      <Code size="2" color="indigo">
-                        Ambiguous voice of a heart which{' '}
-                        <Link highContrast href="#">
-                          prefers{' '}
-                          <Code highContrast variant="ghost">
-                            kiwi bowls
-                          </Code>
-                        </Link>{' '}
-                        to a{' '}
-                        <Link highContrast href="#">
-                          zephyr
-                        </Link>
-                        .
-                      </Code>
-
-                      <Callout.Root color="indigo">
-                        <Callout.Text>
-                          Ambiguous voice of a heart which prefers{' '}
-                          <Code highContrast variant="ghost">
-                            kiwi bowls
-                          </Code>{' '}
-                          to a{' '}
-                          <Link highContrast href="#">
-                            zephyr
-                          </Link>
-                          .
                         </Callout.Text>
                       </Callout.Root>
                     </Flex>

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.3
+
+- Fix a regression when `Link` would use an automatic high-contrast color when an explicit `color` value was used.
+- Fix a regression when `Link` would not use the correct text selection and focus color when nested in gray text.
+- Remove an unnecessary `data-accent-color` attribute from components where it had no practical effect to be there.
+- Rework the internals of the `color` prop definition.
+
 ## 3.0.2
 
 - Remove unnecessary browser prefixes from the CSS, reducing the bundle size by 17 KB

--- a/packages/radix-ui-themes/src/components/avatar.props.ts
+++ b/packages/radix-ui-themes/src/components/avatar.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   radiusPropDef,
 } from '../props/index.js';
@@ -13,7 +13,7 @@ const avatarPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '3', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
   fallback: { type: 'ReactNode', required: true },

--- a/packages/radix-ui-themes/src/components/badge.props.ts
+++ b/packages/radix-ui-themes/src/components/badge.props.ts
@@ -1,4 +1,4 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
+import { accentColorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 import { asChildPropDef } from '../props/as-child.prop.js';
 
@@ -9,7 +9,7 @@ const badgePropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '1', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
 } satisfies {

--- a/packages/radix-ui-themes/src/components/base-button.props.ts
+++ b/packages/radix-ui-themes/src/components/base-button.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   radiusPropDef,
 } from '../props/index.js';
@@ -13,7 +13,7 @@ const baseButtonPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'solid' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
   loading: { type: 'boolean', className: 'rt-loading', default: false },

--- a/packages/radix-ui-themes/src/components/base-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/base-menu.props.ts
@@ -1,9 +1,4 @@
-import {
-  asChildPropDef,
-  colorPropDef,
-  highContrastPropDef,
-  inheritedColorPropDef,
-} from '../props/index.js';
+import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const contentSizes = ['1', '2'] as const;
@@ -32,21 +27,21 @@ const baseMenuContentPropDefs = {
 
 const baseMenuItemPropDefs = {
   ...asChildPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   shortcut: { type: 'string' },
 } satisfies {
   shortcut: PropDef<string>;
 };
 
 const baseMenuCheckboxItemPropDefs = {
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   shortcut: { type: 'string' },
 } satisfies {
   shortcut: PropDef<string>;
 };
 
 const baseMenuRadioItemPropDefs = {
-  ...inheritedColorPropDef,
+  ...colorPropDef,
 };
 
 export {

--- a/packages/radix-ui-themes/src/components/blockquote.props.ts
+++ b/packages/radix-ui-themes/src/components/blockquote.props.ts
@@ -1,7 +1,7 @@
 import {
   asChildPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   truncatePropDef,
   weightPropDef,
@@ -20,7 +20,7 @@ const blockquotePropDefs = {
     responsive: true,
   },
   ...weightPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -1,4 +1,5 @@
 .rt-CalloutRoot {
+  box-sizing: border-box;
   display: grid;
   align-items: flex-start;
   justify-content: flex-start;
@@ -14,7 +15,7 @@
   display: flex;
   align-items: center;
   grid-column-start: -2;
-  height: var(--line-height);
+  height: var(--callout-icon-height);
 }
 
 /* Anything that’s not an icon goes to the right of the icon */
@@ -28,10 +29,6 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-.rt-CalloutRoot {
-  box-sizing: border-box;
-}
-
 @breakpoints {
   .rt-CalloutRoot {
     &:where(.rt-r-size-1) {
@@ -39,18 +36,21 @@
       column-gap: var(--space-2);
       padding: var(--space-3);
       border-radius: var(--radius-3);
+      --callout-icon-height: var(--line-height-2);
     }
     &:where(.rt-r-size-2) {
       row-gap: var(--space-2);
       column-gap: var(--space-3);
       padding: var(--space-4);
       border-radius: var(--radius-4);
+      --callout-icon-height: var(--line-height-2);
     }
     &:where(.rt-r-size-3) {
       row-gap: var(--space-3);
       column-gap: var(--space-4);
       padding: var(--space-5);
       border-radius: var(--radius-5);
+      --callout-icon-height: var(--line-height-3);
     }
   }
 }

--- a/packages/radix-ui-themes/src/components/callout.props.ts
+++ b/packages/radix-ui-themes/src/components/callout.props.ts
@@ -1,4 +1,4 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
+import { asChildPropDef, accentColorPropDef, highContrastPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const sizes = ['1', '2', '3'] as const;
@@ -8,7 +8,7 @@ const calloutRootPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/callout.tsx
+++ b/packages/radix-ui-themes/src/components/callout.tsx
@@ -55,16 +55,8 @@ type CalloutIconElement = React.ElementRef<'div'>;
 interface CalloutIconProps extends ComponentPropsWithout<'div', RemovedProps> {}
 const CalloutIcon = React.forwardRef<CalloutIconElement, CalloutIconProps>(
   ({ className, ...props }, forwardedRef) => {
-    const { color, size, highContrast } = React.useContext(CalloutContext);
     return (
-      <Text
-        asChild
-        color={color}
-        size={mapResponsiveProp(size, mapCalloutSizeToTextSize)}
-        highContrast={highContrast}
-      >
-        <div {...props} className={classNames('rt-CalloutIcon', className)} ref={forwardedRef} />
-      </Text>
+      <div {...props} className={classNames('rt-CalloutIcon', className)} ref={forwardedRef} />
     );
   }
 );
@@ -74,13 +66,11 @@ type CalloutTextElement = React.ElementRef<'p'>;
 type CalloutTextProps = ComponentPropsAs<typeof Text, 'p'>;
 const CalloutText = React.forwardRef<CalloutTextElement, CalloutTextProps>(
   ({ className, ...props }, forwardedRef) => {
-    const { color, size, highContrast } = React.useContext(CalloutContext);
+    const { size } = React.useContext(CalloutContext);
     return (
       <Text
         as="p"
         size={mapResponsiveProp(size, mapCalloutSizeToTextSize)}
-        color={color}
-        highContrast={highContrast}
         {...props}
         asChild={false}
         ref={forwardedRef}

--- a/packages/radix-ui-themes/src/components/callout.tsx
+++ b/packages/radix-ui-themes/src/components/callout.tsx
@@ -13,20 +13,17 @@ import { GetPropDefTypes, MarginProps } from '../props/index.js';
 
 type CalloutRootOwnProps = GetPropDefTypes<typeof calloutRootPropDefs>;
 
-type CalloutContextValue = CalloutRootOwnProps;
+type CalloutContextValue = { size?: CalloutRootOwnProps['size'] };
 const CalloutContext = React.createContext<CalloutContextValue>({});
 
 type CalloutRootElement = React.ElementRef<'div'>;
 interface CalloutRootProps
   extends ComponentPropsWithout<'div', RemovedProps>,
     MarginProps,
-    CalloutContextValue {}
+    CalloutRootOwnProps {}
 const CalloutRoot = React.forwardRef<CalloutRootElement, CalloutRootProps>(
   (props, forwardedRef) => {
-    const {
-      size = calloutRootPropDefs.size.default,
-      highContrast = calloutRootPropDefs.highContrast.default,
-    } = props;
+    const { size = calloutRootPropDefs.size.default } = props;
     const { asChild, children, className, color, ...rootProps } = extractProps(
       props,
       calloutRootPropDefs,
@@ -40,9 +37,7 @@ const CalloutRoot = React.forwardRef<CalloutRootElement, CalloutRootProps>(
         className={classNames('rt-CalloutRoot', className)}
         ref={forwardedRef}
       >
-        <CalloutContext.Provider
-          value={React.useMemo(() => ({ size, color, highContrast }), [size, color, highContrast])}
-        >
+        <CalloutContext.Provider value={React.useMemo(() => ({ size }), [size])}>
           {children}
         </CalloutContext.Provider>
       </Comp>

--- a/packages/radix-ui-themes/src/components/code.props.ts
+++ b/packages/radix-ui-themes/src/components/code.props.ts
@@ -1,6 +1,6 @@
 import {
   weightPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   textWrapPropDef,
   truncatePropDef,
@@ -22,7 +22,7 @@ const codePropDefs = {
   },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
   ...weightPropDef,
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,

--- a/packages/radix-ui-themes/src/components/code.tsx
+++ b/packages/radix-ui-themes/src/components/code.tsx
@@ -20,7 +20,7 @@ const Code = React.forwardRef<CodeElement, CodeProps>((props, forwardedRef) => {
     codePropDefs,
     marginPropDefs
   );
-  // Code ghost color prop should work as an inherited color by default
+  // Code ghost color prop should work as text color by default
   const resolvedColor = props.variant === 'ghost' ? color || undefined : color;
   const Comp = asChild ? Slot : 'code';
   return (

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,7 +1,7 @@
 import {
   widthPropDefs,
   leadingTrimPropDef,
-  colorPropDef,
+  inheritedColorPropDef,
   highContrastPropDef,
 } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
@@ -48,7 +48,7 @@ const dataListItemPropDefs = {
 
 const dataListLabelPropDefs = {
   ...widthPropDefs,
-  ...colorPropDef,
+  ...inheritedColorPropDef,
   ...highContrastPropDef,
 };
 

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,7 +1,7 @@
 import {
   widthPropDefs,
   leadingTrimPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   highContrastPropDef,
 } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
@@ -48,7 +48,7 @@ const dataListItemPropDefs = {
 
 const dataListLabelPropDefs = {
   ...widthPropDefs,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 };
 

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -64,7 +64,7 @@ const DataListLabel = React.forwardRef<DataListLabelElement, DataListLabelProps>
     return (
       <dt
         {...labelProps}
-        data-accent-color={color || undefined}
+        data-accent-color={color}
         ref={forwardedRef}
         className={classNames('rt-DataListLabel', className)}
       />

--- a/packages/radix-ui-themes/src/components/heading.props.ts
+++ b/packages/radix-ui-themes/src/components/heading.props.ts
@@ -2,7 +2,7 @@ import {
   textAlignPropDef,
   asChildPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   leadingTrimPropDef,
   truncatePropDef,
@@ -28,7 +28,7 @@ const headingPropDefs = {
   ...leadingTrimPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 } satisfies {
   as: PropDef<(typeof as)[number]>;

--- a/packages/radix-ui-themes/src/components/heading.tsx
+++ b/packages/radix-ui-themes/src/components/heading.tsx
@@ -26,7 +26,7 @@ const Heading = React.forwardRef<HeadingElement, HeadingProps>((props, forwarded
   } = extractProps(props, headingPropDefs, marginPropDefs);
   return (
     <Slot
-      data-accent-color={color || undefined}
+      data-accent-color={color}
       {...headingProps}
       ref={forwardedRef}
       className={classNames('rt-Heading', className)}

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -17,7 +17,7 @@
     outline-offset: 2px;
   }
 
-  :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) & {
+  :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) &:where([data-accent-color='']) {
     color: var(--accent-12);
   }
 }
@@ -58,7 +58,7 @@
       }
 
       &:where(.rt-high-contrast),
-      :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) & {
+      :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) &:where([data-accent-color='']) {
         text-decoration-line: underline;
         text-decoration-color: var(--accent-a6);
 

--- a/packages/radix-ui-themes/src/components/link.props.ts
+++ b/packages/radix-ui-themes/src/components/link.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   textWrapPropDef,
   leadingTrimPropDef,
@@ -25,7 +25,7 @@ const linkPropDefs = {
   ...truncatePropDef,
   ...textWrapPropDef,
   underline: { type: 'enum', className: 'rt-underline', values: underline, default: 'auto' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/progress.props.ts
+++ b/packages/radix-ui-themes/src/components/progress.props.ts
@@ -1,4 +1,4 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef, widthPropDefs } from '../props/index.js';
+import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const sizes = ['1', '2', '3'] as const;

--- a/packages/radix-ui-themes/src/components/separator.props.ts
+++ b/packages/radix-ui-themes/src/components/separator.props.ts
@@ -1,5 +1,5 @@
 import { colorPropDef } from '../props/index.js';
-import type { PropDef, accentColors } from '../props/index.js';
+import type { PropDef } from '../props/index.js';
 
 const orientationValues = ['horizontal', 'vertical'] as const;
 const sizes = ['1', '2', '3', '4'] as const;

--- a/packages/radix-ui-themes/src/components/text-field.props.ts
+++ b/packages/radix-ui-themes/src/components/text-field.props.ts
@@ -1,10 +1,5 @@
 import type { PropDef } from '../props/index.js';
-import {
-  colorPropDef,
-  inheritedColorPropDef,
-  paddingPropDefs,
-  radiusPropDef,
-} from '../props/index.js';
+import { colorPropDef, paddingPropDefs, radiusPropDef } from '../props/index.js';
 import { flexPropDefs } from './flex.props.js';
 
 const sizes = ['1', '2', '3'] as const;
@@ -24,7 +19,7 @@ const sides = ['left', 'right'] as const;
 
 const textFieldSlotPropDefs = {
   side: { type: 'enum', values: sides },
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   gap: flexPropDefs.gap,
   px: paddingPropDefs.px,
   pl: paddingPropDefs.pl,

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -3,7 +3,7 @@ import {
   textAlignPropDef,
   leadingTrimPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   truncatePropDef,
   asChildPropDef,
@@ -27,7 +27,7 @@ const textPropDefs = {
   ...leadingTrimPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 } satisfies {
   as: PropDef<(typeof as)[number]>;

--- a/packages/radix-ui-themes/src/components/text.tsx
+++ b/packages/radix-ui-themes/src/components/text.tsx
@@ -28,7 +28,7 @@ const Text = React.forwardRef<TextElement, TextProps>((props, forwardedRef) => {
   } = extractProps(props, textPropDefs, marginPropDefs);
   return (
     <Slot
-      data-accent-color={color || undefined}
+      data-accent-color={color}
       {...textProps}
       ref={forwardedRef}
       className={classNames('rt-Text', className)}

--- a/packages/radix-ui-themes/src/props/color.prop.ts
+++ b/packages/radix-ui-themes/src/props/color.prop.ts
@@ -9,32 +9,27 @@ const colorPropDef = {
   color: {
     type: 'enum',
     values: accentColors,
-    default: '' as (typeof accentColors)[number] | undefined,
-  },
-} satisfies {
-  color: PropDef<(typeof accentColors)[number]>;
-};
-
-// Difference between `colorPropDef` and `inheritedColorPropDef` is in the defaults:
-//
-// `default: ''` sets an empty `data-accent-color` attribute to define the right
-// high-contrast colors for descendants that inherit a colour by default.
-//
-// `default: undefined` allows components like Text to inherit color directly,
-// but respond to `data-accent-color` on parent when it's `highContrast`.
-const inheritedColorPropDef = {
-  color: {
-    type: 'enum',
-    values: accentColors,
     default: undefined as (typeof accentColors)[number] | undefined,
   },
 } satisfies {
   color: PropDef<(typeof accentColors)[number]>;
 };
 
+// 1. When used on components that compose Text, sets the color of the text to the current accent.
+// 2. Defines accent color for descendant text components with `highContrast={true}`.
+const accentColorPropDef = {
+  color: {
+    type: 'enum',
+    values: accentColors,
+    default: '' as (typeof accentColors)[number],
+  },
+} satisfies {
+  color: PropDef<(typeof accentColors)[number]>;
+};
+
 export {
+  accentColorPropDef,
   colorPropDef,
-  inheritedColorPropDef,
   //
   accentColors,
   grayColors,

--- a/packages/radix-ui-themes/src/styles/tokens/color.css
+++ b/packages/radix-ui-themes/src/styles/tokens/color.css
@@ -72,7 +72,7 @@
 /* * * * * * * * * * * * * * * * * * * */
 
 .radix-themes,
-[data-accent-color]:where(:not([data-accent-color='gray'])) {
+[data-accent-color]:where(:not([data-accent-color=''], [data-accent-color='gray'])) {
   --focus-1: var(--accent-1);
   --focus-2: var(--accent-2);
   --focus-3: var(--accent-3);


### PR DESCRIPTION
- Fixes a regression when links would automatically become high-contrast when that wasn't desired, e.g [WorkOS dashboard sign-in](https://dashboard.workos.com/signin):

  ![image](https://github.com/radix-ui/themes/assets/8441036/1a1dbe93-d46a-4c97-a318-102a25d0a9a3)

- Fixes a regression when nested high-contrast gray text would not use the correct selection background color:

  <img width="1185" alt="image" src="https://github.com/radix-ui/themes/assets/8441036/44b8fcae-449c-45cb-88f8-2c0a0643a528">

- Simplify some of the color prop mechanics