### PR TITLE
Add `borderless` variants to `Button`, `IconButton` and `SelectTrigger`

### DIFF
--- a/packages/radix-ui-themes/src/components/base-button.css
+++ b/packages/radix-ui-themes/src/components/base-button.css
@@ -317,7 +317,7 @@
 
 /* soft / ghost */
 
-.rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost) {
+.rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost, .rt-variant-borderless) {
   color: var(--accent-a11);
 
   &:where(.rt-high-contrast) {
@@ -353,7 +353,7 @@
   }
 }
 
-.rt-BaseButton:where(.rt-variant-ghost) {
+.rt-BaseButton:where(.rt-variant-ghost, .rt-variant-borderless) {
   @media (hover: hover) {
     &:where(:hover) {
       background-color: var(--accent-a3);

--- a/packages/radix-ui-themes/src/components/base-button.props.ts
+++ b/packages/radix-ui-themes/src/components/base-button.props.ts
@@ -6,7 +6,7 @@ import { radiusPropDef } from '../props/radius.prop.js';
 import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3', '4'] as const;
-const variants = ['classic', 'solid', 'soft', 'surface', 'outline', 'ghost'] as const;
+const variants = ['classic', 'solid', 'soft', 'surface', 'outline', 'borderless', 'ghost'] as const;
 
 const baseButtonPropDefs = {
   ...asChildPropDef,

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -398,7 +398,8 @@
 /* soft / ghost */
 
 .rt-SelectTrigger:where(.rt-variant-soft),
-.rt-SelectTrigger:where(.rt-variant-ghost) {
+.rt-SelectTrigger:where(.rt-variant-ghost),
+.rt-SelectTrigger:where(.rt-variant-borderless) {
   color: var(--accent-12);
 
   &:where([data-placeholder]) {
@@ -430,7 +431,8 @@
   }
 }
 
-.rt-SelectTrigger:where(.rt-variant-ghost) {
+.rt-SelectTrigger:where(.rt-variant-ghost),
+.rt-SelectTrigger:where(.rt-variant-borderless) {
   @media (hover: hover) {
     &:where(:hover) {
       background-color: var(--accent-a3);

--- a/packages/radix-ui-themes/src/components/select.props.ts
+++ b/packages/radix-ui-themes/src/components/select.props.ts
@@ -12,7 +12,7 @@ const selectRootPropDefs = {
   size: PropDef<(typeof sizes)[number]>;
 };
 
-const triggerVariants = ['classic', 'surface', 'soft', 'ghost'] as const;
+const triggerVariants = ['classic', 'surface', 'soft', 'borderless', 'ghost'] as const;
 
 const selectTriggerPropDefs = {
   variant: { type: 'enum', className: 'rt-variant', values: triggerVariants, default: 'surface' },


### PR DESCRIPTION
## Description

Borderless variants combine all color properties from ghost-buttons, but retain the padding, margin, alignment and text-style of the other variants.

This variant is available for Button, IconButton and SelectTrigger.

## Testing steps

The new variants can be viewed in the `./app/sink`:
<img width="1048" alt="Screenshot 2024-07-14 at 11 41 36" src="https://github.com/user-attachments/assets/456d8f87-42ec-483a-9741-44982b562520">

## Relates issues / PRs

#434  
