### PR TITLE
fix: allow nesting sized containers

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -5893,6 +5893,37 @@ export default function Sink() {
                       </Flex>
                     </Flex>
                   </DocsSection>
+
+                  <DocsSection title="Container">
+                    <Text as="p" my="5">
+                      <Code>size</Code> can be set on nested <Code>Container</Code> instances:
+                    </Text>
+
+                    <Container size="4">
+                      <Box
+                        style={{
+                          backgroundColor: 'var(--color-panel-solid)',
+                          borderRadius: 'var(--radius-2)',
+                          boxShadow: 'inset 0 0 0 1px var(--gray-a4)',
+                        }}
+                        p="2"
+                      >
+                        <Text>This should be size 4</Text>
+                      </Box>
+                      <Container size="1">
+                        <Box
+                          style={{
+                            backgroundColor: 'var(--color-panel-solid)',
+                            borderRadius: 'var(--radius-2)',
+                            boxShadow: 'inset 0 0 0 1px var(--gray-a4)',
+                          }}
+                          p="2"
+                        >
+                          <Text>This should be size 1</Text>
+                        </Box>
+                      </Container>
+                    </Container>
+                  </DocsSection>
                 </main>
               </Box>
             </div>

--- a/packages/radix-ui-themes/src/components/container.css
+++ b/packages/radix-ui-themes/src/components/container.css
@@ -26,16 +26,16 @@
 
 @breakpoints {
   .rt-ContainerInner {
-    :where(.rt-Container.rt-r-size-1) & {
+    :where(.rt-Container.rt-r-size-1) > & {
       max-width: var(--container-1);
     }
-    :where(.rt-Container.rt-r-size-2) & {
+    :where(.rt-Container.rt-r-size-2) > & {
       max-width: var(--container-2);
     }
-    :where(.rt-Container.rt-r-size-3) & {
+    :where(.rt-Container.rt-r-size-3) > & {
       max-width: var(--container-3);
     }
-    :where(.rt-Container.rt-r-size-4) & {
+    :where(.rt-Container.rt-r-size-4) > & {
       max-width: var(--container-4);
     }
   }


### PR DESCRIPTION
## Description

Currently, if you try to nest a `Container` component with a smaller `size` than a `Container` component that wraps it at any level, the `size` does not correctly take effect. It always uses the largest `size` of any wrapping `Container` component due to CSS specificity.

This PR resolves this by applying the CSS for the sizing specifically to `.rt-ContainerInner` that are a **direct descendent** of the `.rt-Container`.

## Testing steps

Use the following JSX and check the correct widths are applied in browser.

```jsx
<Container size="4">
  <Text>This should be size 4</Text>
  <Container size="1">
    <Text>This should be size 1</Text>
  </Container>
</Container>
```

Alternatively, review the new Container samples in the "sink" demo example page.

## Related issues / PRs

N/A