### PR TITLE
feat: theme high contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 node_modules
 .turbo
 *.log

--- a/packages/radix-ui-themes/.stylelintrc.cjs
+++ b/packages/radix-ui-themes/.stylelintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     // This is so that Tailwind classes work as expected.
     'selector-max-specificity': ['0,1,1'],
     // Enforce prefixes on classnames and keyframes
-    'selector-class-pattern': /^((xs|sm|md|lg|xl):)?-?rt-|^radix-themes$|^(light|dark)(-theme)?$/,
+    'selector-class-pattern': /^((xs|sm|md|lg|xl):)?-?rt-|^radix-themes$|^(light|dark)(-theme)?$|^more-contrast$/,
     'keyframes-name-pattern': /^rt-([a-z]|-)+$/,
   },
 };

--- a/packages/radix-ui-themes/.stylelintrc.cjs
+++ b/packages/radix-ui-themes/.stylelintrc.cjs
@@ -6,7 +6,7 @@ module.exports = {
     // This is so that Tailwind classes work as expected.
     'selector-max-specificity': ['0,1,1'],
     // Enforce prefixes on classnames and keyframes
-    'selector-class-pattern': /^((xs|sm|md|lg|xl):)?-?rt-|^radix-themes$|^(light|dark)(-theme)?$|^more-contrast$/,
+    'selector-class-pattern': /^((xs|sm|md|lg|xl):)?-?rt-|^radix-themes$|^(light|dark)(-theme)?$|^high-contrast$/,
     'keyframes-name-pattern': /^rt-([a-z]|-)+$/,
   },
 };

--- a/packages/radix-ui-themes/src/components/_internal/base-button.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-button.css
@@ -137,6 +137,8 @@
     background-image: linear-gradient(var(--black-a1), transparent, var(--white-a2));
     box-shadow: inset 0 2px 3px -1px var(--white-a4);
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--gray-1);
@@ -173,6 +175,8 @@
         background-color: var(--accent-10);
         background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
       }
+      .more-contrast &,
+      [data-high-contrast="true"] &,
       &:where(.rt-high-contrast) {
         filter: var(--base-button-classic-high-contrast-hover-filter);
         &::after {
@@ -187,6 +191,8 @@
       background-color: var(--accent-10);
       background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
     }
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       filter: var(--base-button-classic-high-contrast-hover-filter);
       &::after {
@@ -216,6 +222,8 @@
       background-image: linear-gradient(var(--black-a2), transparent, var(--white-a3));
     }
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       background-color: var(--accent-12);
       filter: var(--base-button-classic-high-contrast-active-filter);
@@ -288,6 +296,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: 2px;
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--gray-1);
@@ -320,6 +330,8 @@
 .rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost) {
   color: var(--accent-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -396,6 +408,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);
     color: var(--accent-12);
@@ -430,6 +444,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/_internal/base-button.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-button.css
@@ -137,8 +137,8 @@
     background-image: linear-gradient(var(--black-a1), transparent, var(--white-a2));
     box-shadow: inset 0 2px 3px -1px var(--white-a4);
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--gray-1);
@@ -175,8 +175,8 @@
         background-color: var(--accent-10);
         background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
       }
-      .more-contrast &,
-      [data-high-contrast="true"] &,
+      :where(.more-contrast) &,
+      :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         filter: var(--base-button-classic-high-contrast-hover-filter);
         &::after {
@@ -191,8 +191,8 @@
       background-color: var(--accent-10);
       background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
     }
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       filter: var(--base-button-classic-high-contrast-hover-filter);
       &::after {
@@ -222,8 +222,8 @@
       background-image: linear-gradient(var(--black-a2), transparent, var(--white-a3));
     }
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       background-color: var(--accent-12);
       filter: var(--base-button-classic-high-contrast-active-filter);
@@ -296,8 +296,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: 2px;
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--gray-1);
@@ -330,8 +330,8 @@
 .rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost) {
   color: var(--accent-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -408,8 +408,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);
     color: var(--accent-12);
@@ -444,8 +444,8 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/_internal/base-button.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-button.css
@@ -137,7 +137,7 @@
     background-image: linear-gradient(var(--black-a1), transparent, var(--white-a2));
     box-shadow: inset 0 2px 3px -1px var(--white-a4);
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
@@ -175,7 +175,7 @@
         background-color: var(--accent-10);
         background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
       }
-      :where(.more-contrast) &,
+      :where(.high-contrast) &,
       :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         filter: var(--base-button-classic-high-contrast-hover-filter);
