### PR TITLE
Visually render the Progress `max` prop

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.4 (unreleased)
+
+- Support the `max` prop on the `Progress` component
+
 ## 3.0.3
 
 - Fix an issue when the theme `grayColor` setting would have no effect in combination with explicit `appearance="light"` or `appearance="dark"` values

--- a/packages/radix-ui-themes/src/components/progress.css
+++ b/packages/radix-ui-themes/src/components/progress.css
@@ -1,5 +1,6 @@
 .rt-ProgressRoot {
   --progress-value: 0;
+  --progress-max: 100;
   --progress-duration: 5s;
   pointer-events: none;
   position: relative;
@@ -32,7 +33,7 @@
   height: 100%;
   width: 100%;
 
-  transform: scaleX(calc(var(--progress-value) / 100));
+  transform: scaleX(calc(var(--progress-value) / var(--progress-max)));
   transform-origin: left center;
   transition: transform 120ms;
 

--- a/packages/radix-ui-themes/src/components/progress.tsx
+++ b/packages/radix-ui-themes/src/components/progress.tsx
@@ -35,6 +35,7 @@ const Progress = React.forwardRef<ProgressElement, ProgressProps>((props, forwar
         {
           '--progress-duration': 'value' in progressProps ? undefined : duration,
           '--progress-value': 'value' in progressProps ? progressProps.value : undefined,
+          '--progress-max': 'max' in progressProps ? progressProps.max : undefined,
         },
         style
       )}


### PR DESCRIPTION
Thanks for providing radix themes, it's been a joy working with this package. This is my first PR here, so please let me know if I'm missing anything.

## Description

When rendering the Progress component, calculate the transform scaleX of the Progress.Indicator using the `max` prop supplied by the user.

The `max` prop is documented for the Progress primitive component and is used when determining the `aria-valuemax` and `aria-valuetext` attributes for the Progress div.

## Testing steps

I'm using this sample app to test the change

```javascript
import "@radix-ui/themes/styles.css";
import { useState } from "react";
import { Box, Flex, Progress, Slider, Text, Theme } from "@radix-ui/themes";

function App() {
  const [value, setValue] = useState([50]);
  const [max, setMax] = useState([100]);
  return (
    <Theme>
      <div
        style={{
          backgroundColor: "var(--accent-2)",
          minHeight: "100vh",
          display: "flex",
          flexDirection: "column",
          alignItems: "center",
          justifyContent: "center",
          fontSize: "calc(10px + 2vmin)",
        }}
      >
        <Flex direction={"column"} gap={"3"} style={{ width: "300px" }}>
          <Progress value={value[0]} max={max[0]} />

          <Flex gap={"2"}>
            <Box flexGrow={"1"}>
              <Text>Value {value[0]}</Text>
              <Slider value={value} onValueChange={setValue} max={300} />
            </Box>
            <Box flexGrow={"1"}>
              <Text>Max {max[0]}</Text>
              <Slider value={max} onValueChange={setMax} max={300} />
            </Box>
          </Flex>
        </Flex>
      </div>
    </Theme>
  );
}

export default App;
```

https://github.com/radix-ui/themes/assets/1524005/5d812392-05bb-4cef-aa63-8546e9d5a235

## Relates issues / PRs

None seen.
