### PR TITLE
Add new grid layout props: alignContent, justifyItems, alignSelf, justifySelf

### DIFF
--- a/apps/playground/app/test-grid-align-content/page.tsx
+++ b/apps/playground/app/test-grid-align-content/page.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { Theme, Grid, Text, Box, BoxProps, Code } from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Grid columns="repeat(6, 1fr)" gap="5" height="100dvh">
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="start"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>start</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="center"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>center</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="end"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>end</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="between"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>between</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="evenly"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>evenly</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, min-content)"
+                  gap="1"
+                  alignContent="around"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>around</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+              </Grid>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+const BlueBox = ({ children, ...props }: BoxProps) => (
+  <Box p="3" asChild style={{ background: 'var(--blue-9)', minHeight: '20vh' }} {...props}>
+    <Text size="2" color="gray" highContrast>
+      {children && <Code variant="ghost">{children}</Code>}
+    </Text>
+  </Box>
+);

--- a/apps/playground/app/test-grid-align-self/page.tsx
+++ b/apps/playground/app/test-grid-align-self/page.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Theme, Grid, Text, Box, BoxProps, Code } from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Grid height="100vh" columns="repeat(4, 1fr)" gap="1">
+                <BlueBox alignSelf="start">start</BlueBox>
+                <BlueBox alignSelf="center">center</BlueBox>
+                <BlueBox alignSelf="end">end</BlueBox>
+                <BlueBox alignSelf="stretch">stretch</BlueBox>
+              </Grid>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+const BlueBox = ({ children, ...props }: BoxProps) => (
+  <Box p="3" asChild style={{ background: 'var(--blue-9)', minHeight: '50%' }} {...props}>
+    <Text size="2" color="gray" highContrast>
+      <Code variant="ghost">{children}</Code>
+    </Text>
+  </Box>
+);

--- a/apps/playground/app/test-grid-justify-items/page.tsx
+++ b/apps/playground/app/test-grid-justify-items/page.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Theme, Grid, Text, Box, BoxProps, Code } from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Grid rows="repeat(4, 1fr)" gap="5" height="100dvh">
+                <Grid
+                  height="100%"
+                  rows="repeat(3, 1fr)"
+                  gap="1"
+                  justifyItems="start"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>start</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, 1fr)"
+                  gap="1"
+                  justifyItems="center"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>center</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+
+                <Grid
+                  height="100%"
+                  rows="repeat(3, 1fr)"
+                  gap="1"
+                  justifyItems="end"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>end</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+                <Grid
+                  height="100%"
+                  rows="repeat(3, 1fr)"
+                  gap="1"
+                  justifyItems="stretch"
+                  style={{ background: 'var(--blue-a3)' }}
+                >
+                  <BlueBox>stretch</BlueBox>
+                  <BlueBox />
+                  <BlueBox />
+                </Grid>
+              </Grid>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+const BlueBox = ({ children, ...props }: BoxProps) => (
+  <Box p="3" asChild style={{ background: 'var(--blue-9)', minWidth: '50dvw' }} {...props}>
+    <Text size="2" color="gray" highContrast>
+      {children && <Code variant="ghost">{children}</Code>}
+    </Text>
+  </Box>
+);

--- a/apps/playground/app/test-grid-justify-self/page.tsx
+++ b/apps/playground/app/test-grid-justify-self/page.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Theme, Grid, Text, Box, BoxProps, Code } from '@radix-ui/themes';
+import { NextThemeProvider } from '../next-theme-provider';
+
+export default function Test() {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body>
+        <NextThemeProvider>
+          <Theme asChild>
+            <div id="root">
+              <Grid height="100vh" rows="repeat(4, 1fr)" gap="1">
+                <BlueBox justifySelf="start">start</BlueBox>
+                <BlueBox justifySelf="center">center</BlueBox>
+                <BlueBox justifySelf="end">end</BlueBox>
+                <BlueBox justifySelf="stretch">stretch</BlueBox>
+              </Grid>
+            </div>
+          </Theme>
+        </NextThemeProvider>
+      </body>
+    </html>
+  );
+}
+
+const BlueBox = ({ children, ...props }: BoxProps) => (
+  <Box p="3" asChild style={{ background: 'var(--blue-9)', minWidth: '50%' }} {...props}>
+    <Text size="2" color="gray" highContrast>
+      <Code variant="ghost">{children}</Code>
+    </Text>
+  </Box>
+);

