### PR TITLE
Segmented control: fix indicator box shadow regression

### DIFF
--- a/packages/radix-ui-themes/src/components/segmented-control.css
+++ b/packages/radix-ui-themes/src/components/segmented-control.css
@@ -293,11 +293,9 @@
 /* * * * * * * * * * * * * * * * * * * */
 
 .rt-SegmentedControlRoot:where(.rt-variant-surface) {
-  & :where(.rt-SegmentedControlItem:not([disabled])) {
-    & :where(.rt-SegmentedControlIndicator) {
-      &::before {
-        box-shadow: 0 0 0 1px var(--gray-a4);
-      }
+  & :where(.rt-SegmentedControlItem:not([disabled])) ~ :where(.rt-SegmentedControlIndicator) {
+    &::before {
+      box-shadow: 0 0 0 1px var(--gray-a4);
     }
   }
 }
@@ -309,11 +307,9 @@
 /* * * * * * * * * * * * * * * * * * * */
 
 .rt-SegmentedControlRoot:where(.rt-variant-classic) {
-  & :where(.rt-SegmentedControlItem:not([disabled])) {
-    & :where(.rt-SegmentedControlIndicator) {
-      &::before {
-        box-shadow: var(--shadow-2);
-      }
+  & :where(.rt-SegmentedControlItem:not([disabled])) ~ :where(.rt-SegmentedControlIndicator) {
+    &::before {
+      box-shadow: var(--shadow-2);
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

Fixes regression introduced in #621 where all segmented control indicators (both classic and surface variants) lost their box shadow styles. For disabled controls, there should be no box shadow on the indicator control. The CSS wasn't treating the indicator as a sibling of the item.

### Disabled styles
<img width="1393" alt="Screenshot 2024-12-23 at 2 58 09 PM" src="https://github.com/user-attachments/assets/ba7a0df3-b3d0-4c2a-8a6d-730fe1cac5f0" />

### Active styles
<img width="1431" alt="Screenshot 2024-12-23 at 2 57 54 PM" src="https://github.com/user-attachments/assets/f24e0b5a-449f-40bb-92a3-a4d9fc87dda7" />


## Testing steps

Visit the playground, check that both the classic and surface variant has the correct box shadow on the `::before` pseudoselecter for active controls.

## Relates issues / PRs

- [PR introducing bug](https://github.com/radix-ui/themes/pull/621/)
- [Related issue](https://github.com/radix-ui/themes/issues/635)
