### PR TITLE
fix(Seperator): expose aria-orientation for non-decorative separators

### DIFF
--- a/packages/radix-ui-themes/CHANGELOG.md
+++ b/packages/radix-ui-themes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 
+- Fix `Separator` not exposing `aria-orientation` when `decorative={false}`, causing screen readers to always report a vertical separator as horizontal
 - Expand the prop type for `Select`'s `placeholder` prop to accept any `ReactNode` ([#693](https://github.com/radix-ui/themes/pull/693))
 - Add `ghost-offset` variant to `Button`, `IconButton` and `SelectTrigger` components ([#546](https://github.com/radix-ui/themes/pull/546))
 - Fix broken loading state for `Button` and `IconButton` components using `asChild` ([#752](https://github.com/radix-ui/themes/pull/752))

--- a/packages/radix-ui-themes/src/components/separator.tsx
+++ b/packages/radix-ui-themes/src/components/separator.tsx
@@ -19,10 +19,12 @@ const Separator = React.forwardRef<SeparatorElement, SeparatorProps>((props, for
     separatorPropDefs,
     marginPropDefs,
   );
+  const orientation = typeof props.orientation === 'string' ? props.orientation : 'horizontal';
   return (
     <span
       data-accent-color={color}
       role={decorative ? undefined : 'separator'}
+      aria-orientation={decorative ? undefined : orientation}
       {...separatorProps}
       ref={forwardedRef}
       className={classNames('rt-Separator', className)}


### PR DESCRIPTION
## Description

The `Separator` component supports `orientation="vertical"` and a `decorative` prop (default `true`). When `decorative={false}`, the component renders `role="separator"`, making it semantically meaningful to assistive technologies.

However, the `orientation` prop is consumed entirely by `extractProps`, which converts it to a CSS class and removes it from the DOM output. This means `aria-orientation` is never forwarded to the element.

Per the ARIA spec, the implicit default for `role="separator"` is `aria-orientation="horizontal"`. So a vertical non-decorative separator:

```tsx
<Separator orientation="vertical" decorative={false} />
```

renders as:

```html
<span role="separator" class="rt-Separator rt-r-orientation-vertical" />
```

which screen readers announce as a **horizontal** separator — the wrong direction.

This PR reads `orientation` directly from the original props (before `extractProps` strips it) and forwards it as `aria-orientation` when `decorative={false}`.

## Testing steps

1. Run `pnpm dev` and open `http://localhost:3000/sink`
2. Find the `Separator` section and add a vertical non-decorative separator:
   ```tsx
   <Separator orientation="vertical" decorative={false} />
   ```
3. Inspect the rendered element in DevTools — it should now have `aria-orientation="vertical"`
4. With a screen reader (VoiceOver / NVDA), navigate to the separator — it should be announced as "vertical separator" rather than "separator" (horizontal)

