### PR TITLE
segmented-control: Prevent double screen-reader announcements

### DIFF
--- a/packages/radix-ui-themes/changelog.md
+++ b/packages/radix-ui-themes/changelog.md
@@ -10,6 +10,7 @@
   import * as CheckboxGroup from '@radix-ui/themes/checkbox-group';
   ```
 - Fix visibility flash with closing dialogs ([#649](https://github.com/radix-ui/themes/pull/649))
+- Add `aria-hidden="true"` to duplicate nodes in `SegmentedControl.Item` to prevent double-reading by screen readers ([#651](https://github.com/radix-ui/themes/pull/651))
 
 ## 3.1.6
 

--- a/packages/radix-ui-themes/src/components/segmented-control.tsx
+++ b/packages/radix-ui-themes/src/components/segmented-control.tsx
@@ -91,7 +91,9 @@ const SegmentedControlItem = React.forwardRef<HTMLButtonElement, SegmentedContro
       <span className="rt-SegmentedControlItemSeparator" />
       <span className="rt-SegmentedControlItemLabel">
         <span className="rt-SegmentedControlItemLabelActive">{children}</span>
-        <span className="rt-SegmentedControlItemLabelInactive">{children}</span>
+        <span className="rt-SegmentedControlItemLabelInactive" aria-hidden>
+          {children}
+        </span>
       </span>
     </ToggleGroupPrimitive.Item>
   )


### PR DESCRIPTION
`SegmentedControl.Item` duplicates its child contents, resulting in duplicate content in the accessibility tree. Adding `aria-hidden` to the inactive item to fix that.

Closes #646.