### PR TITLE
Add `minimal` variant for `Table`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ storybook-static/
 packages/radix-ui-themes/*.css
 packages/radix-ui-themes/tokens
 packages/radix-ui-themes/layout
+.vscode/settings.json

--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -232,7 +232,7 @@ export default function Sink() {
                               </Button>
                             </Tooltip>
 
-                            <Tooltip content="The goal of typography is to relate font size, line height, and line width in a proportional way that maximizes beauty and makes reading easier and more pleasant.">
+                            <Tooltip content="The goal of typography is to relate font size, line height, and line width in a proportional way that maximizes beauty and makes reading easier and more pleasant.">
                               <Button variant="solid" size="1">
                                 Multiline
                               </Button>
@@ -3770,7 +3770,7 @@ export default function Sink() {
                                   Typography
                                 </Text>
                                 <Text as="p" color="gray" size={size} style={{ maxWidth: '40ch' }}>
-                                  The goal of typography is to relate font size, line height, and
+                                  The goal of typography is to relate font size, line height, and
                                   line width in a proportional way that maximizes beauty and makes
                                   reading easier and more pleasant.
                                 </Text>
@@ -3797,17 +3797,28 @@ export default function Sink() {
                         </Text>
                         <TableExample />
                       </Flex>
+
+                      <Flex direction="column" gap="3">
+                        <Text color="gray" size="2">
+                          minimal
+                        </Text>
+                        <TableExample variant="minimal" />
+                      </Flex>
                     </Grid>
 
+                    <Separator size="4" my="5" />
+
                     <Grid columns="3" gap="5" mt="5">
-                      {tableRootPropDefs.size.values.map((size) => (
-                        <div key={size}>
-                          <Text as="p" color="gray" size="2" mb="3">
-                            size {size}
-                          </Text>
-                          <TableExample size={size} variant="surface" noEmail />
-                        </div>
-                      ))}
+                      {tableRootPropDefs.variant.values.flatMap((variant) =>
+                        tableRootPropDefs.size.values.map((size) => (
+                          <div key={variant + size}>
+                            <Text as="p" color="gray" size="2" mb="3">
+                              variant {variant}, size {size}
+                            </Text>
+                            <TableExample size={size} variant={variant} noEmail />
+                          </div>
+                        ))
+                      )}
                     </Grid>
                   </DocsSection>
 
@@ -3831,27 +3842,27 @@ export default function Sink() {
                       </Heading>
 
                       <Heading size="8">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                       </Heading>
 
                       <Heading size="7">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way
                       </Heading>
 
                       <Heading size="6">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way
                       </Heading>
 
                       <Text color="gray" size="5">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes beauty and makes reading easier and
                         more pleasant.
                       </Text>
 
                       <Text as="p" size="4">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes beauty and makes reading easier and
                         more pleasant. The question is: What proportion(s) will give us the best
                         results? The golden ratio is often observed in nature where beauty and
@@ -3860,7 +3871,7 @@ export default function Sink() {
                       </Text>
 
                       <Text as="p" size="3" style={{ maxWidth: 600 }}>
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes beauty and makes reading easier and
                         more pleasant. The question is: What proportion(s) will give us the best
                         results? The golden ratio is often observed in nature where beauty and
@@ -3870,7 +3881,7 @@ export default function Sink() {
 
                       <Grid columns="2" gap="5">
                         <Text as="p" size="2" style={{ maxWidth: 400 }}>
-                          The goal of typography is to relate font size, line height, and line width
+                          The goal of typography is to relate font size, line height, and line width
                           in a proportional way that maximizes beauty and makes reading easier and
                           more pleasant. The question is: What proportion(s) will give us the best
                           results? The golden ratio is often observed in nature where beauty and
@@ -3879,7 +3890,7 @@ export default function Sink() {
                         </Text>
 
                         <Text as="p" size="1" style={{ maxWidth: 400 }}>
-                          The goal of typography is to relate font size, line height, and line width
+                          The goal of typography is to relate font size, line height, and line width
                           in a proportional way that maximizes beauty and makes reading easier and
                           more pleasant. The question is: What proportion(s) will give us the best
                           results? The golden ratio is often observed in nature where beauty and
@@ -3938,7 +3949,7 @@ export default function Sink() {
                           The principles of the Typographic Craft are difficult to master
                         </Heading>
                         <Text as="p" size="4">
-                          The goal of typography is to relate font size, line height, and line width
+                          The goal of typography is to relate font size, line height, and line width
                           in a proportional way that maximizes beauty and makes reading easier and
                           more pleasant.
                         </Text>
@@ -3950,7 +3961,7 @@ export default function Sink() {
                             The principles of the Typographic Craft are difficult to master
                           </Heading>
                           <Text as="p" size="3">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes beauty and makes reading
                             easier and more pleasant.
                           </Text>
@@ -3960,7 +3971,7 @@ export default function Sink() {
                             The principles of the Typographic Craft are difficult to master
                           </Heading>
                           <Text as="p" size="2">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes beauty and makes reading
                             easier and more pleasant.
                           </Text>
@@ -3970,30 +3981,30 @@ export default function Sink() {
                       <Grid columns="3" gap="5">
                         <Box>
                           <Heading size="2" mb="1">
-                            The principles of the Typographic Craft are difficult to master
+                            The principles of the Typographic Craft are difficult to master
                           </Heading>
                           <Text as="p" size="2">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes beauty and makes reading
                             easier and more pleasant.
                           </Text>
                         </Box>
                         <Box>
                           <Heading size="2" mb="1">
-                            The principles of the Typographic Craft are difficult to master
+                            The principles of the Typographic Craft are difficult to master
                           </Heading>
                           <Text as="p" size="1">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes beauty and makes reading
                             easier and more pleasant.
                           </Text>
                         </Box>
                         <Box>
                           <Heading size="1" mb="1">
-                            The principles of the Typographic Craft are difficult to master
+                            The principles of the Typographic Craft are difficult to master
                           </Heading>
                           <Text as="p" size="1">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes beauty and makes reading
                             easier and more pleasant.
                           </Text>
@@ -4517,21 +4528,21 @@ export default function Sink() {
                   <DocsSection title="Blockquote">
                     <Flex direction="column" align="start" gap="5">
                       <Blockquote size="6" style={{ maxWidth: '50ch' }}>
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes beauty and makes reading easier and
                         more pleasant. The question is: What proportion(s) will give us the best
                         results?
                       </Blockquote>
 
                       <Blockquote size="4" style={{ maxWidth: '50ch' }} color="gray" highContrast>
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes <Text color="pink">beauty</Text> and
                         makes reading easier and more pleasant. The question is: What proportion(s)
                         will give us the best results?
                       </Blockquote>
 
                       <Blockquote size="2" style={{ maxWidth: '50ch' }} color="blue">
-                        The goal of typography is to relate font size, line height, and line width
+                        The goal of typography is to relate font size, line height, and line width
                         in a proportional way that maximizes <Text highContrast>beauty</Text> and
                         makes reading easier and more pleasant. The question is: What proportion(s)
                         will give us the best results?
@@ -4979,7 +4990,7 @@ export default function Sink() {
                           }}
                         />
                         <Text as="p">
-                          The goal of typography is to relate font size, line height, and line width
+                          The goal of typography is to relate font size, line height, and line width
                           in a proportional way that maximizes beauty and makes reading easier and
                           more pleasant. The question is: What proportion(s) will give us the best
                           results? The golden ratio is often observed in nature where beauty and
@@ -5361,7 +5372,7 @@ export default function Sink() {
                           <Heading size="5">Principles of the Typographic Craft</Heading>
 
                           <Blockquote size="2" style={{ maxWidth: '50ch' }} color="gray">
-                            The goal of typography is to relate font size, line height, and line
+                            The goal of typography is to relate font size, line height, and line
                             width in a proportional way that maximizes{' '}
                             <Text highContrast>beauty</Text> and makes reading easier and more
                             pleasant. The question is: What proportion(s) will give us the best
@@ -5489,7 +5500,7 @@ export default function Sink() {
 
                           <Skeleton>
                             <Blockquote size="2" style={{ maxWidth: '50ch' }} color="gray">
-                              The goal of typography is to relate font size, line height, and line
+                              The goal of typography is to relate font size, line height, and line
                               width in a proportional way that maximizes{' '}
                               <Text highContrast>beauty</Text> and makes reading easier and more
                               pleasant. The question is: What proportion(s) will give us the best

--- a/packages/radix-ui-themes/src/components/table.css
+++ b/packages/radix-ui-themes/src/components/table.css
@@ -1,3 +1,11 @@
+.rt-TableRoot {
+  --table-root-border-width: 0;
+  --table-root-border-style: none;
+  --table-root-border-color: var(--gray-a5);
+
+  border: var(--table-root-border-width) var(--table-root-border-style) var(--table-root-border-color);
+}
+
 .rt-TableRootTable {
   --table-row-background-color: transparent;
   --table-row-box-shadow: inset 0 -1px var(--gray-a5);
@@ -32,16 +40,17 @@
   box-shadow: var(--table-row-box-shadow);
   box-sizing: border-box;
   vertical-align: inherit;
-  padding: var(--table-cell-padding);
+  padding: var(--table-cell-padding-top) var(--table-cell-padding-right) var(--table-cell-padding-bottom)
+    var(--table-cell-padding-left);
   /* Works as min-height */
   height: var(--table-cell-min-height);
 
   /* Inset with Table */
   .rt-Inset :where(&:first-child) {
-    padding-left: var(--inset-padding-left, var(--table-cell-padding));
+    padding-left: var(--inset-padding-left, var(--table-cell-padding-left));
   }
   .rt-Inset :where(&:last-child) {
-    padding-right: var(--inset-padding-right, var(--table-cell-padding));
+    padding-right: var(--inset-padding-right, var(--table-cell-padding-right));
   }
 }
 .rt-TableColumnHeaderCell {
@@ -59,9 +68,14 @@
 
 @breakpoints {
   .rt-TableRoot {
+    /* for backward compatibility */
+    --table-cell-padding: var(--table-cell-padding-top) var(--table-cell-padding-right);
     &:where(.rt-r-size-1) {
       --table-border-radius: var(--radius-3);
-      --table-cell-padding: var(--space-2);
+      --table-cell-padding-top: var(--space-2);
+      --table-cell-padding-bottom: var(--space-2);
+      --table-cell-padding-right: var(--space-2);
+      --table-cell-padding-left: var(--space-2);
       --table-cell-min-height: calc(36px * var(--scaling));
 
       & :where(.rt-TableRootTable) {
@@ -71,7 +85,10 @@
     }
     &:where(.rt-r-size-2) {
       --table-border-radius: var(--radius-4);
-      --table-cell-padding: var(--space-3);
+      --table-cell-padding-top: var(--space-3);
+      --table-cell-padding-bottom: var(--space-3);
+      --table-cell-padding-right: var(--space-3);
+      --table-cell-padding-left: var(--space-3);
       --table-cell-min-height: calc(44px * var(--scaling));
 
       & :where(.rt-TableRootTable) {
@@ -81,7 +98,10 @@
     }
     &:where(.rt-r-size-3) {
       --table-border-radius: var(--radius-4);
-      --table-cell-padding: var(--space-3) var(--space-4);
+      --table-cell-padding-top: var(--space-3);
+      --table-cell-padding-bottom: var(--space-3);
+      --table-cell-padding-right: var(--space-4);
+      --table-cell-padding-left: var(--space-4);
       --table-cell-min-height: var(--space-8);
 
       & :where(.rt-TableRootTable) {
@@ -101,8 +121,9 @@
 /* surface */
 
 .rt-TableRoot:where(.rt-variant-surface) {
+  --table-root-border-width: 1px;
+  --table-root-border-style: solid;
   box-sizing: border-box;
-  border: 1px solid var(--gray-a5);
   border-radius: var(--table-border-radius);
   background-color: var(--color-panel);
   backdrop-filter: var(--backdrop-filter-panel);
@@ -111,7 +132,7 @@
 
   /* When possible, use half-transparent gray for nicer border blending with the background */
   @supports (box-shadow: 0 0 0 1px color-mix(in oklab, white, black)) {
-    border-color: color-mix(in oklab, var(--gray-a5), var(--gray-6));
+    --table-root-border-color: color-mix(in oklab, var(--gray-a5), var(--gray-6));
   }
 
   & :where(.rt-TableRootTable) {
@@ -131,4 +152,38 @@
 .rt-TableRoot:where(.rt-variant-ghost) {
   --scrollarea-scrollbar-horizontal-margin-left: 0;
   --scrollarea-scrollbar-horizontal-margin-right: 0;
+}
+
+/* minimal */
+
+.rt-TableRoot:where(.rt-variant-minimal) {
+  --scrollarea-scrollbar-horizontal-margin-left: 0;
+  --scrollarea-scrollbar-horizontal-margin-right: 0;
+  & :where(.rt-TableRootTable) {
+    --table-row-box-shadow: none;
+  }
+  & :where(.rt-TableCell:first-child) {
+    --table-cell-padding-left: 0;
+  }
+  & :where(.rt-TableCell:last-child) {
+    --table-cell-padding-right: 0;
+  }
+
+  @breakpoints {
+    &:where(.rt-r-size-1) {
+      --table-cell-padding-top: var(--space-1);
+      --table-cell-padding-bottom: var(--space-1);
+      --table-cell-min-height: calc(28px * var(--scaling));
+    }
+    &:where(.rt-r-size-2) {
+      --table-cell-padding-top: var(--space-2);
+      --table-cell-padding-bottom: var(--space-2);
+      --table-cell-min-height: calc(36px * var(--scaling));
+    }
+    &:where(.rt-r-size-3) {
+      --table-cell-padding-top: var(--space-2);
+      --table-cell-padding-bottom: var(--space-2);
+      --table-cell-min-height: calc(40px * var(--scaling));
+    }
+  }
 }

--- a/packages/radix-ui-themes/src/components/table.props.ts
+++ b/packages/radix-ui-themes/src/components/table.props.ts
@@ -4,7 +4,7 @@ import { widthPropDefs } from '../props/width.props.js';
 import type { PropDef } from '../props/prop-def.js';
 
 const sizes = ['1', '2', '3'] as const;
-const variants = ['surface', 'ghost'] as const;
+const variants = ['surface', 'ghost', 'minimal'] as const;
 const layoutValues = ['auto', 'fixed'] as const;
 
 const tableRootPropDefs = {


### PR DESCRIPTION
The new `minimal` table variant includes no borders between cells, and first/last cells will have their left/right padding removed respectively.

Screenshot of the new variant adjacent to the other variants at each size:

![CleanShot 2024-10-03 at 14 10 40@2x](https://github.com/user-attachments/assets/84661d2c-547f-4bd2-87ac-ea78b4fd63c0)
