### PR TITLE
fix: remove Firefox input outline

### DIFF
--- a/packages/radix-ui-themes/src/components/text-area.css
+++ b/packages/radix-ui-themes/src/components/text-area.css
@@ -56,6 +56,13 @@
     background-clip: text;
     -webkit-text-fill-color: var(--gray-12);
   }
+
+  /* Remove outline on Firefox */
+  @supports (-moz-appearance: none) {
+    &:focus {
+      outline: none;
+    }
+  }
 }
 
 /***************************************************************************************************

--- a/packages/radix-ui-themes/src/components/text-field.css
+++ b/packages/radix-ui-themes/src/components/text-field.css
@@ -110,6 +110,13 @@
       -webkit-text-fill-color: var(--gray-12);
     }
   }
+
+  /* Remove outline on Firefox */
+  @supports (-moz-appearance: none) {
+    &:focus {
+      outline: none;
+    }
+  }
 }
 
 .rt-TextFieldSlot {


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

![스크린샷 2024-11-05 시간: 02 59 59](https://github.com/user-attachments/assets/74a7cab9-ec26-473e-a6d6-01abdcb3862b)

Fixed unwanted outline appearing on input elements in Firefox browser.
Modified CSS to remove outline specifically for Firefox while maintaining styles in other browsers.

## Testing steps

1. Check input fields in Firefox browser
2. Verify no unwanted outline appears when clicking input fields
3. Confirm existing styles are maintained in other browsers (Chrome, Safari)

## Relates issues / PRs

N/A