@@ -191,7 +191,7 @@
       background-color: var(--accent-10);
       background-image: linear-gradient(var(--black-a2) -15%, transparent, var(--white-a3));
     }
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       filter: var(--base-button-classic-high-contrast-hover-filter);
@@ -222,7 +222,7 @@
       background-image: linear-gradient(var(--black-a2), transparent, var(--white-a3));
     }
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       background-color: var(--accent-12);
@@ -296,7 +296,7 @@
     outline: 2px solid var(--focus-8);
     outline-offset: 2px;
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
@@ -330,7 +330,7 @@
 .rt-BaseButton:where(.rt-variant-soft, .rt-variant-ghost) {
   color: var(--accent-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -408,7 +408,7 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);
@@ -444,7 +444,7 @@
     outline: 2px solid var(--focus-8);
     outline-offset: -1px;
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
@@ -85,6 +85,8 @@
       color: var(--accent-contrast);
     }
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       &::before {
         background-color: var(--accent-12);
@@ -126,6 +128,8 @@
       color: var(--accent-contrast);
     }
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       &::before {
         background-color: var(--accent-12);
@@ -160,6 +164,8 @@
       color: var(--accent-a11);
     }
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       & :where(.rt-BaseCheckboxIndicator) {
         color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
@@ -85,8 +85,8 @@
       color: var(--accent-contrast);
     }
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       &::before {
         background-color: var(--accent-12);
@@ -128,8 +128,8 @@
       color: var(--accent-contrast);
     }
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       &::before {
         background-color: var(--accent-12);
@@ -164,8 +164,8 @@
       color: var(--accent-a11);
     }
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       & :where(.rt-BaseCheckboxIndicator) {
         color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-checkbox.css
@@ -85,7 +85,7 @@
       color: var(--accent-contrast);
     }
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       &::before {
@@ -128,7 +128,7 @@
       color: var(--accent-contrast);
     }
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       &::before {
@@ -164,7 +164,7 @@
       color: var(--accent-a11);
     }
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       & :where(.rt-BaseCheckboxIndicator) {

--- a/packages/radix-ui-themes/src/components/_internal/base-menu.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-menu.css
@@ -216,7 +216,7 @@
       color: var(--accent-contrast);
     }
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     & :where(.rt-BaseMenuItem[data-highlighted]) {

--- a/packages/radix-ui-themes/src/components/_internal/base-menu.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-menu.css
@@ -216,6 +216,8 @@
       color: var(--accent-contrast);
     }
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     & :where(.rt-BaseMenuItem[data-highlighted]) {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-menu.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-menu.css
@@ -216,8 +216,8 @@
       color: var(--accent-contrast);
     }
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     & :where(.rt-BaseMenuItem[data-highlighted]) {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-radio.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-radio.css
@@ -89,8 +89,8 @@
     background-color: var(--accent-contrast);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
       background-color: var(--accent-12);
@@ -125,8 +125,8 @@
     background-color: var(--accent-contrast);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
       background-color: var(--accent-12);
@@ -156,8 +156,8 @@
     background-color: var(--accent-a11);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::after {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-radio.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-radio.css
@@ -89,6 +89,8 @@
     background-color: var(--accent-contrast);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
       background-color: var(--accent-12);
@@ -123,6 +125,8 @@
     background-color: var(--accent-contrast);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
       background-color: var(--accent-12);
@@ -152,6 +156,8 @@
     background-color: var(--accent-a11);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &::after {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-radio.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-radio.css
@@ -89,7 +89,7 @@
     background-color: var(--accent-contrast);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
@@ -125,7 +125,7 @@
     background-color: var(--accent-contrast);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &:where(:checked, [data-state='checked'])::before {
@@ -156,7 +156,7 @@
     background-color: var(--accent-a11);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::after {

--- a/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
@@ -138,6 +138,8 @@
     background-color: var(--accent-indicator);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   :where(.rt-BaseTabList.rt-high-contrast) & {
     &:where([data-state='active'], [data-active])::before {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
@@ -138,8 +138,8 @@
     background-color: var(--accent-indicator);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   :where(.rt-BaseTabList.rt-high-contrast) & {
     &:where([data-state='active'], [data-active])::before {
       background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
+++ b/packages/radix-ui-themes/src/components/_internal/base-tab-list.css
@@ -138,7 +138,7 @@
     background-color: var(--accent-indicator);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   :where(.rt-BaseTabList.rt-high-contrast) & {
     &:where([data-state='active'], [data-active])::before {

--- a/packages/radix-ui-themes/src/components/avatar.css
+++ b/packages/radix-ui-themes/src/components/avatar.css
@@ -124,7 +124,7 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
-  :where(.more-contrast) & :where(.rt-AvatarFallback),
+  :where(.high-contrast) & :where(.rt-AvatarFallback),
   :where([data-high-contrast="true"]) & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     background-color: var(--accent-12);
@@ -139,7 +139,7 @@
     background-color: var(--accent-a3);
     color: var(--accent-a11);
   }
-  :where(.more-contrast) & :where(.rt-AvatarFallback),
+  :where(.high-contrast) & :where(.rt-AvatarFallback),
   :where([data-high-contrast="true"]) & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/avatar.css
+++ b/packages/radix-ui-themes/src/components/avatar.css
@@ -124,8 +124,8 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
-  .more-contrast & :where(.rt-AvatarFallback),
-  [data-high-contrast="true"] & :where(.rt-AvatarFallback),
+  :where(.more-contrast) & :where(.rt-AvatarFallback),
+  :where([data-high-contrast="true"]) & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -139,8 +139,8 @@
     background-color: var(--accent-a3);
     color: var(--accent-a11);
   }
-  .more-contrast & :where(.rt-AvatarFallback),
-  [data-high-contrast="true"] & :where(.rt-AvatarFallback),
+  :where(.more-contrast) & :where(.rt-AvatarFallback),
+  :where([data-high-contrast="true"]) & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/avatar.css
+++ b/packages/radix-ui-themes/src/components/avatar.css
@@ -124,6 +124,8 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
+  .more-contrast & :where(.rt-AvatarFallback),
+  [data-high-contrast="true"] & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -137,6 +139,8 @@
     background-color: var(--accent-a3);
     color: var(--accent-a11);
   }
+  .more-contrast & :where(.rt-AvatarFallback),
+  [data-high-contrast="true"] & :where(.rt-AvatarFallback),
   &:where(.rt-high-contrast) :where(.rt-AvatarFallback) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -64,8 +64,8 @@
     color: var(--accent-12);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -84,8 +84,8 @@
   box-shadow: inset 0 0 0 1px var(--accent-a6);
   color: var(--accent-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -96,8 +96,8 @@
 .rt-Badge:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
   color: var(--accent-a11);
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -108,8 +108,8 @@
 .rt-Badge:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -64,6 +64,8 @@
     color: var(--accent-12);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -82,6 +84,8 @@
   box-shadow: inset 0 0 0 1px var(--accent-a6);
   color: var(--accent-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -92,6 +96,8 @@
 .rt-Badge:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
   color: var(--accent-a11);
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -102,6 +108,8 @@
 .rt-Badge:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/badge.css
+++ b/packages/radix-ui-themes/src/components/badge.css
@@ -64,7 +64,7 @@
     color: var(--accent-12);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
@@ -84,7 +84,7 @@
   box-shadow: inset 0 0 0 1px var(--accent-a6);
   color: var(--accent-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -96,7 +96,7 @@
 .rt-Badge:where(.rt-variant-soft) {
   background-color: var(--accent-a3);
   color: var(--accent-a11);
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -108,7 +108,7 @@
 .rt-Badge:where(.rt-variant-outline) {
   box-shadow: inset 0 0 0 1px var(--accent-a8);
   color: var(--accent-a11);
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 1px var(--accent-a7), inset 0 0 0 1px var(--gray-a11);

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -6,8 +6,8 @@
   text-align: left;
   color: var(--accent-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -6,6 +6,8 @@
   text-align: left;
   color: var(--accent-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/callout.css
+++ b/packages/radix-ui-themes/src/components/callout.css
@@ -6,7 +6,7 @@
   text-align: left;
   color: var(--accent-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -97,7 +97,11 @@
     color: var(--accent-a11);
   }
 
+  .more-contrast:where([data-accent-color]) &,
+  [data-high-contrast="true"] &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
+  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
+  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -114,6 +118,8 @@
     color: var(--accent-12);
   }
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -132,6 +138,8 @@
       &:where(:hover) {
         background-color: var(--accent-10);
       }
+      .more-contrast &:where(:hover),
+      [data-high-contrast="true"] &:where(:hover),
       &:where(.rt-high-contrast:hover) {
         background-color: var(--accent-12);
         /* Re-use base button hover filter */
@@ -147,6 +155,8 @@
   background-color: var(--accent-a3);
   color: var(--accent-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -168,6 +178,8 @@
   box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a8);
   color: var(--accent-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a7), inset 0 0 0 max(1px, 0.033em) var(--gray-a11);
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -97,10 +97,10 @@
     color: var(--accent-a11);
   }
 
-  :where(.more-contrast) &:where([data-accent-color]),
+  :where(.high-contrast) &:where([data-accent-color]),
   :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.high-contrast) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -118,7 +118,7 @@
     color: var(--accent-12);
   }
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
@@ -138,7 +138,7 @@
       &:where(:hover) {
         background-color: var(--accent-10);
       }
-      :where(.more-contrast) &:where(:hover),
+      :where(.high-contrast) &:where(:hover),
       :where([data-high-contrast="true"]) &:where(:hover),
       &:where(.rt-high-contrast:hover) {
         background-color: var(--accent-12);
@@ -155,7 +155,7 @@
   background-color: var(--accent-a3);
   color: var(--accent-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
@@ -178,7 +178,7 @@
   box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a8);
   color: var(--accent-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a7), inset 0 0 0 max(1px, 0.033em) var(--gray-a11);

--- a/packages/radix-ui-themes/src/components/code.css
+++ b/packages/radix-ui-themes/src/components/code.css
@@ -97,11 +97,11 @@
     color: var(--accent-a11);
   }
 
-  .more-contrast:where([data-accent-color]) &,
-  [data-high-contrast="true"] &:where([data-accent-color]),
+  :where(.more-contrast) &:where([data-accent-color]),
+  :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
-  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -118,8 +118,8 @@
     color: var(--accent-12);
   }
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     background-color: var(--accent-12);
     color: var(--accent-1);
@@ -138,8 +138,8 @@
       &:where(:hover) {
         background-color: var(--accent-10);
       }
-      .more-contrast &:where(:hover),
-      [data-high-contrast="true"] &:where(:hover),
+      :where(.more-contrast) &:where(:hover),
+      :where([data-high-contrast="true"]) &:where(:hover),
       &:where(.rt-high-contrast:hover) {
         background-color: var(--accent-12);
         /* Re-use base button hover filter */
@@ -155,8 +155,8 @@
   background-color: var(--accent-a3);
   color: var(--accent-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }
@@ -178,8 +178,8 @@
   box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a8);
   color: var(--accent-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     box-shadow: inset 0 0 0 max(1px, 0.033em) var(--accent-a7), inset 0 0 0 max(1px, 0.033em) var(--gray-a11);
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -10,8 +10,8 @@
   display: flex;
   color: var(--gray-a11);
 
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--gray-12);
   }
@@ -19,8 +19,8 @@
   &:where([data-accent-color]) {
     color: var(--accent-a11);
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       color: var(--accent-12);
     }

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -10,7 +10,7 @@
   display: flex;
   color: var(--gray-a11);
 
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     color: var(--gray-12);
@@ -19,7 +19,7 @@
   &:where([data-accent-color]) {
     color: var(--accent-a11);
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/data-list.css
+++ b/packages/radix-ui-themes/src/components/data-list.css
@@ -10,6 +10,8 @@
   display: flex;
   color: var(--gray-a11);
 
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     color: var(--gray-12);
   }
@@ -17,6 +19,8 @@
   &:where([data-accent-color]) {
     color: var(--accent-a11);
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       color: var(--accent-12);
     }

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -14,11 +14,11 @@
     color: var(--accent-a11);
   }
 
-  .more-contrast &:where([data-accent-color]),
-  [data-high-contrast="true"] &:where([data-accent-color]),
+  :where(.more-contrast) &:where([data-accent-color]),
+  :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
-  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -14,7 +14,11 @@
     color: var(--accent-a11);
   }
 
+  .more-contrast &:where([data-accent-color]),
+  [data-high-contrast="true"] &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
+  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
+  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/heading.css
+++ b/packages/radix-ui-themes/src/components/heading.css
@@ -14,10 +14,10 @@
     color: var(--accent-a11);
   }
 
-  :where(.more-contrast) &:where([data-accent-color]),
+  :where(.high-contrast) &:where([data-accent-color]),
   :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.high-contrast) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -56,8 +56,8 @@
         }
       }
 
-      .more-contrast &,
-      [data-high-contrast="true"] &,
+      :where(.more-contrast) &,
+      :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast),
       :where(:not(.more-contrast)) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
       :where(:not([data-high-contrast="true"])) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -56,10 +56,10 @@
         }
       }
 
-      :where(.more-contrast) &,
+      :where(.high-contrast) &,
       :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast),
