### PR TITLE
Fix circular deps issue

### DIFF
--- a/packages/radix-ui-themes/.eslintrc.cjs
+++ b/packages/radix-ui-themes/.eslintrc.cjs
@@ -2,4 +2,22 @@ module.exports = {
   root: true,
   extends: ['custom', 'plugin:require-extensions/recommended'],
   plugins: ['require-extensions'],
+  rules: {
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        groups: [['builtin', 'external'], ['parent', 'sibling', 'index'], 'type'],
+      },
+    ],
+    'import/no-internal-modules': [
+      'error',
+      {
+        // Importing from barrel files may lead to circular dependencies within the package.
+        forbid: ['helpers/index.js', 'props/index.js'],
+      },
+    ],
+    'import/consistent-type-specifier-style': ['error', 'prefer-top-level'],
+    'import/newline-after-import': ['error', { count: 1 }],
+  },
 };

--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 3.0.4 (unreleased)
+## 3.0.4
 
+- Fix an issue when the Radix Themes package couldn’t be bundled with webpack because of a circular dependency within
 - Support the `max` prop on the `Progress` component
 
 ## 3.0.3

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -117,8 +117,8 @@
     "@radix-ui/react-use-callback-ref": "^1.0.1",
     "@radix-ui/react-use-controllable-state": "^1.0.1",
     "@radix-ui/react-visually-hidden": "^1.0.3",
