### PR TITLE
docs(text-field): add heading for autofill examples

### DIFF
--- a/apps/playground/app/(themeable)/sink/text-field/page.tsx
+++ b/apps/playground/app/(themeable)/sink/text-field/page.tsx
@@ -159,7 +159,9 @@ export default function TextFieldPage() {
           </Table.Body>
         </Table.Root>
 
-        <Separator my="8" />
+        <Text as="p" my="5">
+          Autofill:
+        </Text>
         <Flex align="center" gap="4" mb="9">
           <Box>
             <form action="/">


### PR DESCRIPTION
## Summary

Adds a heading above the TextField autofill examples to improve the documentation's readability and consistency.

Previously, the autofill demo appeared immediately after a separator without any context, making it less obvious what the examples were demonstrating. This change labels the section to match the surrounding documentation.

## Changes

- Added an **"Autofill:"** heading above the autofill examples.
- Improved consistency with the existing `radius` and `color` documentation sections.

## Before

The autofill examples were displayed without a section heading.

## After

The autofill examples are clearly labeled with an **"Autofill:"** heading.

## Screenshots

### Before

<img width="1108" height="490" alt="Screenshot from 2026-07-14 16-53-12" src="https://github.com/user-attachments/assets/9708c294-ff0f-4b4c-bd9f-6d921ff7ce75" />


### After

<img width="1108" height="490" alt="Screenshot from 2026-07-14 16-53-25" src="https://github.com/user-attachments/assets/e5a4815e-9fcb-474d-b06c-6ed5532cabfa" />
