### PR TITLE
Rename color prop defs for clarity

### DIFF
--- a/packages/radix-ui-themes/src/components/avatar.props.ts
+++ b/packages/radix-ui-themes/src/components/avatar.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   radiusPropDef,
 } from '../props/index.js';
@@ -13,7 +13,7 @@ const avatarPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '3', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
   fallback: { type: 'ReactNode', required: true },

--- a/packages/radix-ui-themes/src/components/badge.props.ts
+++ b/packages/radix-ui-themes/src/components/badge.props.ts
@@ -1,4 +1,4 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
+import { accentColorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 import { asChildPropDef } from '../props/as-child.prop.js';
 
@@ -9,7 +9,7 @@ const badgePropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '1', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
 } satisfies {

--- a/packages/radix-ui-themes/src/components/base-button.props.ts
+++ b/packages/radix-ui-themes/src/components/base-button.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   radiusPropDef,
 } from '../props/index.js';
@@ -13,7 +13,7 @@ const baseButtonPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'solid' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...radiusPropDef,
   loading: { type: 'boolean', className: 'rt-loading', default: false },

--- a/packages/radix-ui-themes/src/components/base-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/base-menu.props.ts
@@ -1,9 +1,4 @@
-import {
-  asChildPropDef,
-  colorPropDef,
-  highContrastPropDef,
-  inheritedColorPropDef,
-} from '../props/index.js';
+import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const contentSizes = ['1', '2'] as const;
@@ -32,21 +27,21 @@ const baseMenuContentPropDefs = {
 
 const baseMenuItemPropDefs = {
   ...asChildPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   shortcut: { type: 'string' },
 } satisfies {
   shortcut: PropDef<string>;
 };
 
 const baseMenuCheckboxItemPropDefs = {
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   shortcut: { type: 'string' },
 } satisfies {
   shortcut: PropDef<string>;
 };
 
 const baseMenuRadioItemPropDefs = {
-  ...inheritedColorPropDef,
+  ...colorPropDef,
 };
 
 export {

--- a/packages/radix-ui-themes/src/components/blockquote.props.ts
+++ b/packages/radix-ui-themes/src/components/blockquote.props.ts
@@ -1,7 +1,7 @@
 import {
   asChildPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   truncatePropDef,
   weightPropDef,
@@ -20,7 +20,7 @@ const blockquotePropDefs = {
     responsive: true,
   },
   ...weightPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,

--- a/packages/radix-ui-themes/src/components/callout.props.ts
+++ b/packages/radix-ui-themes/src/components/callout.props.ts
@@ -1,4 +1,4 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
+import { asChildPropDef, accentColorPropDef, highContrastPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const sizes = ['1', '2', '3'] as const;
@@ -8,7 +8,7 @@ const calloutRootPropDefs = {
   ...asChildPropDef,
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/code.props.ts
+++ b/packages/radix-ui-themes/src/components/code.props.ts
@@ -1,6 +1,6 @@
 import {
   weightPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   textWrapPropDef,
   truncatePropDef,
@@ -22,7 +22,7 @@ const codePropDefs = {
   },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'soft' },
   ...weightPropDef,
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,7 +1,7 @@
 import {
   widthPropDefs,
   leadingTrimPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   highContrastPropDef,
 } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
@@ -48,7 +48,7 @@ const dataListItemPropDefs = {
 
 const dataListLabelPropDefs = {
   ...widthPropDefs,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 };
 

--- a/packages/radix-ui-themes/src/components/heading.props.ts
+++ b/packages/radix-ui-themes/src/components/heading.props.ts
@@ -2,7 +2,7 @@ import {
   textAlignPropDef,
   asChildPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   leadingTrimPropDef,
   truncatePropDef,
@@ -28,7 +28,7 @@ const headingPropDefs = {
   ...leadingTrimPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 } satisfies {
   as: PropDef<(typeof as)[number]>;

--- a/packages/radix-ui-themes/src/components/link.props.ts
+++ b/packages/radix-ui-themes/src/components/link.props.ts
@@ -1,6 +1,6 @@
 import {
   asChildPropDef,
-  colorPropDef,
+  accentColorPropDef,
   highContrastPropDef,
   textWrapPropDef,
   leadingTrimPropDef,
@@ -25,7 +25,7 @@ const linkPropDefs = {
   ...truncatePropDef,
   ...textWrapPropDef,
   underline: { type: 'enum', className: 'rt-underline', values: underline, default: 'auto' },
-  ...colorPropDef,
+  ...accentColorPropDef,
   ...highContrastPropDef,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;

--- a/packages/radix-ui-themes/src/components/progress.props.ts
+++ b/packages/radix-ui-themes/src/components/progress.props.ts
@@ -1,4 +1,4 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef, widthPropDefs } from '../props/index.js';
+import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
 import type { PropDef } from '../props/index.js';
 
 const sizes = ['1', '2', '3'] as const;

--- a/packages/radix-ui-themes/src/components/separator.props.ts
+++ b/packages/radix-ui-themes/src/components/separator.props.ts
@@ -1,5 +1,5 @@
 import { colorPropDef } from '../props/index.js';
-import type { PropDef, accentColors } from '../props/index.js';
+import type { PropDef } from '../props/index.js';
 
 const orientationValues = ['horizontal', 'vertical'] as const;
 const sizes = ['1', '2', '3', '4'] as const;

--- a/packages/radix-ui-themes/src/components/text-field.props.ts
+++ b/packages/radix-ui-themes/src/components/text-field.props.ts
@@ -1,10 +1,5 @@
 import type { PropDef } from '../props/index.js';
-import {
-  colorPropDef,
-  inheritedColorPropDef,
-  paddingPropDefs,
-  radiusPropDef,
-} from '../props/index.js';
+import { colorPropDef, paddingPropDefs, radiusPropDef } from '../props/index.js';
 import { flexPropDefs } from './flex.props.js';
 
 const sizes = ['1', '2', '3'] as const;
@@ -24,7 +19,7 @@ const sides = ['left', 'right'] as const;
 
 const textFieldSlotPropDefs = {
   side: { type: 'enum', values: sides },
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   gap: flexPropDefs.gap,
   px: paddingPropDefs.px,
   pl: paddingPropDefs.pl,

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -3,7 +3,7 @@ import {
   textAlignPropDef,
   leadingTrimPropDef,
   highContrastPropDef,
-  inheritedColorPropDef,
+  colorPropDef,
   textWrapPropDef,
   truncatePropDef,
   asChildPropDef,
@@ -27,7 +27,7 @@ const textPropDefs = {
   ...leadingTrimPropDef,
   ...truncatePropDef,
   ...textWrapPropDef,
-  ...inheritedColorPropDef,
+  ...colorPropDef,
   ...highContrastPropDef,
 } satisfies {
   as: PropDef<(typeof as)[number]>;

--- a/packages/radix-ui-themes/src/props/color.prop.ts
+++ b/packages/radix-ui-themes/src/props/color.prop.ts
@@ -9,32 +9,27 @@ const colorPropDef = {
   color: {
     type: 'enum',
     values: accentColors,
-    default: '' as (typeof accentColors)[number] | undefined,
-  },
-} satisfies {
-  color: PropDef<(typeof accentColors)[number]>;
-};
-
-// Difference between `colorPropDef` and `inheritedColorPropDef` is in the defaults:
-//
-// `default: ''` sets an empty `data-accent-color` attribute to define the right
-// high-contrast colors for descendants that inherit a colour by default.
-//
-// `default: undefined` allows components like Text to inherit color directly,
-// but respond to `data-accent-color` on parent when it's `highContrast`.
-const inheritedColorPropDef = {
-  color: {
-    type: 'enum',
-    values: accentColors,
     default: undefined as (typeof accentColors)[number] | undefined,
   },
 } satisfies {
   color: PropDef<(typeof accentColors)[number]>;
 };
 
+// 1. When used on components that compose Text, sets the color of the text to the current accent.
+// 2. Defines accent color for descendant text components with `highContrast={true}`.
+const accentColorPropDef = {
+  color: {
+    type: 'enum',
+    values: accentColors,
+    default: '' as (typeof accentColors)[number],
+  },
+} satisfies {
+  color: PropDef<(typeof accentColors)[number]>;
+};
+
 export {
+  accentColorPropDef,
   colorPropDef,
-  inheritedColorPropDef,
   //
   accentColors,
   grayColors,


### PR DESCRIPTION
Spinning off from https://github.com/radix-ui/themes/pull/469, I found that the naming and application of color prop defs was unintuitive and took me a bit to wrap my head around after we haven't worked in this area for a bit.

This refactors color prop defs so that:
- `inheritedColorPropDef` is renamed to `colorPropDef`, which should be our default colour prop def choice. This one doesn't yield any `data-accent-color` attribute when there is no explicit value.
- The original `colorPropDef` renamed to `accentColorPropDef`. This one yields an empty `data-accent-color` attribute when there is no explicit value, which is used for coloured text-based components and when we need to indicate that nested high-contrast text should use `--accent-12`

Some components also had an unnecessary `data-accent-color` attribute, which this PR removes