### PR TITLE
Fix CSS specificity issues with `SegmentedControl`

### DIFF
--- a/packages/radix-ui-themes/src/components/segmented-control.css
+++ b/packages/radix-ui-themes/src/components/segmented-control.css
@@ -20,12 +20,11 @@
 
   /* Create a new stacking context */
   isolation: isolate;
+}
 
-  &.disabled {
-    cursor: var(--cursor-disabled);
-    color: var(--gray-a8);
-    background-color: var(--gray-3);
-  }
+.rt-SegmentedControlRoot:where([data-disabled]) {
+  color: var(--gray-a8);
+  background-color: var(--gray-3);
 }
 
 .rt-SegmentedControlItem {

--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -44,6 +44,7 @@ const SegmentedControlRoot = React.forwardRef<HTMLDivElement, SegmentedControlRo
 
     return (
       <ToggleGroupPrimitive.Root
+        data-disabled={props.disabled || undefined}
         data-radius={radius}
         ref={forwardedRef}
         className={classNames('rt-SegmentedControlRoot', className)}


### PR DESCRIPTION
This fixes two existing issues with style linting:

```
src/components/segmented-control.css
  24:3  ✖  Expected "&.disabled" to have a specificity no more than "0,1,1"                                             selector-max-specificity
  24:4  ✖  Expected ".disabled" to match pattern "/^((xs|sm|md|lg|xl):)?-?rt-|^radix-themes$|^(light|dark)(-theme)?$/"  selector-class-pattern
```