### PR TITLE
fix: Tooltip: render non-string content outside of the Text component

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -237,6 +237,23 @@ export default function Sink() {
                                 Multiline
                               </Button>
                             </Tooltip>
+
+                            <Tooltip content={
+                               <DataList.Root my="1">
+                                <DataList.Item>
+                                  <DataList.Label style={{ color: 'var(--gray-5)'}}>Name</DataList.Label>
+                                  <DataList.Value style={{ color: 'var(--gray-1)'}}>Susan Kare</DataList.Value>
+                                </DataList.Item>
+                                <DataList.Item>
+                                  <DataList.Label style={{ color: 'var(--gray-5)'}}>Email</DataList.Label>
+                                  <DataList.Value style={{ color: 'var(--gray-1)'}}>susan.kare@apple.com</DataList.Value>
+                                </DataList.Item>
+                              </DataList.Root>
+                            }>
+                              <Button variant="solid" size="1">
+                                Non-string ReactNode
+                              </Button>
+                            </Tooltip>
                           </Flex>
                         </DocsGridSectionItem>
 

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -238,18 +238,21 @@ export default function Sink() {
                               </Button>
                             </Tooltip>
 
-                            <Tooltip content={
-                               <DataList.Root my="1">
-                                <DataList.Item>
-                                  <DataList.Label style={{ color: 'var(--gray-5)'}}>Name</DataList.Label>
-                                  <DataList.Value style={{ color: 'var(--gray-1)'}}>Susan Kare</DataList.Value>
-                                </DataList.Item>
-                                <DataList.Item>
-                                  <DataList.Label style={{ color: 'var(--gray-5)'}}>Email</DataList.Label>
-                                  <DataList.Value style={{ color: 'var(--gray-1)'}}>susan.kare@apple.com</DataList.Value>
-                                </DataList.Item>
-                              </DataList.Root>
-                            }>
+                            <Tooltip
+                              textAs="div"
+                              content={
+                                <DataList.Root my="1">
+                                  <DataList.Item>
+                                    <DataList.Label style={{ color: 'var(--gray-5)'}}>Name</DataList.Label>
+                                    <DataList.Value style={{ color: 'var(--gray-1)'}}>Susan Kare</DataList.Value>
+                                  </DataList.Item>
+                                  <DataList.Item>
+                                    <DataList.Label style={{ color: 'var(--gray-5)'}}>Email</DataList.Label>
+                                    <DataList.Value style={{ color: 'var(--gray-1)'}}>susan.kare@apple.com</DataList.Value>
+                                  </DataList.Item>
+                                </DataList.Root>
+                              }
+                            >
                               <Button variant="solid" size="1">
                                 Non-string ReactNode
                               </Button>

--- a/packages/radix-ui-themes/src/components/tooltip.props.ts
+++ b/packages/radix-ui-themes/src/components/tooltip.props.ts
@@ -1,4 +1,5 @@
 import { widthPropDefs } from '../props/width.props.js';
+import { textPropDefs } from './text.props.js';
 
 import type { PropDef, GetPropDefTypes } from '../props/prop-def.js';
 
@@ -7,11 +8,13 @@ const tooltipPropDefs = {
   width: widthPropDefs.width,
   minWidth: widthPropDefs.minWidth,
   maxWidth: { ...widthPropDefs.maxWidth, default: '360px' },
+  textAs: textPropDefs['as']
 } satisfies {
   width: PropDef<string>;
   minWidth: PropDef<string>;
   maxWidth: PropDef<string>;
   content: PropDef<React.ReactNode>;
+  textAs: PropDef<string>;
 };
 
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs & typeof widthPropDefs>;

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -47,9 +47,13 @@ const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, forwarded
             ref={forwardedRef}
             className={classNames('rt-TooltipContent', className)}
           >
-            <Text as="p" className="rt-TooltipText" size="1">
-              {content}
-            </Text>
+            {typeof content === 'string' ? (
+              <Text as="p" className="rt-TooltipText" size="1">
+                {content}
+              </Text>
+            ) : (
+              <>{content}</>
+            )}
             <TooltipPrimitive.Arrow className="rt-TooltipArrow" />
           </TooltipPrimitive.Content>
         </Theme>

--- a/packages/radix-ui-themes/src/components/tooltip.tsx
+++ b/packages/radix-ui-themes/src/components/tooltip.tsx
@@ -31,6 +31,7 @@ const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, forwarded
     content,
     container,
     forceMount,
+    textAs,
     ...tooltipContentProps
   } = extractProps(props, tooltipPropDefs);
   const rootProps = { open, defaultOpen, onOpenChange, delayDuration, disableHoverableContent };
@@ -47,13 +48,9 @@ const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, forwarded
             ref={forwardedRef}
             className={classNames('rt-TooltipContent', className)}
           >
-            {typeof content === 'string' ? (
-              <Text as="p" className="rt-TooltipText" size="1">
-                {content}
-              </Text>
-            ) : (
-              <>{content}</>
-            )}
+            <Text as={textAs ?? 'p'} className="rt-TooltipText" size="1">
+              {content}
+            </Text>
             <TooltipPrimitive.Arrow className="rt-TooltipArrow" />
           </TooltipPrimitive.Content>
         </Theme>


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `yarn dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

When using the `<Tooltip>` component and passing in a non-string `React.ReactNode` into `content`, React produces warnings noting that specific elements cannot appear as descendants of a `p` tag. This change introduces a prop on `Tooltip` that allows the dev to define what `<Text as="_">` property they want to pass, enabling non-string content to be an allowed child in the tooltip and not produce a console warning.

The change introduces a `textAs` prop which pulls from the `textPropTypes['as']` value and passes that down to the `<Text>` in the tooltip, falling back to the currently hardcoded `p` value

Here are the warnings that are produced without this change:

![CleanShot 2024-08-05 at 10 44 31@2x](https://github.com/user-attachments/assets/33290b4c-a374-4e89-bf5e-57a540ee4ee9)

![CleanShot 2024-08-05 at 10 44 47@2x](https://github.com/user-attachments/assets/04da6777-7ad4-4e05-9c57-b068e2080f1a)

## Testing steps

<!-- Describe step by step how to test the change being introduced -->

Manual testing on the playground page with a non-string ReactNode example

## Relates issues / PRs

<!-- List out related issues and PR links -->
