### PR TITLE
fix `sideEffects` declaration

### DIFF
--- a/packages/radix-ui-themes/esbuild-esm.mjs
+++ b/packages/radix-ui-themes/esbuild-esm.mjs
@@ -1,6 +1,7 @@
 import esbuild from 'esbuild';
 import fs from 'fs';
 import path from 'path';
+import pkg from './package.json' assert { type: 'json' };
 
 const dir = 'dist/esm';
 
@@ -30,6 +31,6 @@ if (!fs.existsSync(dir)) {
 }
 fs.writeFileSync(
   path.join(dir, 'package.json'),
-  JSON.stringify({ type: 'module' }, null, 2) + '\n',
+  JSON.stringify({ type: 'module', sideEffects: pkg.sideEffects }, null, 2) + '\n',
   'utf-8'
 );

--- a/packages/radix-ui-themes/esbuild-esm.mjs
+++ b/packages/radix-ui-themes/esbuild-esm.mjs
@@ -1,7 +1,7 @@
 import esbuild from 'esbuild';
 import fs from 'fs';
 import path from 'path';
-import pkg from './package.json' assert { type: 'json' };
+import pkg from './package.json' with { type: 'json' };
 
 const dir = 'dist/esm';
 

--- a/packages/radix-ui-themes/package.json
+++ b/packages/radix-ui-themes/package.json
@@ -55,7 +55,7 @@
       }
     }
   },
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "license": "MIT",
   "files": [
     "src/**",


### PR DESCRIPTION
## Description

With the current `sideEffects: false` declaration, webpack drops CSS files from the build completely. The line `import "@radix-ui/themes/styles.css";` does not have any effect

More details in the webpack issue: https://github.com/webpack/webpack/issues/6571

Also, the declaration need to propagate to the inner file in the `/esm` subfolder. Without that, every new package.json in a way assumes side effects by default

## Testing steps

Patched locally, it works. 

No differences found when using Vite

## Relates issues / PRs

A bunch PRs to other libraries with the same fix
* https://github.com/react-querybuilder/react-querybuilder/pull/763
* https://github.com/olifolkerd/tabulator/pull/3542
* https://github.com/adobe/react-spectrum/pull/707
* https://github.com/chartist-js/chartist/pull/1350