### PR TITLE
fix usage of `inert` for React 19

### DIFF
--- a/packages/radix-ui-themes/src/components/skeleton.tsx
+++ b/packages/radix-ui-themes/src/components/skeleton.tsx
@@ -5,6 +5,7 @@ import { Slot } from '@radix-ui/react-slot';
 import { extractProps } from '../helpers/extract-props.js';
 import { marginPropDefs } from '../props/margin.props.js';
 import { skeletonPropDefs } from './skeleton.props.js';
+import { isBeforeReact19 } from '../helpers/react-version.js';
 
 import type { MarginProps } from '../props/margin.props.js';
 import type { GetPropDefTypes } from '../props/prop-def.js';
@@ -34,8 +35,8 @@ const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwar
       className={classNames('rt-Skeleton', className)}
       data-inline-skeleton={React.isValidElement(children) ? undefined : true}
       tabIndex={-1}
-      // Workaround to use `inert` until https://github.com/facebook/react/pull/24730 is merged.
-      {...{ inert: true ? '' : undefined }}
+      // See https://github.com/facebook/react/pull/24730
+      {...{ inert: isBeforeReact19() ? '' : true }}
       {...skeletonProps}
     >
       {children}

--- a/packages/radix-ui-themes/src/components/spinner.tsx
+++ b/packages/radix-ui-themes/src/components/spinner.tsx
@@ -5,6 +5,7 @@ import { Flex } from './flex.js';
 import { spinnerPropDefs } from './spinner.props.js';
 import { extractProps } from '../helpers/extract-props.js';
 import { marginPropDefs } from '../props/margin.props.js';
+import { isBeforeReact19 } from '../helpers/react-version.js';
 
 import type { MarginProps } from '../props/margin.props.js';
 import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
@@ -50,8 +51,8 @@ const Spinner = React.forwardRef<SpinnerElement, SpinnerProps>((props, forwarded
         <span
           aria-hidden
           style={{ display: 'contents', visibility: 'hidden' }}
-          // Workaround to use `inert` until https://github.com/facebook/react/pull/24730 is merged.
-          {...{ inert: true ? '' : undefined }}
+          // See https://github.com/facebook/react/pull/24730 on `inert`
+          {...{ inert: isBeforeReact19() ? '' : true }}
         >
           {children}
         </span>

--- a/packages/radix-ui-themes/src/helpers/react-version.ts
+++ b/packages/radix-ui-themes/src/helpers/react-version.ts
@@ -1,0 +1,5 @@
+import { version } from 'react';
+
+export function isBeforeReact19() {
+  return parseInt(version.split('.')[0], 10) < 19;
+}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

https://github.com/facebook/react/pull/24730 has landed to React 19. 
When using radix-ui/themes with React 19, and using the Skeleton component, I get a warning that looks like:

```
Warning: Received an empty string for a boolean attribute `inert`. This will treat the attribute as if it were false. Either pass `false` to silence this warning, or pass `true` if you used an empty string in earlier versions of React to indicate this attribute is true.
    at span
    at eval (webpack-internal:///(ssr)/./node_modules/@radix-ui/themes/dist/esm/components/skeleton.js:11:179)
```

## Testing steps

Ran my application with this fix and no longer saw the warning.

## Relates issues / PRs

https://github.com/facebook/react/pull/24730
