### PR TITLE
fix: animation properties not vendor prefixed

### DIFF
--- a/packages/radix-ui-themes/.browserslistrc
+++ b/packages/radix-ui-themes/.browserslistrc
@@ -1,1 +1,1 @@
-last 2 years
+last 2 years, last 2 versions


### PR DESCRIPTION
## Description

animation properties are not being prefixed by `autoprefixer` currently, which causes some animations (like the one in the linked issue) to not run as expected. 

Caveat: I do not understand why there are no vendor prefixes for https://browsersl.ist/#q=last+2+years but there are for https://browsersl.ist/#q=last+2+years%2C+last+2+version

## Testing steps

Manual review of the generated css on `pnpm build`

## Relates issues / PRs

Closes https://github.com/radix-ui/themes/issues/713
