### PR TITLE
[Popover]: remove min-width on `Popover.Content`

### DIFF
--- a/packages/radix-ui-themes/src/components/popover.css
+++ b/packages/radix-ui-themes/src/components/popover.css
@@ -4,7 +4,6 @@
   outline: 0;
   overflow: auto;
   position: relative;
-
   --inset-padding-top: var(--popover-content-padding);
   --inset-padding-right: var(--popover-content-padding);
   --inset-padding-bottom: var(--popover-content-padding);

--- a/packages/radix-ui-themes/src/components/popover.css
+++ b/packages/radix-ui-themes/src/components/popover.css
@@ -1,7 +1,6 @@
 .rt-PopoverContent {
   background-color: var(--color-panel-solid);
   box-shadow: var(--shadow-5);
-  min-width: var(--radix-popover-trigger-width);
   outline: 0;
   overflow: auto;
   position: relative;

--- a/packages/radix-ui-themes/src/components/popover.css
+++ b/packages/radix-ui-themes/src/components/popover.css
@@ -4,6 +4,7 @@
   outline: 0;
   overflow: auto;
   position: relative;
+
   --inset-padding-top: var(--popover-content-padding);
   --inset-padding-right: var(--popover-content-padding);
   --inset-padding-bottom: var(--popover-content-padding);


### PR DESCRIPTION
<!--

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description
Removed min-width CSS on `Popover.Content`. This was causing 2 issues as far as I can tell.
1. When the Popover.Trigger is wide, the content of the Popover will stretch to the same width of the trigger (`--radix-popover-trigger-width`)
2. Even when explicitly stating `<Popover.Content maxWidth="120px"/>`, the Content will stretch to the same size as the `Trigger`.

<img width="839" alt="Screenshot 2024-10-03 at 12 26 36" src="https://github.com/user-attachments/assets/04b41245-192d-4f5d-90dc-00e76c523dc8">