### PR TITLE
chore(checkbox): add indeterminate state

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -1334,6 +1334,7 @@ export default function Sink() {
                               <ColumnHeaderCell />
                               <ColumnHeaderCell>not checked</ColumnHeaderCell>
                               <ColumnHeaderCell>checked</ColumnHeaderCell>
+                              <ColumnHeaderCell>indeterminate</ColumnHeaderCell>
                               <ColumnHeaderCell>disabled</ColumnHeaderCell>
                               <ColumnHeaderCell>disabled checked</ColumnHeaderCell>
                             </tr>
@@ -1355,6 +1356,13 @@ export default function Sink() {
                                         variant={variant}
                                         highContrast={label === '+ high-contrast'}
                                         defaultChecked
+                                      />
+                                    </td>
+                                    <td>
+                                      <Checkbox
+                                        variant={variant}
+                                        highContrast={label === '+ high-contrast'}
+                                        checked='indeterminate'
                                       />
                                     </td>
                                     <td>

--- a/packages/radix-ui-themes/src/components/base-checkbox.css
+++ b/packages/radix-ui-themes/src/components/base-checkbox.css
@@ -77,7 +77,8 @@
     }
   }
 
-  &:where([data-state='checked']) {
+  &:where([data-state='checked']),
+  &:where([data-state='indeterminate']) {
     &::before {
       background-color: var(--accent-indicator);
     }
@@ -116,7 +117,8 @@
     }
   }
 
-  &:where([data-state='checked']) {
+  &:where([data-state='checked']),
+  &:where([data-state='indeterminate']) {
     &::before {
       background-color: var(--accent-indicator);
       background-image: linear-gradient(to bottom, var(--white-a3), transparent, var(--black-a1));
@@ -155,7 +157,8 @@
     background-color: var(--accent-a5);
   }
 
-  &:where([data-state='checked']) {
+  &:where([data-state='checked']),
+  &:where([data-state='indeterminate']) {
     & :where(.rt-BaseCheckboxIndicator) {
       color: var(--accent-a11);
     }

--- a/packages/radix-ui-themes/src/components/base-checkbox.css
+++ b/packages/radix-ui-themes/src/components/base-checkbox.css
@@ -77,8 +77,7 @@
     }
   }
 
-  &:where([data-state='checked']),
-  &:where([data-state='indeterminate']) {
+  &:where([data-state='checked'], [data-state='indeterminate']) {
     &::before {
       background-color: var(--accent-indicator);
     }
@@ -117,8 +116,7 @@
     }
   }
 
-  &:where([data-state='checked']),
-  &:where([data-state='indeterminate']) {
+  &:where([data-state='checked'], [data-state='indeterminate']) {
     &::before {
       background-color: var(--accent-indicator);
       background-image: linear-gradient(to bottom, var(--white-a3), transparent, var(--black-a1));
@@ -157,8 +155,7 @@
     background-color: var(--accent-a5);
   }
 
-  &:where([data-state='checked']),
-  &:where([data-state='indeterminate']) {
+  &:where([data-state='checked'], [data-state='indeterminate']) {
     & :where(.rt-BaseCheckboxIndicator) {
       color: var(--accent-a11);
     }

--- a/packages/radix-ui-themes/src/components/checkbox.tsx
+++ b/packages/radix-ui-themes/src/components/checkbox.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 
 import { checkboxPropDefs } from './checkbox.props.js';
-import { ThickCheckIcon } from './icons.js';
+import { ThickCheckIcon, ThickDividerHorizontalIcon } from './icons.js';
 import { extractProps } from '../helpers/extract-props.js';
 import { marginPropDefs } from '../props/margin.props.js';
 
@@ -21,7 +21,7 @@ interface CheckboxProps
     MarginProps,
     CheckboxOwnProps {}
 const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>((props, forwardedRef) => {
-  const { className, color, ...checkboxProps } = extractProps(
+  const { className, color, checked, ...checkboxProps } = extractProps(
     props,
     checkboxPropDefs,
     marginPropDefs
@@ -30,6 +30,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>((props, forwar
     <CheckboxPrimitive.Root
       data-accent-color={color}
       {...checkboxProps}
+      checked={checked}
       asChild={false}
       ref={forwardedRef}
       className={classNames('rt-reset', 'rt-BaseCheckboxRoot', 'rt-CheckboxRoot', className)}
@@ -38,7 +39,7 @@ const Checkbox = React.forwardRef<CheckboxElement, CheckboxProps>((props, forwar
         asChild
         className="rt-BaseCheckboxIndicator rt-CheckboxIndicator"
       >
-        <ThickCheckIcon />
+        {checked === 'indeterminate' ? <ThickDividerHorizontalIcon /> : <ThickCheckIcon />}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/packages/radix-ui-themes/src/components/icons.tsx
+++ b/packages/radix-ui-themes/src/components/icons.tsx
@@ -5,6 +5,29 @@ import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-p
 type IconElement = React.ElementRef<'svg'>;
 interface IconProps extends ComponentPropsWithout<'svg', RemovedProps | 'children'> {}
 
+const ThickDividerHorizontalIcon = React.forwardRef<IconElement, IconProps>((props, forwardedRef) => {
+    return (
+      <svg
+      width="9"
+      height="9"
+      viewBox="0 0 9 9"
+      fill="currentcolor"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+      ref={forwardedRef}
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M0.75 4.5C0.75 4.08579 1.08579 3.75 1.5 3.75H7.5C7.91421 3.75 8.25 4.08579 8.25 4.5C8.25 4.91421 7.91421 5.25 7.5 5.25H1.5C1.08579 5.25 0.75 4.91421 0.75 4.5Z"
+        />
+      </svg>
+    );
+  }
+);
+
+ThickDividerHorizontalIcon.displayName = 'ThickDividerHorizontalIcon';
+
 const ThickCheckIcon = React.forwardRef<IconElement, IconProps>((props, forwardedRef) => {
   return (
     <svg
@@ -64,5 +87,5 @@ const ThickChevronRightIcon = React.forwardRef<IconElement, IconProps>((props, f
 });
 ThickChevronRightIcon.displayName = 'ThickChevronRightIcon';
 
-export { ChevronDownIcon, ThickCheckIcon, ThickChevronRightIcon };
+export { ChevronDownIcon, ThickCheckIcon, ThickChevronRightIcon, ThickDividerHorizontalIcon };
 export type { IconProps };


### PR DESCRIPTION
## Description

This PR adds `indeterminate` state icon on a standalone checkbox. This is only possible in a controlled state so `defaultChecked` will not render.

## Testing steps

Added to sink.

## Relates issues / PRs

#47 