--- a/packages/radix-ui-themes/src/components/grid.props.tsx
+++ b/packages/radix-ui-themes/src/components/grid.props.tsx
@@ -10,6 +10,17 @@ const rowsValues = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
 const flowValues = ['row', 'column', 'dense', 'row-dense', 'column-dense'] as const;
 const alignValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
 const justifyValues = ['start', 'center', 'end', 'between'] as const;
+const alignContentValues = [
+  'start',
+  'center',
+  'end',
+  'baseline',
+  'between',
+  'around',
+  'evenly',
+  'stretch',
+] as const;
+const justifyItemsValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
 
 const gridPropDefs = {
   /**
@@ -150,6 +161,41 @@ const gridPropDefs = {
     parseValue: parseJustifyValue,
     responsive: true,
   },
+  /**
+   * Sets the CSS **align-content** property.
+   * Supports a subset of the corresponding CSS values and responsive objects.
+   *
+   * @example
+   * alignContent="between"
+   * alignContent={{ sm: 'start', lg: 'center' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+   */
+  alignContent: {
+    type: 'enum',
+    className: 'rt-r-ac',
+    values: alignContentValues,
+    parseValue: parseAlignContentValue,
+    responsive: true,
+  },
+  /**
+   * Sets the CSS **justify-items** property.
+   * Supports a subset of the corresponding CSS values and responsive objects.
+   *
+   * @example
+   * justifyItems="center"
+   * justifyItems={{ sm: 'start', lg: 'center' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/align-content
+   */
+  justifyItems: {
+    type: 'enum',
+    className: 'rt-r-ji',
+    values: justifyItemsValues,
+    responsive: true,
+  },
   ...gapPropDefs,
 } satisfies {
   as: PropDef<(typeof as)[number]>;
@@ -160,6 +206,8 @@ const gridPropDefs = {
   flow: PropDef<(typeof flowValues)[number]>;
   align: PropDef<(typeof alignValues)[number]>;
   justify: PropDef<(typeof justifyValues)[number]>;
+  alignContent: PropDef<(typeof alignContentValues)[number]>;
+  justifyItems: PropDef<(typeof justifyItemsValues)[number]>;
 };
 
 function parseGridValue(value: string): string {
@@ -172,6 +220,19 @@ function parseGridValue(value: string): string {
 
 function parseJustifyValue(value: string) {
   return value === 'between' ? 'space-between' : value;
+}
+
+function parseAlignContentValue(value: string) {
+  switch (value) {
+    case 'between':
+      return 'space-between';
+    case 'around':
+      return 'space-around';
+    case 'evenly':
+      return 'space-evenly';
+    default:
+      return value;
+  }
 }
 
 // Use all of the imported prop defs to ensure that JSDoc works

--- a/packages/radix-ui-themes/src/props/layout.props.ts
+++ b/packages/radix-ui-themes/src/props/layout.props.ts
@@ -10,6 +10,8 @@ const positionValues = ['static', 'relative', 'absolute', 'fixed', 'sticky'] as 
 const positionEdgeValues = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-1', '-2', '-3', '-4', '-5', '-6', '-7', '-8', '-9'] as const;
 const flexShrinkValues = ['0', '1'] as const;
 const flexGrowValues = ['0', '1'] as const;
+const alignSelfValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
+const justifySelfValues = ['start', 'center', 'end', 'baseline', 'stretch'] as const;
 
 const layoutPropDefs = {
   ...paddingPropDefs,
@@ -358,6 +360,40 @@ const layoutPropDefs = {
     customProperties: ['--grid-row-end'],
     responsive: true,
   },
+  /**
+   * Sets the CSS **align-self** property.
+   * Supports a subset of the corresponding CSS values and responsive objects.
+   *
+   * @example
+   * alignSelf="center"
+   * alignSelf={{ sm: 'start', lg: 'center' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/align-self
+   */
+  alignSelf: {
+    type: 'enum',
+    className: 'rt-r-as',
+    values: alignSelfValues,
+    responsive: true,
+  },
+  /**
+   * Sets the CSS **justify-self** property.
+   * Supports a subset of the corresponding CSS values and responsive objects.
+   *
+   * @example
+   * justifySelf="center"
+   * justifySelf={{ sm: 'start', lg: 'center' }}
+   *
+   * @link
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self
+   */
+  justifySelf: {
+    type: 'enum',
+    className: 'rt-r-js',
+    values: justifySelfValues,
+    responsive: true,
+  },
 } satisfies {
   position: PropDef<(typeof positionValues)[number]>;
   inset: PropDef<(typeof positionEdgeValues)[number]>;
@@ -378,6 +414,8 @@ const layoutPropDefs = {
   gridRowStart: PropDef<string>;
   gridRowEnd: PropDef<string>;
   gridArea: PropDef<string>;
+  alignSelf: PropDef<(typeof alignSelfValues)[number]>;
+  justifySelf: PropDef<(typeof justifySelfValues)[number]>;
 };
 
 // Use all of the imported prop defs to ensure that JSDoc works

--- a/packages/radix-ui-themes/src/styles/utilities/align-content.css
+++ b/packages/radix-ui-themes/src/styles/utilities/align-content.css
@@ -1,0 +1,33 @@
+@breakpoints {
+  .rt-r-ac-start {
+    align-content: start;
+  }
+
+  .rt-r-ac-center {
+    align-content: center;
+  }
+
+  .rt-r-ac-end {
+    align-content: end;
+  }
+
+  .rt-r-ac-baseline {
+    align-content: baseline;
+  }
+
+  .rt-r-ac-stretch {
+    align-content: stretch;
+  }
+
+  .rt-r-ac-space-between {
+    align-content: space-between;
+  }
+
+  .rt-r-ac-space-around {
+    align-content: space-around;
+  }
+
+  .rt-r-ac-space-evenly {
+    align-content: space-evenly;
+  }
+}

--- a/packages/radix-ui-themes/src/styles/utilities/align-self.css
+++ b/packages/radix-ui-themes/src/styles/utilities/align-self.css
@@ -1,6 +1,6 @@
 @breakpoints {
   .rt-r-as-start {
-    align-self: flex-start;
+    align-self: start;
   }
 
   .rt-r-as-center {
@@ -8,7 +8,7 @@
   }
 
   .rt-r-as-end {
-    align-self: flex-end;
+    align-self: end;
   }
 
   .rt-r-as-baseline {

--- a/packages/radix-ui-themes/src/styles/utilities/justify-items.css
+++ b/packages/radix-ui-themes/src/styles/utilities/justify-items.css
@@ -1,0 +1,21 @@
+@breakpoints {
+  .rt-r-ji-start {
+    justify-items: start;
+  }
+
+  .rt-r-ji-center {
+    justify-items: center;
+  }
+
+  .rt-r-ji-end {
+    justify-items: end;
+  }
+
+  .rt-r-ji-baseline {
+    justify-items: baseline;
+  }
+
+  .rt-r-ji-stretch {
+    justify-items: stretch;
+  }
+}

--- a/packages/radix-ui-themes/src/styles/utilities/justify-self.css
+++ b/packages/radix-ui-themes/src/styles/utilities/justify-self.css
@@ -1,0 +1,21 @@
+@breakpoints {
+  .rt-r-js-start {
+    justify-self: start;
+  }
+
+  .rt-r-js-center {
+    justify-self: center;
+  }
+
+  .rt-r-js-end {
+    justify-self: end;
+  }
+
+  .rt-r-js-baseline {
+    justify-self: baseline;
+  }
+
+  .rt-r-js-stretch {
+    justify-self: stretch;
+  }
+}

--- a/packages/radix-ui-themes/src/styles/utilities/layout.css
+++ b/packages/radix-ui-themes/src/styles/utilities/layout.css
@@ -1,5 +1,6 @@
 @import '../breakpoints.css';
 
+@import './align-content.css';
 @import './align-items.css';
 @import './align-self.css';
 @import './display.css';
@@ -25,6 +26,8 @@
 @import './max-height.css';
 @import './inset.css';
 @import './justify-content.css';
+@import './justify-items.css';
+@import './justify-self.css';
 @import './margin.css';
 @import './overflow.css';
 @import './padding.css';


### PR DESCRIPTION
## Description

- Add alignContent prop to Grid component with values: start, center, end, baseline, between, around, evenly, stretch
- Add justifyItems prop to Grid component with values: start, center, end, baseline, stretch
- Add alignSelf and justifySelf props to layout system with values: start, center, end, baseline, stretch
- Create CSS utility classes for all new properties with responsive support
- Update align-self CSS to use logical values (start/end instead of flex-start/flex-end)
- Add comprehensive test pages demonstrating each new property

## Testing steps

Added new test pages, use those for reference