### PR TITLE
Nicer text field and text area autofill and disabled styles

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -4,8 +4,10 @@
 
 - Fix a regression when `Link` would use an automatic high-contrast color when an explicit `color` value was used.
 - Fix a regression when `Link` would not use the correct text selection and focus color when nested in gray text.
+- Tweak `Link` tap highlight style
 - Remove an unnecessary `data-accent-color` attribute from components where it had no practical effect to be there.
 - Rework the internals of the `color` prop definition.
+- Rework the autofilled and disabled colors for `TextField` and `TextArea`
 
 ## 3.0.2
 

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -44,9 +44,8 @@
     @media (pointer: coarse) {
       /* Better -webkit-tap-highlight-color */
       &:where(:active:not(:focus-visible, [data-state='open'])) {
-        border-radius: calc(0.1em * var(--radius-factor));
-        outline: 1.5em solid var(--accent-a4);
-        outline-offset: -1em;
+        outline: 0.75em solid var(--accent-a4);
+        outline-offset: -0.6em;
       }
     }
 

--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -140,13 +140,15 @@
 
   /* prettier-ignore */
   &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
-    background-color: var(--focus-a3);
-    box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
+    /* Blend with focus color */
+    background-image: linear-gradient(var(--focus-a2), var(--focus-a2));
+    box-shadow: inset 0 0 0 1px var(--focus-a5), inset 0 0 0 1px var(--gray-a4);
   }
 
   &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
     /* Blend with grey */
-    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+    background-image: linear-gradient(var(--gray-a2), var(--gray-a2));
+    box-shadow: inset 0 0 0 var(--text-area-border-width) var(--gray-a6);
   }
 }
 
@@ -168,13 +170,14 @@
 
   /* prettier-ignore */
   &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
-    background-color: var(--focus-a3);
-    box-shadow: inset 0 0 0 1px var(--focus-a3),  var(--shadow-1);
+    /* Blend with focus color */
+    background-image: linear-gradient(var(--focus-a2), var(--focus-a2));
+    box-shadow: inset 0 0 0 1px var(--focus-a5), inset 0 0 0 1px var(--gray-a4);
   }
 
   &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
     /* Blend with grey */
-    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+    background-image: linear-gradient(var(--gray-a2), var(--gray-a2));
   }
 }
 
@@ -203,11 +206,12 @@
 
   /* prettier-ignore */
   &:where(:has(.rt-TextAreaInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
-    background-color: var(--accent-a4);
+    /* Use gray autofill color when component color is gray */
+    box-shadow: inset 0 0 0 1px var(--accent-a5), inset 0 0 0 1px var(--gray-a3);
   }
 
   &:where(:has(.rt-TextAreaInput:where(:disabled, :read-only))) {
-    background-color: var(--gray-a4);
+    background-color: var(--gray-a3);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -302,13 +302,15 @@
 
   /* prettier-ignore */
   &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
-    background-color: var(--focus-a3);
-    box-shadow: inset 0 0 0 1px var(--focus-a3), inset 0 0 0 1px var(--gray-a6);
+    /* Blend with focus color */
+    background-image: linear-gradient(var(--focus-a2), var(--focus-a2));
+    box-shadow: inset 0 0 0 1px var(--focus-a5), inset 0 0 0 1px var(--gray-a4);
   }
 
   &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
     /* Blend with grey */
-    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+    background-image: linear-gradient(var(--gray-a2), var(--gray-a2));
+    box-shadow: inset 0 0 0 var(--text-field-border-width) var(--gray-a6);
   }
 }
 
@@ -341,13 +343,14 @@
 
   /* prettier-ignore */
   &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
-    background-color: var(--focus-a3);
-    box-shadow: inset 0 0 0 1px var(--focus-a3), var(--shadow-1);
+    /* Blend with focus color */
+    background-image: linear-gradient(var(--focus-a2), var(--focus-a2));
+    box-shadow: inset 0 0 0 1px var(--focus-a5), inset 0 0 0 1px var(--gray-a4);
   }
 
   &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
     /* Blend with grey */
-    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+    background-image: linear-gradient(var(--gray-a2), var(--gray-a2));
   }
 }
 
@@ -379,11 +382,11 @@
   /* prettier-ignore */
   &:where(:has(.rt-TextFieldInput:where(:autofill, [data-com-onepassword-filled]):not(:disabled, :read-only))) {
     /* Use gray autofill color when component color is gray */
-    background-color: var(--accent-a4);
+    box-shadow: inset 0 0 0 1px var(--accent-a5), inset 0 0 0 1px var(--gray-a3);
   }
 
   &:where(:has(.rt-TextFieldInput:where(:disabled, :read-only))) {
-    background-color: var(--gray-a4);
+    background-color: var(--gray-a3);
   }
 }
 

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -21,11 +21,8 @@
     @media (pointer: coarse) {
       -webkit-tap-highlight-color: transparent;
       &:where(:active) {
-        border-radius: calc(0.1em * var(--radius-factor));
-        outline-color: var(--gray-a4);
-        outline-width: 1.5em;
-        outline-style: solid;
-        outline-offset: -1em;
+        outline: 0.75em solid var(--gray-a4);
+        outline-offset: -0.6em;
       }
     }
   }


### PR DESCRIPTION
- Rework the autofilled and disabled colors for `TextField` and `TextArea`
  - Both felt a bit obnoxious when actually using apps built with them
- Tweak `Link` tap highlight style

Tap highlight before/after:
<img src="https://github.com/radix-ui/themes/assets/8441036/2c15fa73-49fd-4fa8-896b-75dafefcf13e" width="300" />
<img src="https://github.com/radix-ui/themes/assets/8441036/054529a4-eb94-466f-82b8-57475dc89ecf" width="300" />