-      :where(:not(.more-contrast)) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
+      :where(:not(.high-contrast)) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
       :where(:not([data-high-contrast="true"])) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
       :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) &:where([data-accent-color='']) {
         text-decoration-line: underline;

--- a/packages/radix-ui-themes/src/components/link.css
+++ b/packages/radix-ui-themes/src/components/link.css
@@ -56,7 +56,11 @@
         }
       }
 
+      .more-contrast &,
+      [data-high-contrast="true"] &,
       &:where(.rt-high-contrast),
+      :where(:not(.more-contrast)) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
+      :where(:not([data-high-contrast="true"])) :where([data-accent-color]:not(.radix-themes)) &:where([data-accent-color='']),
       :where([data-accent-color]:not(.radix-themes, .rt-high-contrast)) &:where([data-accent-color='']) {
         text-decoration-line: underline;
         text-decoration-color: var(--accent-a6);

--- a/packages/radix-ui-themes/src/components/progress.css
+++ b/packages/radix-ui-themes/src/components/progress.css
@@ -220,7 +220,7 @@
 }
 
 /* all high-contrast */
-:where(.more-contrast) .rt-ProgressRoot,
+:where(.high-contrast) .rt-ProgressRoot,
 :where([data-high-contrast="true"]) .rt-ProgressRoot,
 .rt-ProgressRoot:where(.rt-high-contrast) {
   --progress-indicator-indeterminate-animation-start: rt-progress-indicator-high-contrast-indeterminate-fade;

--- a/packages/radix-ui-themes/src/components/progress.css
+++ b/packages/radix-ui-themes/src/components/progress.css
@@ -220,8 +220,8 @@
 }
 
 /* all high-contrast */
