### PR TITLE
add support for custom select indicator

### DIFF
--- a/apps/playground/app/sink/page.tsx
+++ b/apps/playground/app/sink/page.tsx
@@ -602,6 +602,17 @@ export default function Sink() {
                     </table>
 
                     <Text as="p" my="5">
+                      Custom indicator:
+                    </Text>
+
+                    <Select.Root defaultValue="apple" indicator={<StarIcon />}>
+                      <Select.Trigger />
+                      <Select.Content>
+                        <SelectItemsDemo />
+                      </Select.Content>
+                    </Select.Root>
+
+                    <Text as="p" my="5">
                       <Code>radius</Code> can be set per instance:
                     </Text>
 

--- a/packages/radix-ui-themes/src/components/select.props.ts
+++ b/packages/radix-ui-themes/src/components/select.props.ts
@@ -8,8 +8,10 @@ const sizes = ['1', '2', '3'] as const;
 
 const selectRootPropDefs = {
   size: { type: 'enum', className: 'rt-r-size', values: sizes, default: '2', responsive: true },
+  indicator: { type: 'ReactNode' },
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
+  indicator: PropDef<React.ReactNode>;
 };
 
 const triggerVariants = ['classic', 'surface', 'soft', 'ghost'] as const;

--- a/packages/radix-ui-themes/src/components/select.tsx
+++ b/packages/radix-ui-themes/src/components/select.tsx
@@ -18,6 +18,7 @@ import { useThemeContext, Theme } from './theme.js';
 import type { MarginProps } from '../props/margin.props.js';
 import type { GetPropDefTypes } from '../props/prop-def.js';
 import type { ComponentPropsWithout, RemovedProps } from '../helpers/component-props.js';
+import { Box } from './box';
 
 type SelectRootOwnProps = GetPropDefTypes<typeof selectRootPropDefs>;
 
@@ -28,10 +29,10 @@ interface SelectRootProps
   extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>,
     SelectContextValue {}
 const SelectRoot: React.FC<SelectRootProps> = (props) => {
-  const { children, size = selectRootPropDefs.size.default, ...rootProps } = props;
+  const { children, size = selectRootPropDefs.size.default, indicator, ...rootProps } = props;
   return (
     <SelectPrimitive.Root {...rootProps}>
-      <SelectContext.Provider value={React.useMemo(() => ({ size }), [size])}>
+      <SelectContext.Provider value={React.useMemo(() => ({ size, indicator }), [size, indicator])}>
         {children}
       </SelectContext.Provider>
     </SelectPrimitive.Root>
@@ -141,6 +142,7 @@ interface SelectItemProps
   extends ComponentPropsWithout<typeof SelectPrimitive.Item, RemovedProps> {}
 const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>((props, forwardedRef) => {
   const { className, children, ...itemProps } = props;
+  const context = React.useContext(SelectContext);
   return (
     <SelectPrimitive.Item
       {...itemProps}
@@ -149,7 +151,9 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>((props, 
       className={classNames('rt-SelectItem', className)}
     >
       <SelectPrimitive.ItemIndicator className="rt-SelectItemIndicator">
-        <ThickCheckIcon className="rt-SelectItemIndicatorIcon" />
+        <Box asChild className="rt-SelectItemIndicatorIcon">
+          {context.indicator ?? <ThickCheckIcon  />}
+        </Box>
       </SelectPrimitive.ItemIndicator>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>

--- a/packages/radix-ui-themes/src/components/select.tsx
+++ b/packages/radix-ui-themes/src/components/select.tsx
@@ -29,7 +29,7 @@ interface SelectRootProps
   extends React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>,
     SelectContextValue {}
 const SelectRoot: React.FC<SelectRootProps> = (props) => {
-  const { children, size = selectRootPropDefs.size.default, indicator, ...rootProps } = props;
+  const { children, size = selectRootPropDefs.size.default, indicator = <ThickCheckIcon />, ...rootProps } = props;
   return (
     <SelectPrimitive.Root {...rootProps}>
       <SelectContext.Provider value={React.useMemo(() => ({ size, indicator }), [size, indicator])}>
@@ -152,7 +152,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>((props, 
     >
       <SelectPrimitive.ItemIndicator className="rt-SelectItemIndicator">
         <Box asChild className="rt-SelectItemIndicatorIcon">
-          {context.indicator ?? <ThickCheckIcon  />}
+          {context.indicator}
         </Box>
       </SelectPrimitive.ItemIndicator>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>


### PR DESCRIPTION
## Description

Adds the ability to provide a custom indicator to the `Select` component, replacing the default checkmark. This is useful in situations where you're using a custom icon set.

## Testing steps

Provide an `indicator` prop to `Select.Root`. This should be a `ReactNode`. An example is given in `sink.tsx`.