### PR TITLE
Segmented control: Support `disabled` prop

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -5722,6 +5722,7 @@ export default function Sink() {
                       <thead>
                         <tr>
                           <ColumnHeaderCell />
+                          <ColumnHeaderCell>disabled</ColumnHeaderCell>
                           {segmentedControlRootPropDefs.size.values.map((size) => (
                             <ColumnHeaderCell key={size}>size {size}</ColumnHeaderCell>
                           ))}
@@ -5731,6 +5732,18 @@ export default function Sink() {
                         {segmentedControlRootPropDefs.variant.values.map((variant) => (
                           <tr key={variant}>
                             <RowHeaderCell>{variant}</RowHeaderCell>
+                            <td>
+                              <SegmentedControl.Root
+                                size="1"
+                                variant={variant}
+                                defaultValue="1"
+                                disabled={true}
+                              >
+                                <SegmentedControl.Item value="1">One</SegmentedControl.Item>
+                                <SegmentedControl.Item value="2">Two</SegmentedControl.Item>
+                                <SegmentedControl.Item value="3">Three</SegmentedControl.Item>
+                              </SegmentedControl.Root>
+                            </td>
                             {segmentedControlRootPropDefs.size.values.map((size) => (
                               <td key={size}>
                                 <SegmentedControl.Root

--- a/packages/radix-ui-themes/src/components/segmented-control.css
+++ b/packages/radix-ui-themes/src/components/segmented-control.css
@@ -20,6 +20,12 @@
 
   /* Create a new stacking context */
   isolation: isolate;
+
+  &.disabled {
+    cursor: var(--cursor-disabled);
+    color: var(--gray-a8);
+    background-color: var(--gray-3);
+  }
 }
 
 .rt-SegmentedControlItem {
@@ -56,7 +62,7 @@
   }
 
   @media (hover: hover) {
-    :where(.rt-SegmentedControlItem[data-state='off']:hover) & {
+    :where(.rt-SegmentedControlItem[data-state='off']:not([disabled]):hover) & {
       background-color: var(--gray-a2);
     }
   }
@@ -153,6 +159,15 @@
 
   :where(.rt-SegmentedControlItem[data-state='on']) ~ & {
     display: block;
+  }
+
+  :where(.rt-SegmentedControlItem[disabled]) ~ & {
+    --segmented-control-indicator-background-color: var(--gray-a3);
+
+    &::before {
+      inset: 0px;
+      box-shadow: none;
+    }
   }
 
   &:where(:nth-child(2)) {
@@ -279,9 +294,11 @@
 /* * * * * * * * * * * * * * * * * * * */
 
 .rt-SegmentedControlRoot:where(.rt-variant-surface) {
-  & :where(.rt-SegmentedControlIndicator) {
-    &::before {
-      box-shadow: 0 0 0 1px var(--gray-a4);
+  & :where(.rt-SegmentedControlItem:not([disabled])) {
+    & :where(.rt-SegmentedControlIndicator) {
+      &::before {
+        box-shadow: 0 0 0 1px var(--gray-a4);
+      }
     }
   }
 }
@@ -293,9 +310,11 @@
 /* * * * * * * * * * * * * * * * * * * */
 
 .rt-SegmentedControlRoot:where(.rt-variant-classic) {
-  & :where(.rt-SegmentedControlIndicator) {
-    &::before {
-      box-shadow: var(--shadow-2);
+  & :where(.rt-SegmentedControlItem:not([disabled])) {
+    & :where(.rt-SegmentedControlIndicator) {
+      &::before {
+        box-shadow: var(--shadow-2);
+      }
     }
   }
 }

--- a/packages/radix-ui-themes/src/components/segmented-control.props.ts
+++ b/packages/radix-ui-themes/src/components/segmented-control.props.ts
@@ -6,10 +6,12 @@ const sizes = ['1', '2', '3'] as const;
 const variants = ['surface', 'classic'] as const;
 
 const segmentedControlRootPropDefs = {
+  disabled: { type: 'boolean', className: 'disabled', default: false },
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
   variant: { type: 'enum', className: 'rt-variant', values: variants, default: 'surface' },
   ...radiusPropDef,
 } satisfies {
+  disabled?: PropDef<boolean>;
   size: PropDef<(typeof sizes)[number]>;
   variant: PropDef<(typeof variants)[number]>;
 };

--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -56,7 +56,7 @@ const SegmentedControlRoot = React.forwardRef<HTMLDivElement, SegmentedControlRo
         type="single"
         value={value}
         asChild={false}
-        disabled={false}
+        disabled={!!props.disabled}
       >
         {children}
         <div className="rt-SegmentedControlIndicator" />


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

Extend `SegmentedControl` to support `disabled` functionality and style. In this implementation both `classic` and `surface` variants share the same disabled styles. [See design spec ](https://www.figma.com/design/Bdv2UWN3GrAH4qUIL7Ldnl/Launch-Week%3A-Radar?node-id=2687-22849&node-type=frame&t=S9FfI6CBMSrkXWkN-0)and [context for request](https://work-os.slack.com/archives/C066T3GNG4Q/p1729705862819629?thread_ts=1729704870.866939&cid=C066T3GNG4Q).

<img width="916" alt="Screenshot 2024-10-29 at 2 08 23 PM" src="https://github.com/user-attachments/assets/cb48e896-c831-42d9-9177-477c3f722fa5">
<img width="884" alt="Screenshot 2024-10-29 at 2 08 28 PM" src="https://github.com/user-attachments/assets/95aafc1a-2a02-4d61-888e-a2661a5e7389">

## Testing steps

Visit the [sink page in the playground](https://themes-playground-git-ksadd-segmented-control-disabled-workos.vercel.app/sink#segmented-control) to see the disabled control.

## Relates issues / PRs

<!-- List out related issues and PR links -->