-.more-contrast .rt-ProgressRoot,
-[data-high-contrast="true"] .rt-ProgressRoot,
+:where(.more-contrast) .rt-ProgressRoot,
+:where([data-high-contrast="true"]) .rt-ProgressRoot,
 .rt-ProgressRoot:where(.rt-high-contrast) {
   --progress-indicator-indeterminate-animation-start: rt-progress-indicator-high-contrast-indeterminate-fade;
   --progress-indicator-indeterminate-animation-repeat: rt-progress-indicator-high-contrast-indeterminate-pulse;

--- a/packages/radix-ui-themes/src/components/progress.css
+++ b/packages/radix-ui-themes/src/components/progress.css
@@ -220,6 +220,8 @@
 }
 
 /* all high-contrast */
+.more-contrast .rt-ProgressRoot,
+[data-high-contrast="true"] .rt-ProgressRoot,
 .rt-ProgressRoot:where(.rt-high-contrast) {
   --progress-indicator-indeterminate-animation-start: rt-progress-indicator-high-contrast-indeterminate-fade;
   --progress-indicator-indeterminate-animation-repeat: rt-progress-indicator-high-contrast-indeterminate-pulse;

--- a/packages/radix-ui-themes/src/components/radio-cards.css
+++ b/packages/radix-ui-themes/src/components/radio-cards.css
@@ -140,6 +140,8 @@
   &::after {
     outline: 2px solid var(--accent-indicator);
   }
+  .more-contrast :where(.rt-RadioCardsRoot) &,
+  [data-high-contrast="true"] :where(.rt-RadioCardsRoot) &,
   :where(.rt-RadioCardsRoot.rt-high-contrast) & {
     &::after {
       outline-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/radio-cards.css
+++ b/packages/radix-ui-themes/src/components/radio-cards.css
@@ -140,7 +140,7 @@
   &::after {
     outline: 2px solid var(--accent-indicator);
   }
-  :where(.more-contrast) :where(.rt-RadioCardsRoot) &,
+  :where(.high-contrast) :where(.rt-RadioCardsRoot) &,
   :where([data-high-contrast="true"]) :where(.rt-RadioCardsRoot) &,
   :where(.rt-RadioCardsRoot.rt-high-contrast) & {
     &::after {

--- a/packages/radix-ui-themes/src/components/radio-cards.css
+++ b/packages/radix-ui-themes/src/components/radio-cards.css
@@ -140,8 +140,8 @@
   &::after {
     outline: 2px solid var(--accent-indicator);
   }
-  .more-contrast :where(.rt-RadioCardsRoot) &,
-  [data-high-contrast="true"] :where(.rt-RadioCardsRoot) &,
+  :where(.more-contrast) :where(.rt-RadioCardsRoot) &,
+  :where([data-high-contrast="true"]) :where(.rt-RadioCardsRoot) &,
   :where(.rt-RadioCardsRoot.rt-high-contrast) & {
     &::after {
       outline-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -479,7 +479,7 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
-  :where(.more-contrast) & :where(.rt-SelectItem[data-highlighted]),
+  :where(.high-contrast) & :where(.rt-SelectItem[data-highlighted]),
   :where([data-high-contrast="true"]) & :where(.rt-SelectItem[data-highlighted]),
   &:where(.rt-high-contrast) :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -479,8 +479,8 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
-  .more-contrast & :where(.rt-SelectItem[data-highlighted]),
-  [data-high-contrast="true"] & :where(.rt-SelectItem[data-highlighted]),
+  :where(.more-contrast) & :where(.rt-SelectItem[data-highlighted]),
+  :where([data-high-contrast="true"]) & :where(.rt-SelectItem[data-highlighted]),
   &:where(.rt-high-contrast) :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-12);
     color: var(--accent-1);

--- a/packages/radix-ui-themes/src/components/select.css
+++ b/packages/radix-ui-themes/src/components/select.css
@@ -479,6 +479,8 @@
     background-color: var(--accent-9);
     color: var(--accent-contrast);
   }
+  .more-contrast & :where(.rt-SelectItem[data-highlighted]),
+  [data-high-contrast="true"] & :where(.rt-SelectItem[data-highlighted]),
   &:where(.rt-high-contrast) :where(.rt-SelectItem[data-highlighted]) {
     background-color: var(--accent-12);
     color: var(--accent-1);

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -173,6 +173,8 @@
     box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--accent-a4), inset 0 0 0 1px var(--black-a1),
       inset 0 1.5px 2px 0 var(--black-a2);
 
+    .more-contrast &,
+    [data-high-contrast="true"] &,
     &:where(.rt-high-contrast) {
       box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--black-a2), inset 0 1.5px 2px 0 var(--black-a2);
     }
@@ -232,6 +234,8 @@
 :is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --slider-range-high-contrast-background-image: none;
 }
+:where(:not(.more-contrast)) .rt-SliderRoot,
+:where(:not([data-high-contrast="true"])) .rt-SliderRoot,
 .rt-SliderRoot:where(:not(.rt-high-contrast)) {
   --slider-range-high-contrast-background-image: none;
 }

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -173,8 +173,8 @@
     box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--accent-a4), inset 0 0 0 1px var(--black-a1),
       inset 0 1.5px 2px 0 var(--black-a2);
 
-    .more-contrast &,
-    [data-high-contrast="true"] &,
+    :where(.more-contrast) &,
+    :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--black-a2), inset 0 1.5px 2px 0 var(--black-a2);
     }