-    "react-remove-scroll-bar": "2.3.4",
-    "classnames": "^2.3.2"
+    "classnames": "^2.3.2",
+    "react-remove-scroll-bar": "2.3.4"
   },
   "peerDependencies": {
     "@types/react": "*",
@@ -141,6 +141,7 @@
     "esbuild": "^0.20.0",
     "eslint": "^8.15.0",
     "eslint-config-custom": "*",
+    "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-require-extensions": "^0.1.3",
     "postcss": "^8.4.33",
     "postcss-cli": "^11.0.0",

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radix-ui/themes",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "type": "commonjs",
   "main": "./dist/cjs/index.js",
   "types": "./dist/cjs/index.d.ts",

--- a/packages/radix-ui-themes/src/components/alert-dialog.tsx
+++ b/packages/radix-ui-themes/src/components/alert-dialog.tsx
@@ -3,14 +3,20 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
 import { alertDialogContentPropDefs } from './alert-dialog.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Heading } from './heading.js';
 import { Text } from './text.js';
 import { Theme } from './theme.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 
-import type { ComponentPropsAs, ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { AlertDialogContentOwnProps } from '../props/index.js';
+import type { AlertDialogContentOwnProps } from './alert-dialog.props.js';
+import type {
+  ComponentPropsWithout,
+  RemovedProps,
+  ComponentPropsAs,
+} from '../helpers/component-props.js';
 
 interface AlertDialogRootProps
   extends React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Root> {}

--- a/packages/radix-ui-themes/src/components/avatar.props.ts
+++ b/packages/radix-ui-themes/src/components/avatar.props.ts
@@ -1,10 +1,9 @@
-import {
-  asChildPropDef,
-  accentColorPropDef,
-  highContrastPropDef,
-  radiusPropDef,
-} from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const variants = ['solid', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/avatar.tsx
+++ b/packages/radix-ui-themes/src/components/avatar.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
-import { avatarPropDefs } from './avatar.props.js';
-import { extractProps, getSubtree } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { avatarPropDefs } from './avatar.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { getSubtree } from '../helpers/get-subtree.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 interface AvatarProps extends MarginProps, AvatarImplProps {}
 const Avatar = React.forwardRef<AvatarImplElement, AvatarProps>((props, forwardedRef) => {

--- a/packages/radix-ui-themes/src/components/badge.props.ts
+++ b/packages/radix-ui-themes/src/components/badge.props.ts
@@ -1,6 +1,9 @@
-import { accentColorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
 import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['solid', 'soft', 'surface', 'outline'] as const;

--- a/packages/radix-ui-themes/src/components/badge.tsx
+++ b/packages/radix-ui-themes/src/components/badge.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { badgePropDefs } from './badge.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { badgePropDefs } from './badge.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type BadgeElement = React.ElementRef<'span'>;
 type BadgeOwnProps = GetPropDefTypes<typeof badgePropDefs>;

--- a/packages/radix-ui-themes/src/components/base-button.props.ts
+++ b/packages/radix-ui-themes/src/components/base-button.props.ts
@@ -1,10 +1,9 @@
-import {
-  asChildPropDef,
-  accentColorPropDef,
-  highContrastPropDef,
-  radiusPropDef,
-} from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4'] as const;
 const variants = ['classic', 'solid', 'soft', 'surface', 'outline', 'ghost'] as const;

--- a/packages/radix-ui-themes/src/components/base-button.tsx
+++ b/packages/radix-ui-themes/src/components/base-button.tsx
@@ -1,15 +1,18 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
+
 import { baseButtonPropDefs } from './base-button.props.js';
-import { extractProps, mapButtonSizeToSpinnerSize, mapResponsiveProp } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 import { Flex } from './flex.js';
 import { Spinner } from './spinner.js';
 import { VisuallyHidden } from './visually-hidden.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { mapResponsiveProp, mapButtonSizeToSpinnerSize } from '../helpers/map-prop-values.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type BaseButtonElement = React.ElementRef<'button'>;
 type BaseButtonOwnProps = GetPropDefTypes<typeof baseButtonPropDefs>;

--- a/packages/radix-ui-themes/src/components/base-checkbox.props.ts
+++ b/packages/radix-ui-themes/src/components/base-checkbox.props.ts
@@ -1,5 +1,7 @@
-import { colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/base-menu.props.ts
+++ b/packages/radix-ui-themes/src/components/base-menu.props.ts
@@ -1,5 +1,8 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const contentSizes = ['1', '2'] as const;
 const contentVariants = ['solid', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/base-radio.props.ts
+++ b/packages/radix-ui-themes/src/components/base-radio.props.ts
@@ -1,5 +1,7 @@
-import { colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/base-tab-list.props.ts
+++ b/packages/radix-ui-themes/src/components/base-tab-list.props.ts
@@ -1,5 +1,7 @@
-import { colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2'] as const;
 const wrapValues = ['nowrap', 'wrap', 'wrap-reverse'] as const;

--- a/packages/radix-ui-themes/src/components/blockquote.props.ts
+++ b/packages/radix-ui-themes/src/components/blockquote.props.ts
@@ -1,13 +1,11 @@
-import {
-  asChildPropDef,
-  highContrastPropDef,
-  colorPropDef,
-  textWrapPropDef,
-  truncatePropDef,
-  weightPropDef,
-} from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
+import { weightPropDef } from '../props/weight.prop.js';
 
-import type { PropDef } from '../props/index.js';
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 

--- a/packages/radix-ui-themes/src/components/blockquote.tsx
+++ b/packages/radix-ui-themes/src/components/blockquote.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
+
 import { Text } from './text.js';
 import { blockquotePropDefs } from './blockquote.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type BlockquoteElement = React.ElementRef<'blockquote'>;
 type BlockQuoteOwnProps = GetPropDefTypes<typeof blockquotePropDefs>;

--- a/packages/radix-ui-themes/src/components/box.props.ts
+++ b/packages/radix-ui-themes/src/components/box.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const as = ['div', 'span'] as const;
 const displayValues = ['none', 'inline', 'inline-block', 'block'] as const;

--- a/packages/radix-ui-themes/src/components/box.tsx
+++ b/packages/radix-ui-themes/src/components/box.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { Slot } from './slot.js';
 import { boxPropDefs } from './box.props.js';
-import { extractProps } from '../helpers/index.js';
-import { layoutPropDefs, marginPropDefs } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { layoutPropDefs } from '../props/layout.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { MarginProps, LayoutProps, BoxOwnProps } from '../props/index.js';
+import type { LayoutProps } from '../props/layout.props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { BoxOwnProps } from './box.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type BoxElement = React.ElementRef<'div'>;
 interface CommonBoxProps extends MarginProps, LayoutProps, BoxOwnProps {}

--- a/packages/radix-ui-themes/src/components/button.tsx
+++ b/packages/radix-ui-themes/src/components/button.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { BaseButton } from './base-button.js';
 
 type ButtonElement = React.ElementRef<typeof BaseButton>;

--- a/packages/radix-ui-themes/src/components/callout.props.ts
+++ b/packages/radix-ui-themes/src/components/callout.props.ts
@@ -1,5 +1,8 @@
-import { asChildPropDef, accentColorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['soft', 'surface', 'outline'] as const;

--- a/packages/radix-ui-themes/src/components/callout.tsx
+++ b/packages/radix-ui-themes/src/components/callout.tsx
@@ -3,13 +3,20 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
+
 import { Text } from './text.js';
 import { calloutRootPropDefs } from './callout.props.js';
-import { extractProps, mapCalloutSizeToTextSize, mapResponsiveProp } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { mapResponsiveProp, mapCalloutSizeToTextSize } from '../helpers/map-prop-values.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsAs, ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type {
+  ComponentPropsWithout,
+  RemovedProps,
+  ComponentPropsAs,
+} from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type CalloutRootOwnProps = GetPropDefTypes<typeof calloutRootPropDefs>;
 

--- a/packages/radix-ui-themes/src/components/card.props.ts
+++ b/packages/radix-ui-themes/src/components/card.props.ts
@@ -1,4 +1,6 @@
-import { asChildPropDef, type PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5'] as const;
 const variants = ['surface', 'classic', 'ghost'] as const;

--- a/packages/radix-ui-themes/src/components/card.tsx
+++ b/packages/radix-ui-themes/src/components/card.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { cardPropDefs } from './card.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { cardPropDefs } from './card.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type CardElement = React.ElementRef<'div'>;
 type CardOwnProps = GetPropDefTypes<typeof cardPropDefs>;

--- a/packages/radix-ui-themes/src/components/checkbox-cards.props.ts
+++ b/packages/radix-ui-themes/src/components/checkbox-cards.props.ts
@@ -1,6 +1,9 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
 import { gridPropDefs } from './grid.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['surface', 'classic'] as const;

--- a/packages/radix-ui-themes/src/components/checkbox-cards.tsx
+++ b/packages/radix-ui-themes/src/components/checkbox-cards.tsx
@@ -3,18 +3,20 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { createContextScope } from '@radix-ui/react-context';
+
 import * as CheckboxGroupPrimitive from './checkbox-group.primitive.js';
 import { createCheckboxGroupScope } from './checkbox-group.primitive.js';
 import { checkboxCardsRootPropDefs } from './checkbox-cards.props.js';
 import { baseCheckboxPropDefs } from './base-checkbox.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 import { Grid } from './grid.js';
 import { ThickCheckIcon } from './icons.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps, Responsive } from '../props/index.js';
 import type { Scope } from '@radix-ui/react-context';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { Responsive, GetPropDefTypes } from '../props/prop-def.js';
 
 const CHECKBOX_CARD_GROUP_NAME = 'CheckboxCards';
 

--- a/packages/radix-ui-themes/src/components/checkbox-group.props.ts
+++ b/packages/radix-ui-themes/src/components/checkbox-group.props.ts
@@ -1,4 +1,4 @@
-import { asChildPropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
 import { baseCheckboxPropDefs } from './base-checkbox.props.js';
 
 const checkboxGroupRootPropDefs = {

--- a/packages/radix-ui-themes/src/components/checkbox-group.tsx
+++ b/packages/radix-ui-themes/src/components/checkbox-group.tsx
@@ -3,17 +3,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { createContextScope } from '@radix-ui/react-context';
+
 import * as CheckboxGroupPrimitive from './checkbox-group.primitive.js';
 import { createCheckboxGroupScope } from './checkbox-group.primitive.js';
 import { checkboxGroupRootPropDefs } from './checkbox-group.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 import { ThickCheckIcon } from './icons.js';
 import { Text } from './text.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
 import type { Scope } from '@radix-ui/react-context';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 const CHECKBOX_GROUP_NAME = 'CheckboxGroup';
 

--- a/packages/radix-ui-themes/src/components/checkbox.tsx
+++ b/packages/radix-ui-themes/src/components/checkbox.tsx
@@ -3,13 +3,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
-import { checkboxPropDefs } from './checkbox.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
-import { ThickCheckIcon } from './icons.js';
 
-import type { ComponentPropsWithout } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { checkboxPropDefs } from './checkbox.props.js';
+import { ThickCheckIcon } from './icons.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type CheckboxElement = React.ElementRef<typeof CheckboxPrimitive.Root>;
 type CheckboxOwnProps = GetPropDefTypes<typeof checkboxPropDefs>;

--- a/packages/radix-ui-themes/src/components/code.props.ts
+++ b/packages/radix-ui-themes/src/components/code.props.ts
@@ -1,13 +1,11 @@
-import {
-  weightPropDef,
-  accentColorPropDef,
-  highContrastPropDef,
-  textWrapPropDef,
-  truncatePropDef,
-} from '../props/index.js';
 import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
+import { weightPropDef } from '../props/weight.prop.js';
 
-import type { PropDef } from '../props/index.js';
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const variants = ['solid', 'soft', 'outline', 'ghost'] as const;

--- a/packages/radix-ui-themes/src/components/code.tsx
+++ b/packages/radix-ui-themes/src/components/code.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { codePropDefs } from './code.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { codePropDefs } from './code.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type CodeElement = React.ElementRef<'code'>;
 type CodeOwnProps = GetPropDefTypes<typeof codePropDefs>;

--- a/packages/radix-ui-themes/src/components/container.props.ts
+++ b/packages/radix-ui-themes/src/components/container.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4'] as const;
 const displayValues = ['none', 'initial'] as const;

--- a/packages/radix-ui-themes/src/components/container.tsx
+++ b/packages/radix-ui-themes/src/components/container.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { containerPropDefs } from './container.props.js';
-import { extractProps, getSubtree } from '../helpers/index.js';
-import { heightPropDefs, layoutPropDefs, marginPropDefs, widthPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { MarginProps, LayoutProps, ContainerOwnProps } from '../props/index.js';
+import { containerPropDefs } from './container.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { getSubtree } from '../helpers/get-subtree.js';
+import { heightPropDefs } from '../props/height.props.js';
+import { layoutPropDefs } from '../props/layout.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { LayoutProps } from '../props/layout.props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { ContainerOwnProps } from './container.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type ContainerElement = React.ElementRef<'div'>;
 interface ContainerProps

--- a/packages/radix-ui-themes/src/components/context-menu.tsx
+++ b/packages/radix-ui-themes/src/components/context-menu.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { Slottable } from '@radix-ui/react-slot';
+
 import { ScrollArea } from './scroll-area.js';
 import {
   contextMenuContentPropDefs,
@@ -11,12 +12,13 @@ import {
   contextMenuCheckboxItemPropDefs,
   contextMenuRadioItemPropDefs,
 } from './context-menu.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Theme, useThemeContext } from './theme.js';
 import { ThickCheckIcon, ThickChevronRightIcon } from './icons.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 interface ContextMenuRootProps
   extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Root> {}

--- a/packages/radix-ui-themes/src/components/data-list.props.ts
+++ b/packages/radix-ui-themes/src/components/data-list.props.ts
@@ -1,10 +1,9 @@
-import {
-  widthPropDefs,
-  leadingTrimPropDef,
-  colorPropDef,
-  highContrastPropDef,
-} from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { leadingTrimPropDef } from '../props/leading-trim.prop.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const alignValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
 const orientationValues = ['horizontal', 'vertical'] as const;

--- a/packages/radix-ui-themes/src/components/data-list.tsx
+++ b/packages/radix-ui-themes/src/components/data-list.tsx
@@ -1,16 +1,18 @@
 import classNames from 'classnames';
 import * as React from 'react';
+
 import { Text } from './text.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 import {
   dataListRootPropDefs,
   dataListItemPropDefs,
   dataListLabelPropDefs,
 } from './data-list.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type DataListRootElement = HTMLDListElement;
 type DataListRootOwnProps = GetPropDefTypes<typeof dataListRootPropDefs>;

--- a/packages/radix-ui-themes/src/components/dialog.props.ts
+++ b/packages/radix-ui-themes/src/components/dialog.props.ts
@@ -1,5 +1,7 @@
-import { asChildPropDef, widthPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const contentSizes = ['1', '2', '3', '4'] as const;
 

--- a/packages/radix-ui-themes/src/components/dialog.tsx
+++ b/packages/radix-ui-themes/src/components/dialog.tsx
@@ -3,14 +3,20 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+
 import { dialogContentPropDefs } from './dialog.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Heading } from './heading.js';
 import { Text } from './text.js';
 import { Theme } from './theme.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 
-import type { ComponentPropsAs, ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { DialogContentOwnProps } from '../props/index.js';
+import type { DialogContentOwnProps } from './dialog.props.js';
+import type {
+  ComponentPropsWithout,
+  RemovedProps,
+  ComponentPropsAs,
+} from '../helpers/component-props.js';
 
 interface DialogRootProps extends ComponentPropsWithout<typeof DialogPrimitive.Root, 'modal'> {}
 const DialogRoot: React.FC<DialogRootProps> = (props) => <DialogPrimitive.Root {...props} modal />;

--- a/packages/radix-ui-themes/src/components/dropdown-menu.tsx
+++ b/packages/radix-ui-themes/src/components/dropdown-menu.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { Slottable } from '@radix-ui/react-slot';
+
 import { ScrollArea } from './scroll-area.js';
 import {
   dropdownMenuContentPropDefs,
@@ -11,13 +12,14 @@ import {
   dropdownMenuCheckboxItemPropDefs,
   dropdownMenuRadioItemPropDefs,
 } from './dropdown-menu.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Theme, useThemeContext } from './theme.js';
 import { ChevronDownIcon, ThickCheckIcon, ThickChevronRightIcon } from './icons.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
 import type { IconProps } from './icons.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 interface DropdownMenuRootProps
   extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root> {}

--- a/packages/radix-ui-themes/src/components/em.props.ts
+++ b/packages/radix-ui-themes/src/components/em.props.ts
@@ -1,4 +1,6 @@
-import { asChildPropDef, textWrapPropDef, truncatePropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
 
 const emPropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/em.tsx
+++ b/packages/radix-ui-themes/src/components/em.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { emPropDefs } from './em.props.js';
-import { extractProps } from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import { emPropDefs } from './em.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type EmElement = React.ElementRef<'em'>;
 type EmOwnProps = GetPropDefTypes<typeof emPropDefs>;

--- a/packages/radix-ui-themes/src/components/flex.props.ts
+++ b/packages/radix-ui-themes/src/components/flex.props.ts
@@ -1,5 +1,7 @@
-import { asChildPropDef, gapPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { gapPropDefs } from '../props/gap.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const as = ['div', 'span'] as const;
 const displayValues = ['none', 'inline-flex', 'flex'] as const;

--- a/packages/radix-ui-themes/src/components/flex.tsx
+++ b/packages/radix-ui-themes/src/components/flex.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
+import { extractProps } from '../helpers/extract-props.js';
+import { layoutPropDefs } from '../props/layout.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 import { Slot } from './slot.js';
 import { flexPropDefs } from './flex.props.js';
-import { extractProps } from '../helpers/index.js';
-import { layoutPropDefs, marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { MarginProps, LayoutProps, FlexOwnProps } from '../props/index.js';
+import type { FlexOwnProps } from './flex.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { LayoutProps } from '../props/layout.props.js';
+import type { MarginProps } from '../props/margin.props.js';
 
 type FlexElement = React.ElementRef<'div'>;
 interface CommonFlexProps extends MarginProps, LayoutProps, FlexOwnProps {}

--- a/packages/radix-ui-themes/src/components/grid.props.ts
+++ b/packages/radix-ui-themes/src/components/grid.props.ts
@@ -1,5 +1,7 @@
-import { asChildPropDef, gapPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { gapPropDefs } from '../props/gap.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const as = ['div', 'span'] as const;
 const displayValues = ['none', 'inline-grid', 'grid'] as const;

--- a/packages/radix-ui-themes/src/components/grid.tsx
+++ b/packages/radix-ui-themes/src/components/grid.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { Slot } from './slot.js';
 import { gridPropDefs } from './grid.props.js';
-import { extractProps } from '../helpers/index.js';
-import { layoutPropDefs, marginPropDefs } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { layoutPropDefs } from '../props/layout.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { MarginProps, LayoutProps, GridOwnProps } from '../props/index.js';
+import type { LayoutProps } from '../props/layout.props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GridOwnProps } from './grid.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type GridElement = React.ElementRef<'div'>;
 interface CommonGridProps extends MarginProps, LayoutProps, GridOwnProps {}

--- a/packages/radix-ui-themes/src/components/heading.props.ts
+++ b/packages/radix-ui-themes/src/components/heading.props.ts
@@ -1,14 +1,13 @@
-import {
-  textAlignPropDef,
-  asChildPropDef,
-  highContrastPropDef,
-  colorPropDef,
-  textWrapPropDef,
-  leadingTrimPropDef,
-  truncatePropDef,
-  weightPropDef,
-} from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { leadingTrimPropDef } from '../props/leading-trim.prop.js';
+import { textAlignPropDef } from '../props/text-align.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
+import { weightPropDef } from '../props/weight.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const as = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;

--- a/packages/radix-ui-themes/src/components/heading.tsx
+++ b/packages/radix-ui-themes/src/components/heading.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { headingPropDefs } from './heading.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { headingPropDefs } from './heading.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type HeadingElement = React.ElementRef<'h1'>;
 type HeadingOwnProps = GetPropDefTypes<typeof headingPropDefs>;

--- a/packages/radix-ui-themes/src/components/hover-card.props.ts
+++ b/packages/radix-ui-themes/src/components/hover-card.props.ts
@@ -1,5 +1,8 @@
-import { asChildPropDef, heightPropDefs, widthPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { heightPropDefs } from '../props/height.props.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const contentSizes = ['1', '2', '3'] as const;
 

--- a/packages/radix-ui-themes/src/components/hover-card.tsx
+++ b/packages/radix-ui-themes/src/components/hover-card.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+
 import { hoverCardContentPropDefs } from './hover-card.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 import { Theme } from './theme.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { HoverCardContentOwnProps } from '../props/index.js';
+import type { HoverCardContentOwnProps } from './hover-card.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 interface HoverCardRootProps
   extends React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root> {}

--- a/packages/radix-ui-themes/src/components/icon-button.tsx
+++ b/packages/radix-ui-themes/src/components/icon-button.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { BaseButton } from './base-button.js';
 
 type IconButtonElement = React.ElementRef<typeof BaseButton>;

--- a/packages/radix-ui-themes/src/components/icons.tsx
+++ b/packages/radix-ui-themes/src/components/icons.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
+import React from 'react';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type IconElement = React.ElementRef<'svg'>;
 interface IconProps extends ComponentPropsWithout<'svg', RemovedProps | 'children'> {}

--- a/packages/radix-ui-themes/src/components/inset.props.ts
+++ b/packages/radix-ui-themes/src/components/inset.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sides = ['all', 'x', 'y', 'top', 'bottom', 'left', 'right'] as const;
 const clipValues = ['border-box', 'padding-box'] as const;

--- a/packages/radix-ui-themes/src/components/inset.tsx
+++ b/packages/radix-ui-themes/src/components/inset.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { insetPropDefs } from './inset.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { insetPropDefs } from './inset.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type InsetElement = React.ElementRef<'div'>;
 type InsetOwnProps = GetPropDefTypes<typeof insetPropDefs>;

--- a/packages/radix-ui-themes/src/components/kbd.props.ts
+++ b/packages/radix-ui-themes/src/components/kbd.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 

--- a/packages/radix-ui-themes/src/components/kbd.tsx
+++ b/packages/radix-ui-themes/src/components/kbd.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { kbdPropDefs } from './kbd.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { kbdPropDefs } from './kbd.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type KbdElement = React.ElementRef<'kbd'>;
 type KbdOwnProps = GetPropDefTypes<typeof kbdPropDefs>;

--- a/packages/radix-ui-themes/src/components/link.props.ts
+++ b/packages/radix-ui-themes/src/components/link.props.ts
@@ -1,13 +1,12 @@
-import {
-  asChildPropDef,
-  accentColorPropDef,
-  highContrastPropDef,
-  textWrapPropDef,
-  leadingTrimPropDef,
-  truncatePropDef,
-  weightPropDef,
-} from '../props/index.js';
-import { type PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { accentColorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { leadingTrimPropDef } from '../props/leading-trim.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
+import { weightPropDef } from '../props/weight.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const underline = ['auto', 'always', 'hover', 'none'] as const;

--- a/packages/radix-ui-themes/src/components/link.tsx
+++ b/packages/radix-ui-themes/src/components/link.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { Text } from './text.js';
-import { linkPropDefs } from './link.props.js';
-import { extractProps } from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { Text } from './text.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { linkPropDefs } from './link.props.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type LinkElement = React.ElementRef<'a'>;
 type LinkOwnProps = GetPropDefTypes<typeof linkPropDefs>;

--- a/packages/radix-ui-themes/src/components/popover.props.ts
+++ b/packages/radix-ui-themes/src/components/popover.props.ts
@@ -1,5 +1,8 @@
-import { asChildPropDef, heightPropDefs, widthPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { heightPropDefs } from '../props/height.props.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const contentSizes = ['1', '2', '3', '4'] as const;
 

--- a/packages/radix-ui-themes/src/components/popover.tsx
+++ b/packages/radix-ui-themes/src/components/popover.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { extractProps } from '../helpers/extract-props.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
 import { popoverContentPropDefs } from './popover.props.js';
-import { extractProps, requireReactElement } from '../helpers/index.js';
 import { Theme } from './theme.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { PopoverContentOwnProps } from '../props/index.js';
+import type { PopoverContentOwnProps } from './popover.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 interface PopoverRootProps extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root> {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => (

--- a/packages/radix-ui-themes/src/components/progress.props.ts
+++ b/packages/radix-ui-themes/src/components/progress.props.ts
@@ -1,5 +1,8 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/progress.tsx
+++ b/packages/radix-ui-themes/src/components/progress.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as ProgressPrimitive from '@radix-ui/react-progress';
-import { progressPropDefs } from './progress.props.js';
-import { extractProps, mergeStyles } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { progressPropDefs } from './progress.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { mergeStyles } from '../helpers/merge-styles.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type ProgressElement = React.ElementRef<typeof ProgressPrimitive.Root>;
 type ProgressOwnProps = GetPropDefTypes<typeof progressPropDefs>;

--- a/packages/radix-ui-themes/src/components/quote.props.ts
+++ b/packages/radix-ui-themes/src/components/quote.props.ts
@@ -1,4 +1,6 @@
-import { asChildPropDef, textWrapPropDef, truncatePropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
 
 const quotePropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/quote.tsx
+++ b/packages/radix-ui-themes/src/components/quote.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { quotePropDefs } from './quote.props.js';
-import { extractProps } from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import { quotePropDefs } from './quote.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type QuoteElement = React.ElementRef<'q'>;
 type QuoteOwnProps = GetPropDefTypes<typeof quotePropDefs>;

--- a/packages/radix-ui-themes/src/components/radio-cards.props.ts
+++ b/packages/radix-ui-themes/src/components/radio-cards.props.ts
@@ -1,6 +1,9 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
 import { gridPropDefs } from './grid.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['surface', 'classic'] as const;

--- a/packages/radix-ui-themes/src/components/radio-cards.tsx
+++ b/packages/radix-ui-themes/src/components/radio-cards.tsx
@@ -3,13 +3,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
-import { radioCardsRootPropDefs } from './radio-cards.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
-import { Grid } from './grid.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { radioCardsRootPropDefs } from './radio-cards.props.js';
+import { Grid } from './grid.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type RadioCardsRootElement = React.ElementRef<typeof RadioGroupPrimitive.Root>;
 type RadioCardsRootOwnProps = GetPropDefTypes<typeof radioCardsRootPropDefs>;

--- a/packages/radix-ui-themes/src/components/radio-group.props.ts
+++ b/packages/radix-ui-themes/src/components/radio-group.props.ts
@@ -1,5 +1,8 @@
-import { asChildPropDef, colorPropDef, highContrastPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/radio-group.tsx
+++ b/packages/radix-ui-themes/src/components/radio-group.tsx
@@ -5,15 +5,16 @@ import classNames from 'classnames';
 import { createContextScope } from '@radix-ui/react-context';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 import { createRadioGroupScope } from '@radix-ui/react-radio-group';
+
 import { radioGroupRootPropDefs } from './radio-group.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
-
 import { Text } from './text.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
 import type { Scope } from '@radix-ui/react-context';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 const RADIO_GROUP_NAME = 'RadioGroup';
 

--- a/packages/radix-ui-themes/src/components/radio.tsx
+++ b/packages/radix-ui-themes/src/components/radio.tsx
@@ -4,12 +4,15 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { composeEventHandlers } from '@radix-ui/primitive';
 import { composeRefs } from '@radix-ui/react-compose-refs';
-import { radioPropDefs } from './radio.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, NotInputRadioAttributes } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { radioPropDefs } from './radio.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout } from '../helpers/component-props.js';
+import type { NotInputRadioAttributes } from '../helpers/input-attributes.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type RadioElement = React.ElementRef<'input'>;
 type RadioOwnProps = GetPropDefTypes<typeof radioPropDefs> & {

--- a/packages/radix-ui-themes/src/components/reset.tsx
+++ b/packages/radix-ui-themes/src/components/reset.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { requireReactElement } from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
+import { requireReactElement } from '../helpers/require-react-element.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 interface ResetProps extends ComponentPropsWithout<typeof Slot, RemovedProps> {}
 const Reset = React.forwardRef<HTMLElement, ResetProps>(

--- a/packages/radix-ui-themes/src/components/scroll-area.props.ts
+++ b/packages/radix-ui-themes/src/components/scroll-area.props.ts
@@ -1,5 +1,7 @@
-import { asChildPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const scrollbarsValues = ['vertical', 'horizontal', 'both'] as const;

--- a/packages/radix-ui-themes/src/components/scroll-area.tsx
+++ b/packages/radix-ui-themes/src/components/scroll-area.tsx
@@ -3,17 +3,17 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
-import { scrollAreaPropDefs } from './scroll-area.props.js';
-import {
-  extractMarginProps,
-  getMarginStyles,
-  getResponsiveClassNames,
-  mergeStyles,
-  getSubtree,
-} from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { scrollAreaPropDefs } from './scroll-area.props.js';
+import { extractMarginProps } from '../helpers/extract-margin-props.js';
+import { getMarginStyles } from '../helpers/get-margin-styles.js';
+import { getResponsiveClassNames } from '../helpers/get-responsive-styles.js';
+import { getSubtree } from '../helpers/get-subtree.js';
+import { mergeStyles } from '../helpers/merge-styles.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type ScrollAreaElement = React.ElementRef<typeof ScrollAreaPrimitive.Viewport>;
 type ScrollAreaOwnProps = GetPropDefTypes<typeof scrollAreaPropDefs>;

--- a/packages/radix-ui-themes/src/components/section.props.ts
+++ b/packages/radix-ui-themes/src/components/section.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4'] as const;
 const displayValues = ['none', 'initial'] as const;

--- a/packages/radix-ui-themes/src/components/section.tsx
+++ b/packages/radix-ui-themes/src/components/section.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { sectionPropDefs } from './section.props.js';
-import { extractProps } from '../helpers/index.js';
-import { layoutPropDefs, marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { MarginProps, LayoutProps, SectionOwnProps } from '../props/index.js';
+import { sectionPropDefs } from './section.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { layoutPropDefs } from '../props/layout.props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { LayoutProps } from '../props/layout.props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { SectionOwnProps } from './section.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type SectionElement = React.ElementRef<'div'>;
 interface SectionProps

--- a/packages/radix-ui-themes/src/components/segmented-control.props.ts
+++ b/packages/radix-ui-themes/src/components/segmented-control.props.ts
@@ -1,5 +1,6 @@
-import { radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['surface', 'classic'] as const;

--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -4,12 +4,14 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
-import { segmentedControlRootPropDefs } from './segmented-control.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { segmentedControlRootPropDefs } from './segmented-control.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type SegmentedControlRootOwnProps = GetPropDefTypes<typeof segmentedControlRootPropDefs>;
 

--- a/packages/radix-ui-themes/src/components/select.props.ts
+++ b/packages/radix-ui-themes/src/components/select.props.ts
@@ -1,6 +1,8 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
 
-import type { PropDef } from '../props/index.js';
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 

--- a/packages/radix-ui-themes/src/components/select.tsx
+++ b/packages/radix-ui-themes/src/components/select.tsx
@@ -4,18 +4,20 @@ import * as React from 'react';
 import classNames from 'classnames';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { ChevronDownIcon, ThickCheckIcon } from './icons.js';
 import {
   selectRootPropDefs,
   selectTriggerPropDefs,
   selectContentPropDefs,
 } from './select.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
-import { Theme, useThemeContext } from './theme.js';
-import { ThickCheckIcon, ChevronDownIcon } from './icons.js';
+import { useThemeContext, Theme } from './theme.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type SelectRootOwnProps = GetPropDefTypes<typeof selectRootPropDefs>;
 

--- a/packages/radix-ui-themes/src/components/separator.props.ts
+++ b/packages/radix-ui-themes/src/components/separator.props.ts
@@ -1,5 +1,6 @@
-import { colorPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const orientationValues = ['horizontal', 'vertical'] as const;
 const sizes = ['1', '2', '3', '4'] as const;

--- a/packages/radix-ui-themes/src/components/separator.tsx
+++ b/packages/radix-ui-themes/src/components/separator.tsx
@@ -2,12 +2,14 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import { separatorPropDefs } from './separator.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { separatorPropDefs } from './separator.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type SeparatorElement = React.ElementRef<'span'>;
 type SeparatorOwnProps = GetPropDefTypes<typeof separatorPropDefs>;

--- a/packages/radix-ui-themes/src/components/skeleton.props.ts
+++ b/packages/radix-ui-themes/src/components/skeleton.props.ts
@@ -1,5 +1,7 @@
-import { widthPropDefs, heightPropDefs } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { heightPropDefs } from '../props/height.props.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const skeletonPropDefs = {
   loading: { type: 'boolean', default: true },

--- a/packages/radix-ui-themes/src/components/skeleton.tsx
+++ b/packages/radix-ui-themes/src/components/skeleton.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { skeletonPropDefs } from './skeleton.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { skeletonPropDefs } from './skeleton.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type SkeletonElement = React.ElementRef<'span'>;
 type SkeletonOwnProps = GetPropDefTypes<typeof skeletonPropDefs>;

--- a/packages/radix-ui-themes/src/components/slider.props.ts
+++ b/packages/radix-ui-themes/src/components/slider.props.ts
@@ -1,5 +1,8 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/slider.tsx
+++ b/packages/radix-ui-themes/src/components/slider.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as SliderPrimitive from '@radix-ui/react-slider';
-import { sliderPropDefs } from './slider.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { sliderPropDefs } from './slider.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type SliderElement = React.ElementRef<typeof SliderPrimitive.Root>;
 type SliderOwnProps = GetPropDefTypes<typeof sliderPropDefs>;

--- a/packages/radix-ui-themes/src/components/spinner.props.ts
+++ b/packages/radix-ui-themes/src/components/spinner.props.ts
@@ -1,4 +1,4 @@
-import type { PropDef } from '../props/index.js';
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 

--- a/packages/radix-ui-themes/src/components/spinner.tsx
+++ b/packages/radix-ui-themes/src/components/spinner.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { Flex } from './flex.js';
 import { spinnerPropDefs } from './spinner.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type SpinnerElement = React.ElementRef<'span'>;
 type SpinnerOwnProps = GetPropDefTypes<typeof spinnerPropDefs>;

--- a/packages/radix-ui-themes/src/components/strong.props.ts
+++ b/packages/radix-ui-themes/src/components/strong.props.ts
@@ -1,4 +1,6 @@
-import { asChildPropDef, textWrapPropDef, truncatePropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
 
 const strongPropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/strong.tsx
+++ b/packages/radix-ui-themes/src/components/strong.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { strongPropDefs } from './strong.props.js';
-import { extractProps } from '../helpers/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { strongPropDefs } from './strong.props.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type StrongElement = React.ElementRef<'strong'>;
 type StrongOwnProps = GetPropDefTypes<typeof strongPropDefs>;

--- a/packages/radix-ui-themes/src/components/switch.props.ts
+++ b/packages/radix-ui-themes/src/components/switch.props.ts
@@ -1,5 +1,8 @@
-import { colorPropDef, highContrastPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/switch.tsx
+++ b/packages/radix-ui-themes/src/components/switch.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as SwitchPrimitive from '@radix-ui/react-switch';
-import { switchPropDefs } from './switch.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { switchPropDefs } from './switch.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
+import type { ComponentPropsWithout } from '../helpers/component-props.js';
 
 type SwitchElement = React.ElementRef<typeof SwitchPrimitive.Root>;
 type SwitchOwnProps = GetPropDefTypes<typeof switchPropDefs>;

--- a/packages/radix-ui-themes/src/components/tab-nav.props.ts
+++ b/packages/radix-ui-themes/src/components/tab-nav.props.ts
@@ -1,5 +1,6 @@
-import { asChildPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const tabNavLinkPropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/tab-nav.tsx
+++ b/packages/radix-ui-themes/src/components/tab-nav.tsx
@@ -3,12 +3,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
-import { tabNavLinkPropDefs, tabNavRootPropDefs } from './tab-nav.props.js';
-import { extractProps, getSubtree } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { tabNavLinkPropDefs, tabNavRootPropDefs } from './tab-nav.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { getSubtree } from '../helpers/get-subtree.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TabNavRootElement = React.ElementRef<typeof NavigationMenu.Root>;
 type TabNavRootElementProps = ComponentPropsWithout<'nav', RemovedProps>;

--- a/packages/radix-ui-themes/src/components/table.props.ts
+++ b/packages/radix-ui-themes/src/components/table.props.ts
@@ -1,5 +1,7 @@
-import type { PropDef } from '../props/index.js';
-import { paddingPropDefs, widthPropDefs } from '../props/index.js';
+import { paddingPropDefs } from '../props/padding.props.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['surface', 'ghost'] as const;

--- a/packages/radix-ui-themes/src/components/table.tsx
+++ b/packages/radix-ui-themes/src/components/table.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react';
 import classNames from 'classnames';
+
 import { tableRootPropDefs, tableRowPropDefs, tableCellPropDefs } from './table.props.js';
-import { extractProps, getResponsiveClassNames } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { getResponsiveClassNames } from '../helpers/get-responsive-styles.js';
+import { marginPropDefs } from '../props/margin.props.js';
 import { ScrollArea } from './scroll-area.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TableRootElement = React.ElementRef<'div'>;
 type TableRootOwnProps = GetPropDefTypes<typeof tableRootPropDefs>;

--- a/packages/radix-ui-themes/src/components/tabs.props.ts
+++ b/packages/radix-ui-themes/src/components/tabs.props.ts
@@ -1,4 +1,4 @@
-import { asChildPropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
 
 const tabsRootPropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/tabs.tsx
+++ b/packages/radix-ui-themes/src/components/tabs.tsx
@@ -3,12 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
-import { tabsContentPropDefs, tabsListPropDefs, tabsRootPropDefs } from './tabs.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { tabsContentPropDefs, tabsListPropDefs, tabsRootPropDefs } from './tabs.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TabsRootElement = React.ElementRef<typeof TabsPrimitive.Root>;
 type TabsRootOwnProps = GetPropDefTypes<typeof tabsRootPropDefs>;

--- a/packages/radix-ui-themes/src/components/text-area.props.ts
+++ b/packages/radix-ui-themes/src/components/text-area.props.ts
@@ -1,5 +1,7 @@
-import { colorPropDef, radiusPropDef } from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { radiusPropDef } from '../props/radius.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/text-area.tsx
+++ b/packages/radix-ui-themes/src/components/text-area.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { textAreaPropDefs } from './text-area.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { textAreaPropDefs } from './text-area.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TextAreaElement = React.ElementRef<'textarea'>;
 type TextAreaOwnProps = GetPropDefTypes<typeof textAreaPropDefs> & {

--- a/packages/radix-ui-themes/src/components/text-field.props.ts
+++ b/packages/radix-ui-themes/src/components/text-field.props.ts
@@ -1,6 +1,9 @@
-import type { PropDef } from '../props/index.js';
-import { colorPropDef, paddingPropDefs, radiusPropDef } from '../props/index.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { paddingPropDefs } from '../props/padding.props.js';
+import { radiusPropDef } from '../props/radius.prop.js';
 import { flexPropDefs } from './flex.props.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
 const variants = ['classic', 'surface', 'soft'] as const;

--- a/packages/radix-ui-themes/src/components/text-field.tsx
+++ b/packages/radix-ui-themes/src/components/text-field.tsx
@@ -2,17 +2,16 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import { textFieldRootPropDefs, textFieldSlotPropDefs } from './text-field.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
-
-import type {
-  ComponentPropsWithout,
-  NotInputTextualAttributes,
-  RemovedProps,
-} from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
 import { composeRefs } from '@radix-ui/react-compose-refs';
+
+import { textFieldRootPropDefs, textFieldSlotPropDefs } from './text-field.props.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { NotInputTextualAttributes } from '../helpers/input-attributes.js';
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TextFieldRootElement = React.ElementRef<'input'>;
 type TextFieldRootOwnProps = GetPropDefTypes<typeof textFieldRootPropDefs> & {

--- a/packages/radix-ui-themes/src/components/text.props.ts
+++ b/packages/radix-ui-themes/src/components/text.props.ts
@@ -1,14 +1,13 @@
-import {
-  weightPropDef,
-  textAlignPropDef,
-  leadingTrimPropDef,
-  highContrastPropDef,
-  colorPropDef,
-  textWrapPropDef,
-  truncatePropDef,
-  asChildPropDef,
-} from '../props/index.js';
-import type { PropDef } from '../props/index.js';
+import { asChildPropDef } from '../props/as-child.prop.js';
+import { colorPropDef } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
+import { leadingTrimPropDef } from '../props/leading-trim.prop.js';
+import { textAlignPropDef } from '../props/text-align.prop.js';
+import { textWrapPropDef } from '../props/text-wrap.prop.js';
+import { truncatePropDef } from '../props/truncate.prop.js';
+import { weightPropDef } from '../props/weight.prop.js';
+
+import type { PropDef } from '../props/prop-def.js';
 
 const as = ['span', 'div', 'label', 'p'] as const;
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;

--- a/packages/radix-ui-themes/src/components/text.tsx
+++ b/packages/radix-ui-themes/src/components/text.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
-import { textPropDefs } from './text.props.js';
-import { extractProps } from '../helpers/index.js';
-import { marginPropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes, MarginProps } from '../props/index.js';
+import { extractProps } from '../helpers/extract-props.js';
+import { marginPropDefs } from '../props/margin.props.js';
+import { textPropDefs } from './text.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type TextElement = React.ElementRef<'span'>;
 type TextOwnProps = GetPropDefTypes<typeof textPropDefs>;

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { useCallbackRef } from '@radix-ui/react-use-callback-ref';
+
 import {
   AccessibleIcon,
   Box,
@@ -17,11 +18,11 @@ import {
   Tooltip,
 } from '../index.js';
 import { Theme, useThemeContext } from './theme.js';
-import { getMatchingGrayColor } from '../helpers/index.js';
-import { themePropDefs } from '../props/index.js';
+import { getMatchingGrayColor } from '../helpers/get-matching-gray-color.js';
+import { themePropDefs } from './theme.props.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
-import type { GetPropDefTypes } from '../props/index.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 interface ThemePanelProps extends Omit<ThemePanelImplProps, keyof ThemePanelImplPrivateProps> {
   defaultOpen?: boolean;

--- a/packages/radix-ui-themes/src/components/theme.props.ts
+++ b/packages/radix-ui-themes/src/components/theme.props.ts
@@ -1,6 +1,7 @@
 import { asChildPropDef } from '../props/as-child.prop.js';
 import { accentColors, grayColors } from '../props/color.prop.js';
 import { radii } from '../props/radius.prop.js';
+
 import type { GetPropDefTypes, PropDef } from '../props/prop-def.js';
 
 const appearances = ['inherit', 'light', 'dark'] as const;

--- a/packages/radix-ui-themes/src/components/theme.tsx
+++ b/packages/radix-ui-themes/src/components/theme.tsx
@@ -5,10 +5,12 @@ import classNames from 'classnames';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import { DirectionProvider } from '@radix-ui/react-direction';
 import { Slot } from '@radix-ui/react-slot';
-import { getMatchingGrayColor } from '../helpers/index.js';
-import { ThemeOwnProps, themePropDefs } from '../props/index.js';
 
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
+import { getMatchingGrayColor } from '../helpers/get-matching-gray-color.js';
+import { themePropDefs } from './theme.props.js';
+
+import type { ThemeOwnProps } from './theme.props.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 const noop = () => {};
 

--- a/packages/radix-ui-themes/src/components/tooltip.props.ts
+++ b/packages/radix-ui-themes/src/components/tooltip.props.ts
@@ -1,5 +1,6 @@
-import { widthPropDefs } from '../props/index.js';
-import type { GetPropDefTypes, PropDef } from '../props/index.js';
+import { widthPropDefs } from '../props/width.props.js';
+
+import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
 const tooltipPropDefs = {
   content: { type: 'ReactNode', required: true },

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -3,13 +3,14 @@
 import * as React from 'react';
 import classNames from 'classnames';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
 import { Text } from './text.js';
 import { Theme } from './theme.js';
-import { extractProps } from '../helpers/index.js';
+import { extractProps } from '../helpers/extract-props.js';
 import { tooltipPropDefs } from './tooltip.props.js';
 
-import type { GetPropDefTypes } from '../props/index.js';
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/index.js';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type TooltipElement = React.ElementRef<typeof TooltipPrimitive.Content>;
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;

--- a/packages/radix-ui-themes/src/helpers/extract-props.ts
+++ b/packages/radix-ui-themes/src/helpers/extract-props.ts
@@ -1,8 +1,10 @@
-import type * as React from 'react';
 import classNames from 'classnames';
+
 import { getResponsiveClassNames, getResponsiveStyles } from './get-responsive-styles.js';
 import { isResponsiveObject } from './is-responsive-object.js';
 import { mergeStyles } from './merge-styles.js';
+
+import type * as React from 'react';
 import type { PropDef } from '../props/prop-def.js';
 
 type PropDefsWithClassName<T> = T extends Record<string, PropDef>

--- a/packages/radix-ui-themes/src/helpers/get-margin-styles.ts
+++ b/packages/radix-ui-themes/src/helpers/get-margin-styles.ts
@@ -1,7 +1,10 @@
 import classNames from 'classnames';
-import { MarginProps, marginPropDefs } from '../props/margin.props.js';
+
 import { getResponsiveStyles } from './get-responsive-styles.js';
 import { mergeStyles } from './merge-styles.js';
+import { marginPropDefs } from '../props/margin.props.js';
+
+import type { MarginProps } from '../props/margin.props.js';
 
 const marginValues = marginPropDefs.m.values;
 

--- a/packages/radix-ui-themes/src/helpers/get-matching-gray-color.ts
+++ b/packages/radix-ui-themes/src/helpers/get-matching-gray-color.ts
@@ -1,4 +1,4 @@
-import { accentColors } from '../props/index.js';
+import type { accentColors } from '../props/color.prop.js';
 
 type ThemeAccentColor = (typeof accentColors)[number];
 

--- a/packages/radix-ui-themes/src/helpers/get-responsive-styles.ts
+++ b/packages/radix-ui-themes/src/helpers/get-responsive-styles.ts
@@ -1,7 +1,8 @@
 import { breakpoints } from '../props/prop-def.js';
-import type { Responsive, Union } from '../props/prop-def.js';
 import { hasOwnProperty } from './has-own-property.js';
 import { isResponsiveObject } from './is-responsive-object.js';
+
+import type { Responsive, Union } from '../props/prop-def.js';
 
 interface GetResponsiveStylesOptions {
   className: string;

--- a/packages/radix-ui-themes/src/helpers/is-responsive-object.ts
+++ b/packages/radix-ui-themes/src/helpers/is-responsive-object.ts
@@ -1,5 +1,6 @@
-import { breakpoints } from '../props/index.js';
-import type { Breakpoint, Responsive } from '../props/index.js';
+import { breakpoints } from '../props/prop-def.js';
+
+import type { Responsive, Breakpoint } from '../props/prop-def.js';
 
 export function isResponsiveObject<Value extends string>(
   obj: Responsive<Value | Omit<string, Value>> | undefined

--- a/packages/radix-ui-themes/src/helpers/map-prop-values.ts
+++ b/packages/radix-ui-themes/src/helpers/map-prop-values.ts
@@ -3,7 +3,7 @@ import { calloutRootPropDefs } from '../components/callout.props.js';
 import { spinnerPropDefs } from '../components/spinner.props.js';
 import { textPropDefs } from '../components/text.props.js';
 
-import type { Responsive } from '../props/index.js';
+import type { Responsive } from '../props/prop-def.js';
 
 function mapResponsiveProp<Input extends string, Output>(
   propValue: Responsive<Input> | undefined,

--- a/packages/radix-ui-themes/src/props/height.props.ts
+++ b/packages/radix-ui-themes/src/props/height.props.ts
@@ -1,4 +1,4 @@
-import { GetPropDefTypes, PropDef } from './prop-def.js';
+import type { PropDef, GetPropDefTypes } from './prop-def.js';
 
 const heightPropDefs = {
   /**

--- a/packages/radix-ui-themes/src/props/layout.props.ts
+++ b/packages/radix-ui-themes/src/props/layout.props.ts
@@ -1,7 +1,8 @@
 import { paddingPropDefs } from './padding.props.js';
-import type { PropDef, GetPropDefTypes } from './prop-def.js';
 import { heightPropDefs } from './height.props.js';
 import { widthPropDefs } from './width.props.js';
+
+import type { PropDef, GetPropDefTypes } from './prop-def.js';
 
 const overflowValues = ['visible', 'hidden', 'clip', 'scroll', 'auto'] as const;
 const positionValues = ['static', 'relative', 'absolute', 'fixed', 'sticky'] as const;

--- a/packages/radix-ui-themes/src/props/width.props.ts
+++ b/packages/radix-ui-themes/src/props/width.props.ts
@@ -1,4 +1,4 @@
-import { GetPropDefTypes, PropDef } from './prop-def.js';
+import type { GetPropDefTypes, PropDef } from './prop-def.js';
 
 const widthPropDefs = {
   /**

--- a/packages/radix-ui-themes/tsconfig.json
+++ b/packages/radix-ui-themes/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "lib": ["DOM", "ESNext", "DOM.Iterable"],
     "jsx": "react",
     "declaration": true,
@@ -7,6 +9,7 @@
     "outDir": "dist",
     "strict": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "verbatimModuleSyntax": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1851,7 +1851,7 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.28.1:
+eslint-plugin-import@^2.28.1, eslint-plugin-import@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz#d45b37b5ef5901d639c15270d74d46d161150643"
   integrity sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==


### PR DESCRIPTION
Fixes an issue caused by internal barrel files usage when the Next.js compiler would _sometimes_ fail to compile a project that'd use Radix Themes.

Example for posterity:

<img width="926" alt="image" src="https://github.com/radix-ui/themes/assets/8441036/b27d7945-af32-45dd-8e63-a8a914227a49">
