### PR TITLE
dialog: Fix animation flash on close

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -9,6 +9,7 @@
   // We recommend using namespaced imports for compound components
   import * as CheckboxGroup from '@radix-ui/themes/checkbox-group';
   ```
+- Fix visibility flash with closing dialogs ([#649](https://github.com/radix-ui/themes/pull/649))
 
 ## 3.1.6
 

--- a/packages/radix-ui-themes/src/components/_internal/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-dialog.css
@@ -88,7 +88,7 @@
       opacity: 1;
     }
     to {
-      opacity: 0;
+      opacity: 1;
     }
   }
 

--- a/packages/radix-ui-themes/src/components/_internal/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-dialog.css
@@ -84,11 +84,10 @@
 
 @media (prefers-reduced-motion: no-preference) {
   @keyframes rt-dialog-overlay-no-op {
-    0%,
-    99% {
+    from {
       opacity: 1;
     }
-    100% {
+    to {
       opacity: 0;
     }
   }
@@ -124,6 +123,7 @@
       animation: rt-fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
     }
     &:where([data-state='closed'])::before {
+      opacity: 0;
       animation: rt-fade-out 160ms cubic-bezier(0.16, 1, 0.3, 1);
     }
   }
@@ -133,6 +133,7 @@
       animation: rt-dialog-content-show 200ms cubic-bezier(0.16, 1, 0.3, 1);
     }
     &:where([data-state='closed']) {
+      opacity: 0;
       animation: rt-dialog-content-hide 100ms cubic-bezier(0.16, 1, 0.3, 1);
     }
   }

--- a/packages/radix-ui-themes/src/components/_internal/base-dialog.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-dialog.css
@@ -84,11 +84,12 @@
 
 @media (prefers-reduced-motion: no-preference) {
   @keyframes rt-dialog-overlay-no-op {
-    from {
+    0%,
+    99% {
       opacity: 1;
     }
-    to {
-      opacity: 1;
+    100% {
+      opacity: 0;
     }
   }
 
@@ -119,7 +120,6 @@
     &:where([data-state='closed']) {
       animation: rt-dialog-overlay-no-op 160ms cubic-bezier(0.16, 1, 0.3, 1);
     }
-
     &:where([data-state='open'])::before {
       animation: rt-fade-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
     }


### PR DESCRIPTION
This PR fixes the animation "flash" when closing a dialog. The root cause is a "noop" animation intended to persist the parent element's visibility long enough for its children to animate out. While the children have animations to `opacity: 0` when the dialog is closed, the opacity property itself is not set to 0. So if the child animations complete before the parent, the opacity will briefly return to its initial value. Setting the opacity to 0 fixes this.

Closes #640

https://github.com/user-attachments/assets/e78badc1-a88b-47f6-9754-d718d53a3670