--- a/packages/radix-ui-themes/src/components/slider.css
+++ b/packages/radix-ui-themes/src/components/slider.css
@@ -173,7 +173,7 @@
     box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--accent-a4), inset 0 0 0 1px var(--black-a1),
       inset 0 1.5px 2px 0 var(--black-a2);
 
-    :where(.more-contrast) &,
+    :where(.high-contrast) &,
     :where([data-high-contrast="true"]) &,
     &:where(.rt-high-contrast) {
       box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--black-a2), inset 0 1.5px 2px 0 var(--black-a2);
@@ -234,7 +234,7 @@
 :is(.dark, .dark-theme) :where(.radix-themes:not(.light, .light-theme)) {
   --slider-range-high-contrast-background-image: none;
 }
-:where(:not(.more-contrast)) .rt-SliderRoot,
+:where(:not(.high-contrast)) .rt-SliderRoot,
 :where(:not([data-high-contrast="true"])) .rt-SliderRoot,
 .rt-SliderRoot:where(:not(.rt-high-contrast)) {
   --slider-range-high-contrast-background-image: none;

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -139,7 +139,7 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {
@@ -171,7 +171,7 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
-      :where(.more-contrast) &,
+      :where(.high-contrast) &,
       :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
@@ -213,7 +213,7 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {
@@ -248,7 +248,7 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
-      :where(.more-contrast) &,
+      :where(.high-contrast) &,
       :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
@@ -282,7 +282,7 @@
   &:where(:active)::before {
     background-color: var(--gray-a4);
   }
-  :where(.more-contrast) &,
+  :where(.high-contrast) &,
   :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -139,8 +139,8 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {
       /* prettier-ignore */
@@ -171,8 +171,8 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
-      .more-contrast &,
-      [data-high-contrast="true"] &,
+      :where(.more-contrast) &,
+      :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
           -1px 0 1px var(--black-a2);
@@ -213,8 +213,8 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {
       box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--black-a2), inset 0 1.5px 2px 0 var(--black-a2);
@@ -248,8 +248,8 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
-      .more-contrast &,
-      [data-high-contrast="true"] &,
+      :where(.more-contrast) &,
+      :where([data-high-contrast="true"]) &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
           -1px 0 1px var(--black-a2);
@@ -282,8 +282,8 @@
   &:where(:active)::before {
     background-color: var(--gray-a4);
   }
-  .more-contrast &,
-  [data-high-contrast="true"] &,
+  :where(.more-contrast) &,
+  :where([data-high-contrast="true"]) &,
   &:where(.rt-high-contrast) {
     &::before {
       /* prettier-ignore */

--- a/packages/radix-ui-themes/src/components/switch.css
+++ b/packages/radix-ui-themes/src/components/switch.css
@@ -139,6 +139,8 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &::before {
       /* prettier-ignore */
@@ -169,6 +171,8 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
+      .more-contrast &,
+      [data-high-contrast="true"] &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
           -1px 0 1px var(--black-a2);
@@ -209,6 +213,8 @@
   &:where([data-state='checked']:active)::before {
     filter: var(--switch-surface-checked-active-filter);
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &::before {
       box-shadow: inset 0 0 0 1px var(--gray-a3), inset 0 0 0 1px var(--black-a2), inset 0 1.5px 2px 0 var(--black-a2);
@@ -242,6 +248,8 @@
       box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a1),
         0 0 0 1px var(--accent-a4), -1px 0 1px var(--black-a2);
 
+      .more-contrast &,
+      [data-high-contrast="true"] &,
       &:where(.rt-high-contrast) {
         box-shadow: 0 1px 3px var(--black-a2), 0 2px 4px -1px var(--black-a1), 0 0 0 1px var(--black-a2),
           -1px 0 1px var(--black-a2);
@@ -274,6 +282,8 @@
   &:where(:active)::before {
     background-color: var(--gray-a4);
   }
+  .more-contrast &,
+  [data-high-contrast="true"] &,
   &:where(.rt-high-contrast) {
     &::before {
       /* prettier-ignore */

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -10,10 +10,10 @@
     color: var(--accent-a11);
   }
 
-  :where(.more-contrast) &:where([data-accent-color]),
+  :where(.high-contrast) &:where([data-accent-color]),
   :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.high-contrast) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -10,7 +10,11 @@
     color: var(--accent-a11);
   }
 
+  .more-contrast &:where([data-accent-color]),
+  [data-high-contrast="true"] &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
+  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
+  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/text.css
+++ b/packages/radix-ui-themes/src/components/text.css
@@ -10,11 +10,11 @@
     color: var(--accent-a11);
   }
 
-  .more-contrast &:where([data-accent-color]),
-  [data-high-contrast="true"] &:where([data-accent-color]),
+  :where(.more-contrast) &:where([data-accent-color]),
+  :where([data-high-contrast="true"]) &:where([data-accent-color]),
   &:where([data-accent-color].rt-high-contrast),
-  .more-contrast :where([data-accent-color]:not(.radix-themes)) &,
-  [data-high-contrast="true"] :where([data-accent-color]:not(.radix-themes)) &,
+  :where(.more-contrast) :where([data-accent-color]:not(.radix-themes)) &,
+  :where([data-high-contrast="true"]) :where([data-accent-color]:not(.radix-themes)) &,
   :where([data-accent-color]:not(.radix-themes)) &:where(.rt-high-contrast) {
     color: var(--accent-12);
   }

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -402,6 +402,39 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                       }
                     />
                     <Flex align="center" justify="center" height="32px" gap="2">
+                      {value === 'true' ? (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="15"
+                          height="15"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          className="lucide lucide-contrast-icon lucide-contrast"
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                          <path d="M12 18a6 6 0 0 0 0-12v12z" fill="currentColor" />
+                        </svg>
+                      ) : (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="15"
+                          height="15"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          className="lucide lucide-contrast-icon lucide-contrast"
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                          <path d="M12 18a6 6 0 0 0 0-12v12z" />
+                        </svg>
+                      )}
                       <Text size="1" weight="medium">
                         {upperFirst(value)}
                       </Text>
@@ -411,7 +444,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
               </Grid>
 
               <Text id="radius-title" as="p" size="2" weight="medium" mt="5">
-                Radius
+              Radius
               </Text>
 
               <Grid columns="5" gap="2" mt="3" role="group" aria-labelledby="radius-title">

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -410,9 +410,9 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                           viewBox="0 0 24 24"
                           fill="none"
                           stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                           className="lucide lucide-contrast-icon lucide-contrast"
                         >
                           <circle cx="12" cy="12" r="10" />
@@ -426,9 +426,9 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                           viewBox="0 0 24 24"
                           fill="none"
                           stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
                           className="lucide lucide-contrast-icon lucide-contrast"
                         >
                           <circle cx="12" cy="12" r="10" />

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -53,6 +53,8 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
     const {
       appearance,
       onAppearanceChange,
+      highContrast,
+      onHighContrastChange,
       accentColor,
       onAccentColorChange,
       grayColor,
@@ -95,6 +97,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
     async function handleCopyThemeConfig() {
       const theme = {
         appearance: appearance === themePropDefs.appearance.default ? undefined : appearance,
+        highContrast: highContrast === themePropDefs.highContrast.default ? undefined : highContrast,
         accentColor: accentColor === themePropDefs.accentColor.default ? undefined : accentColor,
         grayColor: grayColor === themePropDefs.grayColor.default ? undefined : grayColor,
         panelBackground:
@@ -103,9 +106,13 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
         scaling: scaling === themePropDefs.scaling.default ? undefined : scaling,
       } satisfies GetPropDefTypes<typeof themePropDefs>;
 
-      const props = Object.keys(theme)
-        .filter((key) => theme[key as keyof typeof theme] !== undefined)
-        .map((key) => `${key}="${theme[key as keyof typeof theme]}"`)
+      const props = Object.entries(theme)
+        .filter(([key]) => theme[key as keyof typeof theme] !== undefined)
+        .map(([key, value]) => {
+          if (typeof value === 'boolean' && value) return key
+
+          return `${key}="${theme[key as keyof typeof theme]}"`;
+        })
         .join(' ');
 
       const textToCopy = props ? `<Theme ${props}>` : '<Theme>';
@@ -369,6 +376,32 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
                           ></path>
                         </svg>
                       )}
+                      <Text size="1" weight="medium">
+                        {upperFirst(value)}
+                      </Text>
+                    </Flex>
+                  </label>
+                ))}
+              </Grid>
+
+              <Text id="highContrast-title" as="p" size="2" weight="medium" mt="5">
+                High contrast
+              </Text>
+
+              <Grid columns="2" gap="2" mt="3" role="group" aria-labelledby="highContrast-title">
+                {(['true', 'false'] as const).map((value) => (
+                  <label key={value} className="rt-ThemePanelRadioCard">
+                    <input
+                      className="rt-ThemePanelRadioCardInput"
+                      type="radio"
+                      name="highContrast"
+                      value={value}
+                      checked={highContrast?.toString() === value}
+                      onChange={(event) =>
+                        onHighContrastChange(event.target.value === 'true')
+                      }
+                    />
+                    <Flex align="center" justify="center" height="32px" gap="2">
                       <Text size="1" weight="medium">
                         {upperFirst(value)}
                       </Text>

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -444,7 +444,7 @@ const ThemePanelImpl = React.forwardRef<ThemePanelImplElement, ThemePanelImplPro
               </Grid>
 
               <Text id="radius-title" as="p" size="2" weight="medium" mt="5">
-              Radius
+                Radius
               </Text>
 
               <Grid columns="5" gap="2" mt="3" role="group" aria-labelledby="radius-title">

--- a/packages/radix-ui-themes/src/components/theme.props.tsx
+++ b/packages/radix-ui-themes/src/components/theme.props.tsx
@@ -1,5 +1,6 @@
 import { asChildPropDef } from '../props/as-child.prop.js';
 import { accentColors, grayColors } from '../props/color.prop.js';
+import { highContrastPropDef } from '../props/high-contrast.prop.js';
 import { radii } from '../props/radius.prop.js';
 
 import type { GetPropDefTypes, PropDef } from '../props/prop-def.js';
@@ -60,6 +61,7 @@ const themePropDefs = {
    * https://www.radix-ui.com/themes/docs/theme/layout
    */
   scaling: { type: 'enum', values: scalings, default: '100%' },
+  ...highContrastPropDef,
 } satisfies {
   hasBackground: PropDef<boolean>;
   appearance: PropDef<(typeof appearances)[number]>;

--- a/packages/radix-ui-themes/src/components/theme.props.tsx
+++ b/packages/radix-ui-themes/src/components/theme.props.tsx
@@ -19,7 +19,7 @@ const themePropDefs = {
    */
   hasBackground: { type: 'boolean', default: true },
   /**
-   * Sets the color scheme of the theme, typcially referred to as light and dark mode.
+   * Sets the color scheme of the theme, typically referred to as light and dark mode.
    *
    * @link
    * https://www.radix-ui.com/themes/docs/theme/dark-mode
@@ -61,6 +61,12 @@ const themePropDefs = {
    * https://www.radix-ui.com/themes/docs/theme/layout
    */
   scaling: { type: 'enum', values: scalings, default: '100%' },
+  /**
+   * Sets a high contrast colors of the theme for accessibility.
+   *
+   * @link
+   * https://www.radix-ui.com/themes/docs/theme/high-contrast
+   */
   ...highContrastPropDef,
 } satisfies {
   hasBackground: PropDef<boolean>;

--- a/packages/radix-ui-themes/src/components/theme.tsx
+++ b/packages/radix-ui-themes/src/components/theme.tsx
@@ -224,6 +224,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
           {
             light: appearance === 'light',
             dark: appearance === 'dark',
+            'more-contrast': highContrast,
           },
           themeProps.className
         )}

--- a/packages/radix-ui-themes/src/components/theme.tsx
+++ b/packages/radix-ui-themes/src/components/theme.tsx
@@ -224,7 +224,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
           {
             light: appearance === 'light',
             dark: appearance === 'dark',
-            'more-contrast': highContrast,
+            'high-contrast': highContrast,
           },
           themeProps.className
         )}

--- a/packages/radix-ui-themes/src/components/theme.tsx
+++ b/packages/radix-ui-themes/src/components/theme.tsx
@@ -21,6 +21,7 @@ type ThemeScaling = (typeof themePropDefs.scaling.values)[number];
 
 interface ThemeChangeHandlers {
   onAppearanceChange: (appearance: ThemeAppearance) => void;
+  onHighContrastChange: (highContrast: boolean) => void;
   onAccentColorChange: (accentColor: ThemeAccentColor) => void;
   onGrayColorChange: (grayColor: ThemeGrayColor) => void;
   onPanelBackgroundChange: (panelBackground: ThemePanelBackground) => void;
@@ -30,6 +31,7 @@ interface ThemeChangeHandlers {
 
 interface ThemeContextValue extends ThemeChangeHandlers {
   appearance: ThemeAppearance;
+  highContrast?: boolean;
   accentColor: ThemeAccentColor;
   grayColor: ThemeGrayColor;
   resolvedGrayColor: ThemeGrayColor;
@@ -68,6 +70,7 @@ const ThemeRoot = React.forwardRef<ThemeImplElement, ThemeImplPublicProps>(
   (props, forwardedRef) => {
     const {
       appearance: appearanceProp = themePropDefs.appearance.default,
+      highContrast: highContrastProp = themePropDefs.highContrast.default,
       accentColor: accentColorProp = themePropDefs.accentColor.default,
       grayColor: grayColorProp = themePropDefs.grayColor.default,
       panelBackground: panelBackgroundProp = themePropDefs.panelBackground.default,
@@ -78,6 +81,9 @@ const ThemeRoot = React.forwardRef<ThemeImplElement, ThemeImplPublicProps>(
     } = props;
     const [appearance, setAppearance] = React.useState(appearanceProp);
     React.useEffect(() => setAppearance(appearanceProp), [appearanceProp]);
+
+    const [highContrast, setHighContrast] = React.useState(highContrastProp);
+    React.useEffect(() => setHighContrast(highContrastProp), [highContrastProp]);
 
     const [accentColor, setAccentColor] = React.useState(accentColorProp);
     React.useEffect(() => setAccentColor(accentColorProp), [accentColorProp]);
@@ -102,6 +108,7 @@ const ThemeRoot = React.forwardRef<ThemeImplElement, ThemeImplPublicProps>(
         hasBackground={hasBackground}
         //
         appearance={appearance}
+        highContrast={highContrast}
         accentColor={accentColor}
         grayColor={grayColor}
         panelBackground={panelBackground}
@@ -109,6 +116,7 @@ const ThemeRoot = React.forwardRef<ThemeImplElement, ThemeImplPublicProps>(
         scaling={scaling}
         //
         onAppearanceChange={setAppearance}
+        onHighContrastChange={setHighContrast}
         onAccentColorChange={setAccentColor}
         onGrayColorChange={setGrayColor}
         onPanelBackgroundChange={setPanelBackground}
@@ -136,6 +144,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
     hasBackground: hasBackgroundProp,
     //
     appearance = context?.appearance ?? themePropDefs.appearance.default,
+    highContrast = context?.highContrast ?? themePropDefs.highContrast.default,
     accentColor = context?.accentColor ?? themePropDefs.accentColor.default,
     grayColor = context?.resolvedGrayColor ?? themePropDefs.grayColor.default,
     panelBackground = context?.panelBackground ?? themePropDefs.panelBackground.default,
@@ -143,6 +152,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
     scaling = context?.scaling ?? themePropDefs.scaling.default,
     //
     onAppearanceChange = noop,
+    onHighContrastChange = noop,
     onAccentColorChange = noop,
     onGrayColorChange = noop,
     onPanelBackgroundChange = noop,
@@ -161,6 +171,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
       value={React.useMemo(
         () => ({
           appearance,
+          highContrast,
           accentColor,
           grayColor,
           resolvedGrayColor,
@@ -169,6 +180,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
           scaling,
           //
           onAppearanceChange,
+          onHighContrastChange,
           onAccentColorChange,
           onGrayColorChange,
           onPanelBackgroundChange,
@@ -177,6 +189,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
         }),
         [
           appearance,
+          highContrast,
           accentColor,
           grayColor,
           resolvedGrayColor,
@@ -185,6 +198,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
           scaling,
           //
           onAppearanceChange,
+          onHighContrastChange,
           onAccentColorChange,
           onGrayColorChange,
           onPanelBackgroundChange,
@@ -195,6 +209,7 @@ const ThemeImpl = React.forwardRef<ThemeImplElement, ThemeImplProps>((props, for
     >
       <Comp
         data-is-root-theme={isRoot ? 'true' : 'false'}
+        data-high-contrast={highContrast ? 'true' : 'false'}
         data-accent-color={accentColor}
         data-gray-color={resolvedGrayColor}
         // for nested `Theme` background


### PR DESCRIPTION
## Description

To improve accessibility and better support users with visual impairments, this PR introduces first-class support for high contrast themes. According to accessibility guidelines, high contrast modes are essential for many users, and making them easier to enable and manage significantly improves usability and inclusiveness.

## Changes

- Added a highContrast prop to the Theme components. When enabled, all nested elements automatically receive high contrast styling, removing the need to configure this individually on each component.
- Added a high contrast toggle to ThemeToggle, making it easy to preview and switch high contrast mode during development or runtime.
- When high contrast mode is active, the attribute `[data-high-theme="true"]` and the `.high-contrast` class are applied. This allows developers to check the contrast state in CSS or toggle it using external libraries—similar to the existing `.light` and `.dark` class mechanisms.

## Testing steps

Open playground and try to toggle high contrast or copy theme
Critical moment: if you enable global high contrast you can not turn it off for individual component

## Relates issues / PRs

Add the same functionality to next-themes https://github.com/pacocoursey/next-themes/pull/360 to toggle contrast value using `.high-contrast` class in SSR-friendly way and including support `prefers-contrast:more` media query

In future step, after this PR will be merged I will update radix-ui docs to add info about this functional
After next-theme PR will be merged and released I will add an example how it works in playground
