### PR TITLE
fix(ThemePanel): cancel stale reset timeout when Copy Theme is clicke…

### DIFF
--- a/packages/radix-ui-themes/CHANGELOG.md
+++ b/packages/radix-ui-themes/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.4.0
 
+- Fix `ThemePanel` "Copy Theme" button resetting prematurely when clicked multiple times in quick succession
 - Expand the prop type for `Select`'s `placeholder` prop to accept any `ReactNode` ([#693](https://github.com/radix-ui/themes/pull/693))
 - Add `ghost-offset` variant to `Button`, `IconButton` and `SelectTrigger` components ([#546](https://github.com/radix-ui/themes/pull/546))
 - Fix broken loading state for `Button` and `IconButton` components using `asChild` ([#752](https://github.com/radix-ui/themes/pull/752))

--- a/packages/radix-ui-themes/src/components/theme-panel.tsx
+++ b/packages/radix-ui-themes/src/components/theme-panel.tsx
@@ -226,6 +226,7 @@ const ThemePanelContent = React.forwardRef<ThemePanelContentElement, ThemePanelC
     const resolvedGrayColor = grayColor === 'auto' ? autoMatchedGray : grayColor;
 
     const [copyState, setCopyState] = React.useState<'idle' | 'copying' | 'copied'>('idle');
+    const copyTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
     async function handleCopyThemeConfig() {
       const theme = {
         appearance: appearance === themePropDefs.appearance.default ? undefined : appearance,
@@ -247,7 +248,8 @@ const ThemePanelContent = React.forwardRef<ThemePanelContentElement, ThemePanelC
       setCopyState('copying');
       await navigator.clipboard.writeText(textToCopy);
       setCopyState('copied');
-      setTimeout(() => setCopyState('idle'), 2000);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopyState('idle'), 2000);
     }
 
     React.useEffect(() => {


### PR DESCRIPTION
## Description

Clicking the "Copy Theme" button in `ThemePanel` calls `handleCopyThemeConfig`, which sets the button label to "Copied" and schedules a `setTimeout` to reset it back to "Copy Theme" after 2 seconds. Each click schedules a new timeout without cancelling the previous one.

Clicking the button twice in quick succession queues two independent timeouts. The first fires after 2 seconds from the _first_ click and resets the label back to "Copy Theme" — even though the second copy happened more recently. The button flickers back to "Copy Theme" too early, then stays there.

**Steps to reproduce:**

1. Open the ThemePanel
2. Click "Copy Theme"
3. Click it again within 2 seconds
4. The button resets to "Copy Theme" earlier than expected (after ~2s from click 1, not click 2)

This PR stores the timeout ID in a `useRef` and calls `clearTimeout` before scheduling each new one, so only the most recent timeout is ever active.

## Testing steps

1. Run `pnpm dev` and open `http://localhost:3000/sink`
2. Open the Theme Panel (press `T` or click the trigger)
3. Click "Copy Theme" twice within 2 seconds
4. **Before:** the button label flickers back to "Copy Theme" too early
5. **After:** the 2-second countdown resets on each click — the label stays as "Copied" for a full 2 seconds after the _last_ click

