### PR TITLE
Remove 'dense' option from grid-auto-flow 

### DIFF
--- a/packages/radix-ui-themes/src/components/grid.props.tsx
+++ b/packages/radix-ui-themes/src/components/grid.props.tsx
@@ -7,7 +7,7 @@ const as = ['div', 'span'] as const;
 const displayValues = ['none', 'inline-grid', 'grid'] as const;
 const columnsValues = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const rowsValues = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
-const flowValues = ['row', 'column', 'dense', 'row-dense', 'column-dense'] as const;
+const flowValues = ['row', 'column', 'row-dense', 'column-dense'] as const;
 const alignValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
 const justifyValues = ['start', 'center', 'end', 'between'] as const;
 


### PR DESCRIPTION
<!--

Thank you for contributing! Please follow the steps below to help us process your PR quickly.

- 📝 Use a meaningful title for the pull request and include the name of the package modified.
- 🔍 Add or edit demo examples in ./app/sink or other pages to reflect the change (run `pnpm dev`).
- 🙏 Please review your own PR to check for anything you may have missed.

-->

## Description

<!-- Describe the change you are introducing -->

In CSS Grid, grid-auto-flow: row dense and grid-auto-flow: dense are essentially the same. row is the default flow, so row dense is just a way to explicitly state that the grid should fill rows and then try to fill in any holes as tightly as possible. The dense keyword alone means the same thing, as it prioritizes filling gaps over respecting the original item order. 

## Testing steps

<!-- Describe step by step how to test the change being introduced -->

## Relates issues / PRs

<!-- List out related issues and PR links -->
