### PR TITLE
Change type of select placeholder from `string` to `ReactNode`

### DIFF
--- a/packages/radix-ui-themes/src/components/select.props.tsx
+++ b/packages/radix-ui-themes/src/components/select.props.tsx
@@ -18,10 +18,10 @@ const selectTriggerPropDefs = {
   variant: { type: 'enum', className: 'rt-variant', values: triggerVariants, default: 'surface' },
   ...colorPropDef,
   ...radiusPropDef,
-  placeholder: { type: 'string' },
+  placeholder: { type: 'ReactNode' },
 } satisfies {
   variant: PropDef<(typeof triggerVariants)[number]>;
-  placeholder: PropDef<string>;
+  placeholder: PropDef<React.ReactNode>;
 };
 
 const contentVariants = ['solid', 'soft'] as const;


### PR DESCRIPTION
## Description

The `placeholder` prop of `Select` currently accepts only the `string` type, but the prop is passed directly to `SelectPrimitive.Value` ([source](https://github.com/radix-ui/themes/blob/main/packages/radix-ui-themes/src/components/select.tsx#L66)), which accepts any React node ([source](https://github.com/radix-ui/primitives/blob/main/packages/react/select/src/select.tsx#L327)).

This PR changes to `placeholder` type to `ReactNode`, which resolves the inconsistency.

## Testing steps

Pass a React node to `placeholder` and it will produce a type error.

## Relates issues / PRs

None
