### PR TITLE
Export ThemeContext

### DIFF
--- a/packages/radix-ui-themes/src/components/theme.tsx
+++ b/packages/radix-ui-themes/src/components/theme.tsx
@@ -220,5 +220,5 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
 });
 ThemeImpl.displayName = 'ThemeImpl';
 
-export { Theme, useThemeContext };
+export { Theme, ThemeContext, useThemeContext };
 export type { ThemeProps };


### PR DESCRIPTION
## Description

I need Radix Themes to be defined on the `<body>` element (so that, for example, the body can have a background set), and I'm providing my own implementation of `ThemeContext`. But the `ThemeContext` variable isn't exported (even though `useThemeContext` is exported), which prevents me from being able to provide a theme context on my own.

This PR exports `ThemeContext` to enable uses cases where we need to control the behavior of the theme.

## Testing steps

N/A
