### PR TITLE
(Draft) Add intersection observer to skeleton

### DIFF
--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import * as React from 'react';
-import classNames from 'classnames';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { useControllableState } from '@radix-ui/react-use-controllable-state';
+import classNames from 'classnames';
+import * as React from 'react';
 
-import { segmentedControlRootPropDefs } from './segmented-control.props.js';
 import { extractProps } from '../helpers/extract-props.js';
 import { marginPropDefs } from '../props/margin.props.js';
+import { segmentedControlRootPropDefs } from './segmented-control.props.js';
 
-import type { MarginProps } from '../props/margin.props.js';
 import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import type { MarginProps } from '../props/margin.props.js';
 import type { GetPropDefTypes } from '../props/prop-def.js';
 
 type SegmentedControlRootOwnProps = GetPropDefTypes<typeof segmentedControlRootPropDefs>;
@@ -98,5 +98,5 @@ const SegmentedControlItem = React.forwardRef<HTMLButtonElement, SegmentedContro
 
 SegmentedControlItem.displayName = 'SegmentedControl.Item';
 
-export { SegmentedControlRoot as Root, SegmentedControlItem as Item };
-export type { SegmentedControlRootProps as RootProps, SegmentedControlItemProps as ItemProps };
+export { SegmentedControlItem as Item, SegmentedControlRoot as Root };
+export type { SegmentedControlItemProps as ItemProps, SegmentedControlRootProps as RootProps };

--- a/packages/radix-ui-themes/src/components/skeleton.tsx
+++ b/packages/radix-ui-themes/src/components/skeleton.tsx
@@ -1,28 +1,42 @@
-import * as React from 'react';
-import classNames from 'classnames';
 import { Slot } from '@radix-ui/react-slot';
+import classNames from 'classnames';
+import * as React from 'react';
 
-import { inert } from '../helpers/inert.js';
 import { extractProps } from '../helpers/extract-props.js';
+import { inert } from '../helpers/inert.js';
 import { marginPropDefs } from '../props/margin.props.js';
 import { skeletonPropDefs } from './skeleton.props.js';
 
+import { useComposedRefs } from '@radix-ui/react-compose-refs';
+import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 import type { MarginProps } from '../props/margin.props.js';
 import type { GetPropDefTypes } from '../props/prop-def.js';
-import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
 
 type SkeletonElement = React.ElementRef<'span'>;
 type SkeletonOwnProps = GetPropDefTypes<typeof skeletonPropDefs>;
 interface SkeletonProps
   extends ComponentPropsWithout<'span', RemovedProps>,
     MarginProps,
-    SkeletonOwnProps {}
+    SkeletonOwnProps {
+  onIntersection?: IntersectionObserverCallback;
+  intersectionOptions?: IntersectionObserverInit;
+}
 const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwardedRef) => {
-  const { children, className, loading, ...skeletonProps } = extractProps(
-    props,
-    skeletonPropDefs,
-    marginPropDefs
-  );
+  const { children, className, loading, onIntersection, intersectionOptions, ...skeletonProps } =
+    extractProps(props, skeletonPropDefs, marginPropDefs);
+  const ref = React.useRef<HTMLSpanElement>(null);
+  const composedRefs = useComposedRefs(forwardedRef, ref);
+
+  React.useEffect(() => {
+    if (!onIntersection) return;
+
+    const observer = new IntersectionObserver(onIntersection, intersectionOptions);
+    observer.observe(ref.current!);
+
+    return () => observer.disconnect();
+  }, []);
+
+  React.useImperativeHandle(forwardedRef, () => ref.current!);
 
   if (!loading) return children;
 
@@ -30,7 +44,7 @@ const Skeleton = React.forwardRef<SkeletonElement, SkeletonProps>((props, forwar
 
   return (
     <Tag
-      ref={forwardedRef}
+      ref={composedRefs}
       aria-hidden
       className={classNames('rt-Skeleton', className)}
       data-inline-skeleton={React.isValidElement(children) ? undefined : true}


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

Add intersection observer API directly into Skeleton. When `onIntersection` is passed, an observer is created. Passing `intersectionOptions` is also supported.

## Testing steps

Figuring this out as we speak.

## Relates issues / PRs

N/A