### PR TITLE
Prevent RadioCard appearing as chopped when zooming browser out

### DIFF
--- a/packages/radix-ui-themes/src/components/radio-cards.css
+++ b/packages/radix-ui-themes/src/components/radio-cards.css
@@ -18,6 +18,8 @@
   align-items: center;
   justify-content: center;
   gap: var(--space-2);
+  contain: layout;
+  overflow: visible;
 
   & > * {
     /* Avoid unintentional drag interactions (e.g. on images) */


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description
When zooming a browser out, a `RadioCards.Item` will appear as "chopped". This fixes the styling of the card so border is contained.

### Before:
![CleanShot 2025-05-02 at 13 05 12](https://github.com/user-attachments/assets/58365ddd-2908-4344-8220-7f46ff268b42)
![CleanShot 2025-05-02 at 13 26 39](https://github.com/user-attachments/assets/c00a4749-cd8b-4436-baa5-6dfadcce8387)


### After:
![CleanShot 2025-05-02 at 13 05 18](https://github.com/user-attachments/assets/18704227-e478-4884-a862-c817e4841001)
![CleanShot 2025-05-02 at 13 27 40](https://github.com/user-attachments/assets/ec3e1506-812b-4e4d-931a-dd6f46d8d85e)

## Testing steps
- Render a `<RadioCards.Item />`.
- Zoom your browser out below 100%.
- Notice the border is viewable around the card.


## Relates issues / PRs

<!-- List out related issues and PR links -->
