### PR TITLE
fix(Spinner): prevent keyboard focus on hidden children via inert att…

### DIFF
--- a/packages/radix-ui-themes/CHANGELOG.md
+++ b/packages/radix-ui-themes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 
+- Fix `Spinner` hidden children remaining keyboard-focusable during loading by applying the `inert` attribute
 - Expand the prop type for `Select`'s `placeholder` prop to accept any `ReactNode` ([#693](https://github.com/radix-ui/themes/pull/693))
 - Add `ghost-offset` variant to `Button`, `IconButton` and `SelectTrigger` components ([#546](https://github.com/radix-ui/themes/pull/546))
 - Fix broken loading state for `Button` and `IconButton` components using `asChild` ([#752](https://github.com/radix-ui/themes/pull/752))

--- a/packages/radix-ui-themes/src/components/spinner.tsx
+++ b/packages/radix-ui-themes/src/components/spinner.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
 
+import { inert } from '../helpers/inert.js';
 import { Flex } from './flex.js';
 import { spinnerPropDefs } from './spinner.props.js';
 import { extractProps } from '../helpers/extract-props.js';
@@ -45,7 +46,7 @@ const Spinner = React.forwardRef<SpinnerElement, SpinnerProps>((props, forwarded
          * `display: contents` removes the content from the accessibility tree in some browsers,
          * so we force remove it with `aria-hidden`
          */}
-        <span aria-hidden style={{ display: 'contents', visibility: 'hidden' }} inert={undefined}>
+        <span aria-hidden style={{ display: 'contents', visibility: 'hidden' }} inert={inert}>
           {children}
         </span>
 


### PR DESCRIPTION
## Description

When `loading` is true and `children` are provided, `Spinner` wraps the children in a hidden span to preserve the button's size during the loading state:

```tsx
<span aria-hidden style={{ display: 'contents', visibility: 'hidden' }} inert={undefined}>
  {children}
</span>
```

`inert={undefined}` in React removes the attribute from the DOM entirely — it is a no-op. This means any focusable element passed as a child (a button, link, input, etc.) can still receive keyboard focus via Tab while it is visually hidden and removed from the accessibility tree.

The codebase already has a purpose-built helper at `src/helpers/inert.ts` that handles the React 18 vs 19 difference for the `inert` attribute. It is used correctly in both `Skeleton` and `ThemePanel`. `Spinner` is the only loading component that doesn't use it.

This PR replaces `inert={undefined}` with `inert={inert}` (the existing helper), consistent with the pattern already in `skeleton.tsx`.

## Testing steps

1. Run `pnpm dev` and open `http://localhost:3000/sink`
2. Find a `Button` with a loading spinner that has focusable children (or create one):
   ```tsx
   <Spinner loading>
     <button>Inner button</button>
   </Spinner>
   ```
3. **Before:** pressing Tab while loading could land focus on the hidden inner button
4. **After:** the hidden children are fully inert — Tab skips them entirely

## Relates issues / PRs

N/A
